### PR TITLE
fix: production audit — Barbican scraper, duplicate IDs, directors perf, search UX

### DIFF
--- a/frontend/src/lib/components/filters/SearchInput.svelte
+++ b/frontend/src/lib/components/filters/SearchInput.svelte
@@ -163,7 +163,12 @@
 			{#if loading}
 				<div class="results-loading">SEARCHING...</div>
 			{:else if totalResults === 0 && query.length >= 2}
-				<div class="results-empty">NO RESULTS</div>
+				<div class="results-empty">
+					<span>NO RESULTS</span>
+					<a href="/search?q={encodeURIComponent(query)}" class="search-all-link" onclick={() => { open = false; query = ''; }}>
+						SEARCH ALL DATES →
+					</a>
+				</div>
 			{:else}
 				{#if films.length > 0}
 					<div class="results-section-header">FILMS</div>
@@ -232,6 +237,13 @@
 		padding: 0.375rem 0.625rem;
 		border: 1px solid var(--color-border-subtle);
 		transition: border-color var(--duration-fast) var(--ease-sharp);
+		min-height: 44px;
+	}
+
+	@media (min-width: 768px) {
+		.search-input-wrap {
+			min-height: auto;
+		}
 	}
 
 	.search-input-wrap:focus-within {
@@ -260,11 +272,25 @@
 	}
 
 	.clear-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 44px;
+		min-height: 44px;
+		margin: -0.375rem -0.625rem -0.375rem 0;
 		padding: 2px;
 		color: var(--color-text-tertiary);
 		background: transparent;
 		border: none;
 		cursor: pointer;
+	}
+
+	@media (min-width: 768px) {
+		.clear-btn {
+			min-width: auto;
+			min-height: auto;
+			margin: 0;
+		}
 	}
 
 	.clear-btn:hover {
@@ -309,6 +335,24 @@
 		letter-spacing: 0.06em;
 		color: var(--color-text-tertiary);
 		text-align: center;
+	}
+
+	.results-empty {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.search-all-link {
+		font-size: var(--font-size-xs);
+		color: var(--color-text);
+		text-decoration: none;
+		font-weight: 500;
+		letter-spacing: 0.06em;
+	}
+
+	.search-all-link:hover {
+		text-decoration: underline;
 	}
 
 	.result-row {

--- a/frontend/src/routes/directors/+page.server.ts
+++ b/frontend/src/routes/directors/+page.server.ts
@@ -1,5 +1,4 @@
 import { apiFetch } from '$lib/server/api';
-import { endOfDay, addDays } from 'date-fns';
 import type { Config } from '@sveltejs/adapter-vercel';
 import type { PageServerLoad } from './$types';
 
@@ -13,65 +12,14 @@ export interface DirectorEntry {
 	films: string[];
 }
 
-interface ScreeningsResponse {
-	screenings: Array<{
-		film: {
-			id: string;
-			title: string;
-			directors: string[];
-		};
-	}>;
-	meta: {
-		cursor: string | null;
-		hasMore: boolean;
-	};
+interface DirectorsResponse {
+	directors: DirectorEntry[];
 }
 
 export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 	setHeaders({ 'cache-control': 'public, s-maxage=3600, stale-while-revalidate=86400' });
-	const now = new Date();
-	const end = endOfDay(addDays(now, 14));
 
-	// Fetch all screenings using cursor pagination (API max 500 per request)
-	const allScreenings: ScreeningsResponse['screenings'] = [];
-	let cursor: string | null = null;
-	let hasMore = true;
+	const data = await apiFetch<DirectorsResponse>('/api/directors?days=14', fetch);
 
-	while (hasMore) {
-		const params = new URLSearchParams({
-			startDate: now.toISOString(),
-			endDate: end.toISOString(),
-			limit: '500'
-		});
-		if (cursor) params.set('cursor', cursor);
-
-		const data = await apiFetch<ScreeningsResponse>(
-			`/api/screenings?${params}`,
-			fetch
-		);
-		allScreenings.push(...data.screenings);
-		cursor = data.meta.cursor;
-		hasMore = data.meta.hasMore;
-	}
-
-	const directorMap = new Map<string, DirectorEntry>();
-
-	for (const s of allScreenings) {
-		if (!s.film?.directors) continue;
-		for (const director of s.film.directors) {
-			const existing = directorMap.get(director);
-			if (existing) {
-				if (!existing.films.includes(s.film.title)) {
-					existing.films.push(s.film.title);
-					existing.filmCount++;
-				}
-			} else {
-				directorMap.set(director, { name: director, filmCount: 1, films: [s.film.title] });
-			}
-		}
-	}
-
-	const directors = [...directorMap.values()].sort((a, b) => b.filmCount - a.filmCount);
-
-	return { directors };
+	return { directors: data.directors };
 };

--- a/src/app/api/directors/route.ts
+++ b/src/app/api/directors/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Directors API Route
+ * GET /api/directors - List directors with upcoming film counts
+ *
+ * Returns directors aggregated from films with upcoming screenings,
+ * sorted by film count descending. Uses a single SQL query with
+ * unnest() instead of fetching all screenings and aggregating in JS.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "drizzle-orm";
+
+import { db } from "@/db";
+import { CACHE_5MIN } from "@/lib/cache-headers";
+import { checkRateLimit, getClientIP, RATE_LIMITS } from "@/lib/rate-limit";
+
+export async function GET(request: NextRequest) {
+  const ip = getClientIP(request);
+  const rateLimitResult = await checkRateLimit(ip, {
+    ...RATE_LIMITS.public,
+    prefix: "directors",
+  });
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: "Too many requests", directors: [] },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateLimitResult.resetIn) },
+      }
+    );
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const days = Math.min(Number(searchParams.get("days")) || 14, 60);
+
+  const result = await db.execute<{
+    director: string;
+    film_count: number;
+    films: string[];
+  }>(sql`
+    SELECT
+      d.director,
+      COUNT(DISTINCT f.id)::int AS film_count,
+      ARRAY_AGG(DISTINCT f.title ORDER BY f.title) AS films
+    FROM films f
+    JOIN screenings s ON s.film_id = f.id
+    CROSS JOIN LATERAL unnest(f.directors) AS d(director)
+    WHERE s.datetime >= NOW()
+      AND s.datetime < NOW() + make_interval(days => ${days})
+      AND f.content_type = 'film'
+    GROUP BY d.director
+    ORDER BY film_count DESC, d.director ASC
+  `);
+
+  const directors = result.rows.map((row) => ({
+    name: row.director,
+    filmCount: row.film_count,
+    films: row.films,
+  }));
+
+  return NextResponse.json(
+    { directors },
+    { headers: CACHE_5MIN }
+  );
+}

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -304,8 +304,8 @@ const londonCinemas = [
       "The birthplace of British cinema, where the Lumière brothers screened the first moving pictures in 1896. Historic single-screen venue at the University of Westminster.",
   },
   {
-    id: "david-lean",
-    name: "David Lean Cinema",
+    id: "david-lean-cinema",
+    name: "The David Lean Cinema",
     shortName: "David Lean",
     chain: null,
     address: {

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -220,11 +220,11 @@ const getScraperRegistry = (): Record<string, () => Promise<ScraperEntry>> => ({
     );
   },
 
-  "phoenix": async () => {
+  "phoenix-east-finchley": async () => {
     const { createPhoenixScraper } = await import("@/scrapers/cinemas/phoenix");
     return createIndependentEntry(
       {
-        id: "phoenix",
+        id: "phoenix-east-finchley",
         name: "Phoenix Cinema",
         shortName: "Phoenix",
         website: "https://phoenixcinema.co.uk",

--- a/src/inngest/known-ids.ts
+++ b/src/inngest/known-ids.ts
@@ -25,7 +25,6 @@ export const SCRAPER_REGISTRY_IDS = new Set([
   "garden",
   "castle",
   "phoenix-east-finchley",
-  "phoenix", // legacy alias for phoenix-east-finchley
   "rich-mix",
   "close-up-cinema",
   "cine-lumiere",

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -77,6 +77,25 @@ Use this format when recording cinema-specific quirks:
 - Vista site codes: SOH1, MAY1, BLO1, ALD1, VIC1, HOX1, KIN1, RIC1, WIM01, CAM1
 - Last verified (2026-03-18): SSR token extraction working, all venues returning data
 
+### Barbican
+- Scraper: `src/scrapers/cinemas/barbican.ts`
+- Source URL pattern: `https://www.barbican.org.uk/whats-on/cinema?day=YYYY-MM-DD`
+- Approach: Daily cinema listing page (Cheerio, static HTML)
+- Date/time format: Times displayed as "12.00pm", "5.55pm" (dot separator, 12-hour with am/pm). Convert dot to colon before feeding to `parseScreeningTime()`.
+- Key selectors:
+  - `.cinema-listing-card` — film card container
+  - `.cinema-listing-card__title a` — film title + event URL (href to `/whats-on/YYYY/event/slug`)
+  - `.cinema-instance-list__instance` — individual showtime
+  - `a[href*="tickets.barbican"], a[href*="choose-seats"]` — booking link (text is the time)
+  - Sold out: no booking link; `<span>` contains "X.XXpm (Sold out)"
+- Known pitfalls:
+  - **BST timezone**: Displayed times are UK local. Must use `ukLocalToUTC()` to convert.
+  - **Sold-out screenings**: Have no `<a>` tag, only a `<span>` with "(Sold out)" appended to the time.
+  - **Coverage**: The `/whats-on/cinema?day=` page covers ALL cinema series (New Releases, Cold War Visions, Relaxed Screenings, London Soundtrack Festival, etc.). The old `/whats-on/series/new-releases` page only covered one series.
+  - **Day range**: The nav shows ~7 days but the `?day=` parameter accepts any future date. We scrape 14 days ahead.
+  - **Old performances endpoint**: The `/whats-on/event/{nodeId}/performances` page still works but its `datetime` attribute has a misleading `Z` suffix — the values are actually UK local time, not UTC. The old scraper used `new Date(attr)` which was off by 1 hour during BST.
+- Last verified (2026-04-10): Rewrote to use daily listing approach. 9 screenings parsed from April 10 test page, matching website exactly.
+
 ### Everyman
 - Scraper: `src/scrapers/chains/everyman.ts`
 - Notes: Playwright-heavy; more sensitive to markup and client-side app changes.

--- a/src/scrapers/cinemas/barbican.ts
+++ b/src/scrapers/cinemas/barbican.ts
@@ -1,13 +1,30 @@
 /**
  * Barbican Cinema Scraper
- * Scrapes film listings from barbican.org.uk
+ *
+ * Strategy: Scrape the daily cinema listing page at /whats-on/cinema?day=YYYY-MM-DD
+ * which shows ALL cinema screenings for a given day across every series (New Releases,
+ * Cold War Visions, Relaxed Screenings, London Soundtrack Festival, etc.).
+ *
+ * This is much more reliable than the old approach of scraping /whats-on/series/new-releases
+ * then fetching individual film pages and performance endpoints, because:
+ * 1. It covers ALL cinema series, not just "new-releases"
+ * 2. Fewer HTTP requests (14 pages vs 48+)
+ * 3. All data (title, time, booking URL) is on one page per day
+ * 4. No fragile node ID extraction step
+ *
+ * Each day page contains .cinema-listing-card elements with film titles and
+ * .cinema-instance-list__instance elements with showtimes and booking links.
+ * Times are displayed in UK local format like "12.00pm", "5.55pm".
  */
 
 import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
 import type { CheerioAPI } from "../utils/cheerio-types";
-import { parseFilmMetadata } from "../utils/metadata-parser";
+import { parseScreeningTime, ukLocalToUTC } from "../utils/date-parser";
 import { FestivalDetector } from "../festivals/festival-detector";
+
+/** Number of days ahead to scrape from today */
+const DAYS_AHEAD = 14;
 
 export class BarbicanScraper extends BaseScraper {
   config: ScraperConfig = {
@@ -18,80 +35,27 @@ export class BarbicanScraper extends BaseScraper {
   };
 
   protected async fetchPages(): Promise<string[]> {
-    // First get list of cinema films
-    const listingUrl = `${this.config.baseUrl}/whats-on/series/new-releases`;
-    console.log(`[${this.config.cinemaId}] Fetching film listing: ${listingUrl}`);
-
-    const listingHtml = await this.fetchUrl(listingUrl);
-    const $ = this.parseHtml(listingHtml);
-
-    // Extract film URLs - they're in format /whats-on/2025/event/slug
-    const filmUrls = new Set<string>();
-    $('a[href*="/whats-on/"]').each((_, el) => {
-      const href = $(el).attr("href");
-      if (href && /\/whats-on\/\d{4}\/event\//.test(href)) {
-        const fullUrl = href.startsWith("http") ? href : `${this.config.baseUrl}${href}`;
-        filmUrls.add(fullUrl);
-      }
-    });
-
-    console.log(`[${this.config.cinemaId}] Found ${filmUrls.size} film pages`);
-
-    // Fetch each film's detail page to get node ID, then fetch performances
     const pages: string[] = [];
-    const processedNodeIds = new Set<string>();
+    const today = new Date();
 
-    for (const filmUrl of Array.from(filmUrls).slice(0, 30)) {
+    for (let i = 0; i < DAYS_AHEAD; i++) {
+      const date = new Date(today);
+      date.setDate(today.getDate() + i);
+      const dateStr = date.toISOString().split("T")[0]; // YYYY-MM-DD
+
+      const url = `${this.config.baseUrl}/whats-on/cinema?day=${dateStr}`;
+      console.log(`[${this.config.cinemaId}] Fetching: ${url}`);
+
       try {
-        console.log(`[${this.config.cinemaId}] Fetching: ${filmUrl}`);
-        const filmHtml = await this.fetchUrl(filmUrl);
-        const film$ = this.parseHtml(filmHtml);
-
-        // Get title - strip BBFC ratings like (15), (12A), (PG), etc.
-        let title = film$("h1").first().text().trim() ||
-                   film$('meta[property="og:title"]').attr("content")?.replace(" | Barbican", "").trim() ||
-                   "Unknown";
-
-        // Normalize whitespace (including newlines) and remove BBFC ratings
-        // Ratings can appear after a newline, e.g., "Die My Love\n(15)"
-        title = title
-          .replace(/\s+/g, " ")  // Collapse all whitespace (including newlines) to single spaces
-          .replace(/\s*\((U|PG|12A?|15|18)\*?\)\s*$/i, "")  // Remove BBFC rating at end
-          .trim();
-
-        // Find node ID from the booking button endpoint or page
-        const nodeMatch = filmHtml.match(/node\/(\d+)/);
-        if (!nodeMatch) {
-          console.log(`[${this.config.cinemaId}] No node ID found for ${title}`);
-          continue;
-        }
-
-        const nodeId = nodeMatch[1];
-        if (processedNodeIds.has(nodeId)) {
-          continue; // Skip duplicates
-        }
-        processedNodeIds.add(nodeId);
-
-        // Extract metadata (director, year) from the film detail page
-        // Barbican often includes this in the page content
-        const pageText = film$("body").text();
-        const metadata = parseFilmMetadata(pageText);
-
-        // Fetch performances page
-        const performancesUrl = `${this.config.baseUrl}/whats-on/event/${nodeId}/performances`;
-        console.log(`[${this.config.cinemaId}] Fetching performances for ${title}`);
-
-        const performancesHtml = await this.fetchUrl(performancesUrl);
-
-        // Store title, metadata, and performances HTML for parsing
-        pages.push(JSON.stringify({ title, nodeId, html: performancesHtml, metadata }));
-
-        await this.delay(this.config.delayBetweenRequests);
+        const html = await this.fetchUrl(url);
+        // Store the date and HTML together for parsing
+        pages.push(JSON.stringify({ date: dateStr, html }));
       } catch (error) {
-        console.error(`[${this.config.cinemaId}] Failed to fetch ${filmUrl}:`, error);
+        console.error(`[${this.config.cinemaId}] Failed to fetch ${url}:`, error);
       }
     }
 
+    console.log(`[${this.config.cinemaId}] Fetched ${pages.length} day pages`);
     return pages;
   }
 
@@ -101,17 +65,17 @@ export class BarbicanScraper extends BaseScraper {
 
     for (const page of htmlPages) {
       try {
-        const { title, nodeId, html, metadata } = JSON.parse(page);
+        const { date, html } = JSON.parse(page);
         const $ = this.parseHtml(html);
 
-        const filmScreenings = this.parsePerformances($, title, nodeId, metadata);
-        screenings.push(...filmScreenings);
+        const dayScreenings = this.parseDayPage($, date);
+        screenings.push(...dayScreenings);
 
-        if (filmScreenings.length > 0) {
-          console.log(`[${this.config.cinemaId}] ${title}: ${filmScreenings.length} screenings`);
+        if (dayScreenings.length > 0) {
+          console.log(`[${this.config.cinemaId}] ${date}: ${dayScreenings.length} screenings`);
         }
       } catch (error) {
-        console.error(`[${this.config.cinemaId}] Error parsing performances:`, error);
+        console.error(`[${this.config.cinemaId}] Error parsing day page:`, error);
       }
     }
 
@@ -119,60 +83,117 @@ export class BarbicanScraper extends BaseScraper {
     return screenings;
   }
 
-  private parsePerformances(
-    $: CheerioAPI,
-    title: string,
-    nodeId: string,
-    metadata?: { director?: string; year?: number }
-  ): RawScreening[] {
+  /**
+   * Parse a single day's cinema listing page.
+   *
+   * Structure:
+   *   .cinema-listing-card
+   *     .cinema-listing-card__title > a[href]  (film title + event URL)
+   *     .cinema-listing-card__instances
+   *       .cinema-instance-list__instance
+   *         a[href*="tickets.barbican"]  (booking link with time text like "12.00pm")
+   *         — OR for sold-out screenings —
+   *         span containing "X.XXpm (Sold out)"
+   */
+  private parseDayPage($: CheerioAPI, dateStr: string): RawScreening[] {
     const screenings: RawScreening[] = [];
-    const now = new Date();
+    const [year, month, day] = dateStr.split("-").map(Number);
 
-    // Each screening is in a .instance-listing element
-    $(".instance-listing").each((_, el) => {
-      const $instance = $(el);
+    $(this.getSelector("filmCard", ".cinema-listing-card")).each((_, cardEl) => {
+      const $card = $(cardEl);
 
-      // Get datetime from time[datetime] attribute
-      const timeEl = $instance.find("time[datetime]");
-      const datetimeAttr = timeEl.attr("datetime");
+      // Extract film title and event URL
+      const titleLink = $card.find(
+        this.getSelector("titleLink", ".cinema-listing-card__title a")
+      );
+      const rawTitle = titleLink.text().trim();
+      const eventHref = titleLink.attr("href") || "";
 
-      if (!datetimeAttr) return;
+      if (!rawTitle) return;
 
-      const datetime = new Date(datetimeAttr);
+      // Clean title: normalize whitespace and strip BBFC ratings
+      const title = rawTitle
+        .replace(/\s+/g, " ")
+        .replace(/\s*\((U|PG|12A?|15|18)\*?\)\s*$/i, "")
+        .trim();
 
-      // Skip past screenings
-      if (datetime < now) return;
+      // Build the event page URL for fallback booking links
+      const eventUrl = eventHref.startsWith("http")
+        ? eventHref
+        : `${this.config.baseUrl}${eventHref}`;
 
-      // Get venue/screen
-      const venue = $instance.find(".instance-listing__venue strong").text().trim();
+      // Parse each showtime instance within this film card
+      $card
+        .find(this.getSelector("instance", ".cinema-instance-list__instance"))
+        .each((_, instanceEl) => {
+          const $instance = $(instanceEl);
 
-      // Get booking URL - check multiple selectors as Barbican uses different formats
-      let bookingLink = $instance.find('a[href*="tickets.barbican"]').attr("href") ||
-                       $instance.find('a[href*="choose-seats"]').attr("href") ||
-                       $instance.find('a[href*="/book/"]').attr("href") ||
-                       $instance.find('a.btn--primary[href]').attr("href");
+          // Try to get time from booking link first (preferred — has href for booking URL)
+          const bookingLink = $instance.find('a[href*="tickets.barbican"], a[href*="choose-seats"]');
+          let timeText: string | null = null;
+          let bookingUrl: string | null = null;
+          let soldOut = false;
 
-      // Ensure absolute URL - relative URLs need base URL prepended
-      if (bookingLink && !bookingLink.startsWith("http")) {
-        bookingLink = `${this.config.baseUrl}${bookingLink.startsWith("/") ? "" : "/"}${bookingLink}`;
-      }
+          if (bookingLink.length > 0) {
+            // The link text contains the time, e.g. "12.00pm"
+            timeText = bookingLink.text().trim();
+            bookingUrl = bookingLink.attr("href") || null;
+          } else {
+            // Sold out: no booking link, time in a span like "6.30pm (Sold out)"
+            const spanText = $instance.find("span").first().text().trim();
+            const soldOutMatch = spanText.match(
+              /(\d{1,2}\.\d{2}(?:am|pm))\s*\(Sold out\)/i
+            );
+            if (soldOutMatch) {
+              timeText = soldOutMatch[1];
+              soldOut = true;
+            }
+          }
 
-      // Validate URL format before using
-      const bookingUrl = bookingLink && bookingLink.startsWith("http")
-        ? bookingLink
-        : `${this.config.baseUrl}/whats-on/event/${nodeId}/performances`;
+          if (!timeText) return;
 
-      screenings.push({
-        filmTitle: title,
-        datetime,
-        screen: venue || undefined,
-        bookingUrl,
-        sourceId: `barbican-${nodeId}-${datetime.toISOString()}`,
-        // Pass extracted metadata for better TMDB matching
-        year: metadata?.year,
-        director: metadata?.director,
-        ...FestivalDetector.detect("barbican", title, datetime, bookingUrl),
-      });
+          // Parse time — Barbican uses dot separator: "12.00pm", "5.55pm"
+          // Convert dot to colon for the shared parser: "12:00pm", "5:55pm"
+          const normalizedTime = timeText.replace(".", ":");
+          const parsedTime = parseScreeningTime(normalizedTime);
+
+          if (!parsedTime) {
+            console.warn(
+              `[${this.config.cinemaId}] Could not parse time "${timeText}" for ${title}`
+            );
+            return;
+          }
+
+          // Warn about suspiciously early times
+          if (parsedTime.hours < 10) {
+            console.warn(
+              `[${this.config.cinemaId}] Suspiciously early time ${parsedTime.hours}:${String(parsedTime.minutes).padStart(2, "0")} for ${title} — check parse`
+            );
+          }
+
+          // Construct UTC datetime from UK local time
+          // month is 0-indexed for ukLocalToUTC, dateStr month is 1-indexed
+          const datetime = ukLocalToUTC(year, month - 1, day, parsedTime.hours, parsedTime.minutes);
+
+          // Build a unique source ID from date + time + title slug
+          const titleSlug = title
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .slice(0, 40);
+          const sourceId = `barbican-${dateStr}-${String(parsedTime.hours).padStart(2, "0")}${String(parsedTime.minutes).padStart(2, "0")}-${titleSlug}`;
+
+          // Fall back to event page URL if no booking link (sold out)
+          const finalBookingUrl = bookingUrl || eventUrl;
+
+          screenings.push({
+            filmTitle: title,
+            datetime,
+            bookingUrl: finalBookingUrl,
+            sourceId,
+            availabilityStatus: soldOut ? "sold_out" : "available",
+            ...FestivalDetector.detect("barbican", title, datetime, finalBookingUrl),
+          });
+        });
     });
 
     return screenings;

--- a/src/scrapers/cinemas/david-lean.ts
+++ b/src/scrapers/cinemas/david-lean.ts
@@ -19,7 +19,7 @@ import { combineDateAndTime } from "../utils/date-parser";
 import { checkHealth } from "../utils/health-check";
 
 const DAVID_LEAN_CONFIG: ScraperConfig = {
-  cinemaId: "david-lean",
+  cinemaId: "david-lean-cinema",
   baseUrl: "https://www.davidleancinema.uk",
   requestsPerMinute: 10,
   delayBetweenRequests: 1000,

--- a/src/scrapers/cinemas/phoenix.ts
+++ b/src/scrapers/cinemas/phoenix.ts
@@ -17,7 +17,7 @@ import { BOT_USER_AGENT } from "../constants";
 import { combineDateAndTime } from "../utils/date-parser";
 
 const PHOENIX_CONFIG: ScraperConfig & { programmeUrl: string } = {
-  cinemaId: "phoenix",
+  cinemaId: "phoenix-east-finchley",
   baseUrl: "https://www.phoenixcinema.co.uk",
   programmeUrl: "https://www.phoenixcinema.co.uk/whats-on/",
   requestsPerMinute: 10,

--- a/src/scrapers/cli.ts
+++ b/src/scrapers/cli.ts
@@ -252,7 +252,7 @@ const SCRAPERS: ScraperDefinition[] = [
     },
   },
   {
-    id: "phoenix",
+    id: "phoenix-east-finchley",
     name: "Phoenix Cinema",
     type: "independent",
     createConfig: async () => {
@@ -260,7 +260,7 @@ const SCRAPERS: ScraperDefinition[] = [
       return {
         type: "single",
         venue: {
-          id: "phoenix",
+          id: "phoenix-east-finchley",
           name: "Phoenix Cinema",
           shortName: "Phoenix",
           website: "https://phoenixcinema.co.uk",

--- a/src/scrapers/local-runner.ts
+++ b/src/scrapers/local-runner.ts
@@ -40,7 +40,7 @@ const PLAYWRIGHT_SCRAPERS = [
   { id: "everyman-screen-on-the-green", name: "Everyman (all venues)", script: "scrape:everyman", priority: 1, isChain: true },
   { id: "electric-portobello", name: "Electric Portobello", script: "scrape:electric", priority: 3 },
   { id: "lexi-cinema", name: "Lexi Cinema", script: "scrape:lexi", priority: 3 },
-  { id: "phoenix-cinema", name: "Phoenix Cinema", script: "scrape:phoenix", priority: 3 },
+  { id: "phoenix-east-finchley", name: "Phoenix Cinema", script: "scrape:phoenix", priority: 3 },
 ];
 
 // Dedupe by script (chains share the same script)

--- a/src/scrapers/run-david-lean-v2.ts
+++ b/src/scrapers/run-david-lean-v2.ts
@@ -8,7 +8,7 @@ import { createDavidLeanScraper } from "./cinemas/david-lean";
 const config: SingleVenueConfig = {
   type: "single",
   venue: {
-    id: "david-lean",
+    id: "david-lean-cinema",
     name: "David Lean Cinema",
     shortName: "David Lean",
     website: "https://www.davidleancinema.org.uk",

--- a/src/scrapers/run-phoenix-v2.ts
+++ b/src/scrapers/run-phoenix-v2.ts
@@ -8,7 +8,7 @@ import { createPhoenixScraper } from "./cinemas/phoenix";
 const config: SingleVenueConfig = {
   type: "single",
   venue: {
-    id: "phoenix",
+    id: "phoenix-east-finchley",
     name: "Phoenix Cinema",
     shortName: "Phoenix",
     website: "https://phoenixcinema.co.uk",


### PR DESCRIPTION
## Summary

Comprehensive fixes from the 2026-04-10 production audit of pictures.london (4 parallel Playwright + API agents tested page load, screening data, visual issues, and backend data completeness).

- **Barbican scraper rewrite** — zero screenings since Apr 9. Switched from broken `/whats-on/series/new-releases` scraping to daily listing pages (`/whats-on/cinema?day=YYYY-MM-DD`). Covers all cinema series, 14 requests instead of 48+
- **Duplicate cinema IDs fixed** — `david-lean`/`phoenix` legacy IDs canonicalized to `david-lean-cinema`/`phoenix-east-finchley` across all scrapers, inngest, CLI, runners, and seed data. Migration script also ran against production DB
- **Directors page performance** — created `/api/directors` endpoint with single SQL `unnest()` + `GROUP BY` query, replacing multi-call cursor pagination that caused 2.3s FCP
- **Search UX** — added "SEARCH ALL DATES →" link when autocomplete returns no results

### Manual actions still needed
- [ ] Set `PUBLIC_CLERK_PUBLISHABLE_KEY` to `pk_live_Y2xlcmsucGljdHVyZXMubG9uZG9uJA` in Vercel dashboard (frontend project) — currently using dev keys
- [ ] Check `scraper-chain-everyman` in Trigger.dev — ALL Everyman venues have ~10x data gap (87 API showtimes vs 19 in DB for Maida Vale alone)
- [ ] Run `npm run audit:fix-upcoming` to backfill Amelie 25th Anniversary poster (missing due to title typo "Re- Release")

## Test plan
- [ ] Verify directors page loads in < 1s (was 2.3s)
- [ ] Verify Barbican screenings appear after next scraper run
- [ ] Verify search shows "SEARCH ALL DATES →" when autocomplete has no results
- [ ] Check no duplicate cinema entries remain in the screenings table

🤖 Generated with [Claude Code](https://claude.com/claude-code)