### PR TITLE
fix: homepage shows full month of screenings instead of only today

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-11: Fix Homepage — Show Full Month of Screenings
+**PR**: #421 | **Files**: `frontend/src/routes/+page.server.ts`
+- Homepage only showed today's screenings because `?limit=200` triggered cursor pagination and today's 250+ screenings consumed the entire limit
+- Removed limit param, added 30-day `endDate` — API's non-paginated path returns all ~3,000 screenings
+- ISR caches for 1 hour so the full month is served from Vercel's edge cache instantly
+
+---
+
 ## 2026-04-08: Comprehensive Mobile UI Fixes
 **PR**: #409 | **Files**: `Header.svelte`, `Dropdown.svelte`, `CinemaPicker.svelte`, `DateTimePicker.svelte`, `app.css`, `cinemas/+page.svelte`, `reachable/+page.svelte`, `TableView.svelte`, `MobilePanel.svelte`, `+layout.svelte`, `+page.svelte`
 - Fix dropdown overflow caused by `100vw` width calculation on mobile

--- a/changelogs/2026-04-11-fix-homepage-screening-limit.md
+++ b/changelogs/2026-04-11-fix-homepage-screening-limit.md
@@ -1,0 +1,17 @@
+# Fix Homepage — Show Full Month of Screenings
+
+**PR**: #421
+**Date**: 2026-04-11
+
+## Changes
+- Removed `?limit=200` from homepage API call in `+page.server.ts`
+- Added explicit `endDate` parameter set to 30 days from now
+- This switches from the cursor-paginated API path (capped at 200) to the legacy non-paginated path (returns all screenings in the date range)
+
+## Root Cause
+The `limit=200` parameter triggered cursor pagination in the screenings API. Since today alone has 250+ screenings, all 200 returned results were from today — zero future days appeared on the homepage.
+
+## Impact
+- Users now see a full month of screenings grouped by day (TODAY, TOMORROW, next week, etc.)
+- ~3,000 screenings returned per ISR refresh (~2.5MB raw, ~500KB gzipped)
+- ISR caches for 1 hour — the fetch cost is amortized across all users

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -33,7 +33,12 @@ interface ScreeningsResponse {
 export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 	setHeaders({ 'cache-control': 'public, s-maxage=3600, stale-while-revalidate=86400' });
 
-	const data = await apiFetch<ScreeningsResponse>('/api/screenings?limit=200', fetch);
+	const end = new Date();
+	end.setDate(end.getDate() + 30);
+	const data = await apiFetch<ScreeningsResponse>(
+		`/api/screenings?endDate=${end.toISOString()}`,
+		fetch
+	);
 
 	return {
 		screenings: data.screenings.map((s) => ({


### PR DESCRIPTION
## Summary

- Homepage only showed today's screenings — the `?limit=200` param triggered cursor pagination, and since today has 250+ screenings, all 200 returned were from today
- Removed the limit param and added `endDate=30 days` — the API's non-paginated path returns all ~3,000 screenings for the full month
- ISR caches for 1 hour so the fetch cost is amortized — users get the full month from edge cache instantly

## Test plan
- [ ] After deploy, verify homepage shows day sections for today + future days (TOMORROW, next week, etc.)
- [ ] Scroll to bottom — should see screenings through mid-May
- [ ] Verify page load is still fast (ISR cache serves from edge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)