### PR TITLE
fix: poster images not loading until hover

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-15: Fix poster images not loading until hover
+**PR**: #424 | **Files**: `frontend/src/lib/components/calendar/FilmCard.svelte`
+- Remove `crossorigin="anonymous"` from poster `<img>` tags — caused lazy-loaded images to stall in the browser's IntersectionObserver when combined with CORS preflight overhead
+- FittedTitleCanvas already handles its own CORS loading independently via `new Image()`
+- Regression from #423 (responsive TMDB poster images)
+
+---
+
 ## 2026-04-15: TMDB Responsive Poster Images
 **PR**: #423 | **Files**: `frontend/src/lib/utils.ts`, `frontend/src/app.html`, `FittedTitleCanvas.svelte`, `FilmCard.svelte`, `SearchInput.svelte`, `ReachableResults.svelte`, `film/[id]/+page.svelte`, `search/+page.svelte`, `watchlist/+page.svelte`, `tonight/+page.svelte`, `this-weekend/+page.svelte`, `festivals/+page.server.ts`
 - Add responsive `srcset` using TMDB's width tiers (w92–w780) so browsers pick optimal image size per device

--- a/changelogs/2026-04-15-fix-poster-image-loading.md
+++ b/changelogs/2026-04-15-fix-poster-image-loading.md
@@ -1,0 +1,15 @@
+# Fix poster images not loading until hover
+
+**PR**: #424
+**Date**: 2026-04-15
+
+## Changes
+- Removed `crossorigin="anonymous"` attribute from the `<img>` tag in `FilmCard.svelte`
+- This was a regression introduced in #423 (responsive TMDB poster images)
+
+## Root Cause
+The `crossorigin="anonymous"` attribute forces the browser to use CORS mode for image requests. Combined with `loading="lazy"` and many concurrent images in a CSS subgrid layout, the browser's IntersectionObserver would stall — images remained in a "pending" state even when clearly in the viewport. A hover event (which mounts the `FittedTitleCanvas` overlay) triggered a DOM mutation and layout recalculation that unstuck the observer.
+
+## Impact
+- All poster images on the homepage, calendar, and film grids now load reliably on first render
+- No impact on the hover title overlay — `FittedTitleCanvas` loads its own CORS-enabled image independently via `new Image()`

--- a/frontend/src/lib/components/calendar/FilmCard.svelte
+++ b/frontend/src/lib/components/calendar/FilmCard.svelte
@@ -92,7 +92,6 @@
 					class="w-full h-full object-cover"
 					loading="lazy"
 					decoding="async"
-					crossorigin="anonymous"
 				/>
 			{:else}
 				<div class="w-full h-full flex items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- Removes `crossorigin="anonymous"` from the `<img>` tag in `FilmCard.svelte` — this was causing lazy-loaded poster images to stall in the browser's IntersectionObserver, only appearing on hover
- Regression from #423 (responsive TMDB poster images)
- `FittedTitleCanvas` already handles its own CORS loading via `new Image()`, so the base `<img>` never needed the attribute

## Test plan
- [x] Verified all poster images load immediately on homepage (dev server)
- [x] Verified lazy-loaded images below the fold appear on scroll
- [x] Type-check passes (`svelte-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)