### PR TITLE
fix: resolve TS2339 in directors route breaking CI

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-04-16: Fix directors API TypeScript error blocking CI
+**PR**: #425 | **Files**: `src/app/api/directors/route.ts`
+- Replace `result.rows.map()` with `result.map()` — Drizzle's `db.execute()` returns a `RowList` (directly iterable), not an object with a `.rows` property
+- Fixes TS2339 error that has been failing CI on main since #420
+
+---
+
 ## 2026-04-15: Fix poster images not loading until hover
 **PR**: #424 | **Files**: `frontend/src/lib/components/calendar/FilmCard.svelte`
 - Remove `crossorigin="anonymous"` from poster `<img>` tags — caused lazy-loaded images to stall in the browser's IntersectionObserver when combined with CORS preflight overhead

--- a/changelogs/2026-04-16-fix-directors-route-typecheck.md
+++ b/changelogs/2026-04-16-fix-directors-route-typecheck.md
@@ -1,0 +1,12 @@
+# Fix directors API TypeScript error blocking CI
+
+**PR**: #425
+**Date**: 2026-04-16
+
+## Changes
+- Replaced `result.rows.map()` with `result.map()` in the directors API route
+- Drizzle ORM's `db.execute()` with postgres.js returns a `RowList<T[]>` which is directly iterable — there is no `.rows` property (that's a node-postgres pattern)
+
+## Impact
+- Unblocks CI on main — TypeScript type check (`tsc --noEmit`) now passes
+- The API endpoint was working at runtime (postgres.js is lenient), but the type error prevented CI from going green

--- a/src/app/api/directors/route.ts
+++ b/src/app/api/directors/route.ts
@@ -52,7 +52,7 @@ export async function GET(request: NextRequest) {
     ORDER BY film_count DESC, d.director ASC
   `);
 
-  const directors = result.rows.map((row) => ({
+  const directors = result.map((row) => ({
     name: row.director,
     filmCount: row.film_count,
     films: row.films,


### PR DESCRIPTION
## Summary
- Replace `result.rows.map()` with `result.map()` in `src/app/api/directors/route.ts`
- Drizzle's `db.execute()` returns a `RowList` (directly iterable) — no `.rows` property exists (that's a node-postgres pattern)
- This TS2339 error has been failing CI on main since #420

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] `npm run lint` — no new errors
- [x] `npm run test:run` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)