### PR TITLE
fix: add phoenix legacy alias to Inngest known IDs

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-04-16: Add phoenix legacy alias to Inngest known IDs
+**PR**: #426 | **Files**: `src/inngest/known-ids.ts`
+- Add `"phoenix"` as legacy alias for `phoenix-east-finchley` in `SCRAPER_REGISTRY_IDS`
+- Fixes 2 failing cinema-registry contract tests — last remaining CI test failures on main
+
+---
+
 ## 2026-04-16: Fix directors API TypeScript error blocking CI
 **PR**: #425 | **Files**: `src/app/api/directors/route.ts`
 - Replace `result.rows.map()` with `result.map()` — Drizzle's `db.execute()` returns a `RowList` (directly iterable), not an object with a `.rows` property

--- a/changelogs/2026-04-16-fix-phoenix-known-ids.md
+++ b/changelogs/2026-04-16-fix-phoenix-known-ids.md
@@ -1,0 +1,12 @@
+# Add phoenix legacy alias to Inngest known IDs
+
+**PR**: #426
+**Date**: 2026-04-16
+
+## Changes
+- Added `"phoenix"` as a legacy alias in `SCRAPER_REGISTRY_IDS` alongside `"phoenix-east-finchley"`
+- Mirrors the existing pattern where `"nickel"` is a legacy alias for `"the-nickel"`
+
+## Impact
+- Fixes 2 failing contract tests in `cinema-registry.test.ts` that validate every active cinema resolves to an Inngest-known ID
+- Combined with #425 (directors route TS fix), this should bring CI on main to fully green

--- a/src/inngest/known-ids.ts
+++ b/src/inngest/known-ids.ts
@@ -25,6 +25,7 @@ export const SCRAPER_REGISTRY_IDS = new Set([
   "garden",
   "castle",
   "phoenix-east-finchley",
+  "phoenix", // legacy alias for phoenix-east-finchley
   "rich-mix",
   "close-up-cinema",
   "cine-lumiere",


### PR DESCRIPTION
## Summary
- Add `"phoenix"` as legacy alias for `phoenix-east-finchley` in `SCRAPER_REGISTRY_IDS`
- `INNGEST_ID_OVERRIDES` maps `phoenix-east-finchley` → `phoenix`, but `phoenix` wasn't in the known IDs set
- Fixes 2 failing contract tests in `cinema-registry.test.ts` — the last test failures on main
- Combined with #425, this should bring CI fully green

## Test plan
- [x] `npm run test:run` — 907/907 pass, 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] Verified locally: both cinema-registry contract tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)