### PR TITLE
fix: match grid/list ViewToggle height to neighboring filter dropdowns

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-18: Fix grid/list ViewToggle overheight on desktop filter bar
+**PR**: TBD | **Files**: `frontend/src/lib/components/filters/ViewToggle.svelte`
+- Reduce ViewToggle buttons from 44px → 32px tall on desktop so they line up with neighboring `WHEN / ALL CINEMAS / FORMAT` dropdown triggers
+- Keep 44px touch targets on mobile (`max-width: 767px`) for WCAG 2.5.5 compliance
+- Fixes visual desync where the active (black-filled) button visibly overshot the filter bar row
+
+---
+
 ## 2026-04-17: Fix mobile input zoom + auto-keyboard on cinema filter
 **PR**: TBD | **Files**: `frontend/src/lib/components/ui/Dropdown.svelte`, `frontend/src/lib/components/filters/CinemaPicker.svelte`, `frontend/src/lib/components/filters/SearchInput.svelte`, `frontend/tests/mobile.spec.ts`
 - Focus the dropdown panel (via `tabindex="-1"`) instead of auto-focusing its first child input — opening the cinema filter no longer pops the soft keyboard on iOS, so users can scroll the cinema list

--- a/changelogs/2026-04-18-fix-view-toggle-height.md
+++ b/changelogs/2026-04-18-fix-view-toggle-height.md
@@ -1,0 +1,16 @@
+# Fix grid/list ViewToggle overheight on desktop filter bar
+
+**PR**: TBD
+**Date**: 2026-04-18
+
+## Changes
+- `ViewToggle` buttons: `min-height: 2.75rem` (44px) → `height: 2rem` (32px) on desktop
+- Added `@media (max-width: 767px)` override to restore the 44px touch target on mobile
+- Swapped `min-width: 2.75rem` for `min-width: 2rem` with `padding: 0 0.5rem` to keep icons centered
+
+## Why
+The ViewToggle sat in the same row as `WHEN / ALL CINEMAS / FORMAT` dropdown triggers, which render ~32px tall from `padding: 0.375rem 0.625rem` + `font-size-xs`. The 44px toggle button — most visible when its active state fills with solid black — stuck out above and below the row, breaking the Swiss-brutalist alignment of the filter bar.
+
+## Impact
+- Desktop filter bar now has consistent 32px control height across all filter zones
+- Mobile unchanged — touch targets remain WCAG 2.5.5-compliant at 44px

--- a/frontend/src/lib/components/filters/ViewToggle.svelte
+++ b/frontend/src/lib/components/filters/ViewToggle.svelte
@@ -40,8 +40,9 @@
 	}
 
 	.toggle-btn {
-		min-width: 2.75rem;
-		min-height: 2.75rem;
+		min-width: 2rem;
+		height: 2rem;
+		padding: 0 0.5rem;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -56,6 +57,13 @@
 
 	.toggle-btn:last-child {
 		border-right: none;
+	}
+
+	@media (max-width: 767px) {
+		.toggle-btn {
+			min-width: 2.75rem;
+			height: 2.75rem;
+		}
 	}
 
 	.toggle-btn:hover {


### PR DESCRIPTION
## Summary
- The grid/list ViewToggle buttons rendered at 44px tall while neighboring `WHEN / ALL CINEMAS / FORMAT` dropdown triggers render ~32px, so the active (solid-black) button visibly overshot the filter bar row.
- Reduced desktop height to `2rem` (32px); kept the 44px touch target on mobile via `@media (max-width: 767px)` so WCAG 2.5.5 still holds.

## Before / After
Before: active toggle button stuck ~12px above the baseline of the filter row.
After: toggle aligns with WHEN / ALL CINEMAS / FORMAT triggers.

## Test plan
- [ ] `cd frontend && npm run dev` — open home page, confirm grid/list toggle is flush with filter-bar row at desktop widths.
- [ ] Resize to <768px — confirm toggle buttons grow back to 44px for touch.
- [ ] `cd frontend && npx playwright test` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)