### PR TITLE
fix: hide past screenings on calendar pages so film cards don't render empty

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-18: Hide past screenings on calendar/tonight/this-weekend (no empty film cards)
+**PR**: TBD | **Files**: `frontend/src/routes/+page.svelte`, `frontend/src/routes/tonight/+page.svelte`, `frontend/src/routes/this-weekend/+page.svelte`
+- Drop screenings where `datetime <= now()` in each page's derived film-grouping, so films whose only screenings today are already in the past stop appearing as empty cards (e.g. SIRĀT at 16:50 with a 14:00-only slot for today)
+- Root cause: these pages are ISR-cached (15m–1h). The server-side API filter can only use cache creation time, not the user's "now", so past-screening filtering has to happen client-side at render time
+- `FilmCard` already had this filter internally, but it only emptied the pill row — the card itself still rendered, reserving grid space
+
+---
+
 ## 2026-04-18: Fix grid/list ViewToggle overheight on desktop filter bar
 **PR**: TBD | **Files**: `frontend/src/lib/components/filters/ViewToggle.svelte`
 - Reduce ViewToggle buttons from 44px → 32px tall on desktop so they line up with neighboring `WHEN / ALL CINEMAS / FORMAT` dropdown triggers

--- a/changelogs/2026-04-18-fix-empty-film-cards-past-screenings.md
+++ b/changelogs/2026-04-18-fix-empty-film-cards-past-screenings.md
@@ -1,0 +1,30 @@
+# Hide past screenings on calendar pages (no empty film cards)
+
+**PR**: TBD
+**Date**: 2026-04-18
+
+## Changes
+- `frontend/src/routes/+page.svelte` — in the `filmMap` derived loop, skip any screening whose `datetime <= Date.now()`
+- `frontend/src/routes/tonight/+page.svelte` — same filter added to the film grouping loop
+- `frontend/src/routes/this-weekend/+page.svelte` — same filter added before day-grouping
+
+## Bug
+Users reported film cards rendering with a poster + title + metadata but zero screening pills. Example: `SIRĀT` on the main calendar at 16:50 — its only screening for today was at 14:00, already past.
+
+## Root cause
+All three calendar pages are ISR-cached on Vercel:
+- `/` → 3600s
+- `/tonight` → 900s
+- `/this-weekend` → 3600s
+
+The server-side API call filters by cache creation time, not the user's "now". A screening scheduled for 14:00 was upcoming when the page was built at 13:45, so it made it into the ISR response — but by 16:50 the user sees a stale, past screening.
+
+`FilmCard` internally filters `new Date(sc.datetime) > new Date()`, which drops the past pill but still renders the card shell — leading to the poster-without-pills bug.
+
+## Fix
+Move the past-screening filter one level up into each page's derived grouping. If a film has no future screenings left, it disappears from the day-group entirely instead of reserving an empty grid slot.
+
+## Impact
+- Home calendar, tonight, and this-weekend all stop showing empty cards
+- Zero backend changes; no scraper or schema impact
+- Re-computes on every Svelte 5 `$derived` invalidation — the cost is negligible compared to ISR revalidation

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -19,8 +19,14 @@
 			screenings: (typeof data.screenings)[0][];
 		}>();
 
+		// Drop screenings that have already started. ISR caches this page for 1h,
+		// so the server can't filter by "now" — it has to happen at render time.
+		const now = Date.now();
+
 		for (const s of data.screenings) {
 			if (!s.film) continue;
+
+			if (new Date(s.datetime).getTime() <= now) continue;
 
 			// Apply film search filter
 			if (filters.filmSearch && !s.film.title.toLowerCase().includes(filters.filmSearch.toLowerCase())) continue;

--- a/frontend/src/routes/this-weekend/+page.svelte
+++ b/frontend/src/routes/this-weekend/+page.svelte
@@ -7,7 +7,11 @@
 	type LoadedScreening = (typeof data.screenings)[number];
 
 	const dayGroups = $derived.by(() => {
-		const allScreenings: LoadedScreening[] = data.screenings;
+		// Drop past screenings — ISR caches this page, so filter at render time.
+		const now = Date.now();
+		const allScreenings: LoadedScreening[] = data.screenings.filter(
+			(s) => new Date(s.datetime).getTime() > now
+		);
 		const grouped = groupBy(allScreenings.filter((s) => s.film), (s) => toLondonDateStr(s.datetime));
 
 		return Object.entries(grouped)

--- a/frontend/src/routes/tonight/+page.svelte
+++ b/frontend/src/routes/tonight/+page.svelte
@@ -12,8 +12,11 @@
 
 	const filmMap = $derived.by(() => {
 		const map = new Map<string, { film: LoadedScreening['film']; screenings: LoadedScreening[] }>();
+		// Drop past screenings — ISR caches this page, so filter at render time.
+		const now = Date.now();
 		for (const s of data.screenings) {
 			if (!s.film) continue;
+			if (new Date(s.datetime).getTime() <= now) continue;
 			const existing = map.get(s.film.id);
 			if (existing) {
 				existing.screenings.push(s);


### PR DESCRIPTION
## Summary
Films with only past screenings for today (e.g. SIRĀT at 14:00 viewed at 16:50) rendered as a poster + title + metadata with an empty pill row. Root cause: `/`, `/tonight`, `/this-weekend` are ISR-cached (15m–1h), so past screenings from cache-build time leak into the client. `FilmCard` filtered its pills but still rendered the card shell.

Moved the past-screening filter one level up into each page's derived film grouping so films with zero future screenings disappear from the grid entirely.

## Files
- `frontend/src/routes/+page.svelte` — `filmMap` loop skips `datetime <= now`
- `frontend/src/routes/tonight/+page.svelte` — same
- `frontend/src/routes/this-weekend/+page.svelte` — filter applied to `allScreenings` before `groupBy`

## Test plan
- [ ] Open `/` — no film cards with empty pill rows.
- [ ] Open `/tonight` after a showtime has passed — past screenings gone; films with no future showings gone.
- [ ] Open `/this-weekend` — only future screenings shown.
- [ ] `cd frontend && npx playwright test` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)