### PR TITLE
feat(frontend): V2a Literary Antiqua redesign — mobile + desktop

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,17 @@
+## 2026-04-19: V2a Literary Antiqua redesign — mobile + desktop listings and film detail
+**PR**: TBD | **Files**: `frontend/src/app.css`, `frontend/src/routes/+page.svelte`, `frontend/src/routes/film/[id]/+page.svelte`, `frontend/src/lib/components/layout/Header.svelte`, `frontend/src/lib/components/filters/{DesktopFilterSidebar,MobileFilterSheet,MobileDatePicker,CalendarPopover,FilmTypeFilter}.svelte`, `frontend/src/lib/components/calendar/{DayMasthead,DesktopHybridCard,MobileFilmRow}.svelte`, `frontend/vite.config.ts`
+- Full rebrand of pictures.london following the Claude Design handoff bundle (`pictures-london-v2a-hybrid.html` + siblings) the user landed on after iterating through 5 V2a typographic directions
+- Palette: warm beige (`#efe9dc`) + oxblood accent (`#a83232`) + deep ink text (`#1a1410`) — replaces the bright-red/warm-white Swiss brutalist scheme
+- Typography: Fraunces SOFT display + Cormorant italic deck/byline + IBM Plex Mono meta (was Inter + Space Grotesk + JetBrains Mono)
+- Homepage desktop: new 240px sidebar rail (Where / Time of day / Format / Genre / Era) + big italic-first-letter day masthead ("Friday, the nineteenth") + 4-col dense grid with inline screenings per card
+- Homepage mobile: serif italic date header + search + Filter button + All / New / Repertory bordered tabs + text-forward film rows with right-side posters
+- Mobile filter sheet: full-height overlay with literary chips; mobile date picker: bottom sheet with monthly calendar (Mon-start, weekend in accent)
+- Film detail: 320px poster + 96px italic display title hero, grouped-by-cinema chip-button screenings, day strip, Credits sidebar
+- Header: filter bar removed from header (homepage owns its own filters); watchlist + sign-in reflow in serif
+- Follow-up: 38 Playwright tests assert the old filter-bar DOM (WHEN/CINEMAS/FORMAT dropdowns) — those tests need restructuring to match the new sidebar/sheet topology
+
+---
+
 ## 2026-04-18: Hide past screenings on calendar/tonight/this-weekend (no empty film cards)
 **PR**: TBD | **Files**: `frontend/src/routes/+page.svelte`, `frontend/src/routes/tonight/+page.svelte`, `frontend/src/routes/this-weekend/+page.svelte`
 - Drop screenings where `datetime <= now()` in each page's derived film-grouping, so films whose only screenings today are already in the past stop appearing as empty cards (e.g. SIRĀT at 16:50 with a 14:00-only slot for today)

--- a/changelogs/2026-04-19-v2a-literary-redesign.md
+++ b/changelogs/2026-04-19-v2a-literary-redesign.md
@@ -1,0 +1,118 @@
+# V2a Literary Antiqua Redesign — Mobile + Desktop
+
+**PR**: TBD
+**Date**: 2026-04-19
+**Source**: Claude Design handoff bundle (`/Users/jamesbarge/Downloads/Pictures.zip`) — `pictures-london-v2a-hybrid.html` + sibling `pictures-london-v2a.html` defining the full V2a system across mobile listings, mobile filter sheet, mobile date picker, mobile film detail, desktop hybrid listings, and desktop film detail.
+
+## Why
+
+The user has iterated for hours in Claude Design through five competing V2 typographic directions (Syne/Archivo/DM slab/Bricolage/etc.) and landed on **V2a Literary Antiqua** — a bookish, Penguin-Classics-meets-Sight-&-Sound system. Their explicit feedback on the current Swiss brutalist design: "It looks quite sloppy and amateurish in many ways at the moment." The stated goals — "considered / editorial / London indie cinema character", "stronger hierarchy", "typography doing more heavy lifting", "memorable / distinctive brand" — drive this rebrand.
+
+## Changes
+
+### Design tokens (`frontend/src/app.css`)
+
+Rebrand via CSS custom properties — every component that consumes the existing `--color-*` / `--font-*` variables picks up the new look automatically.
+
+| Token | Before | After |
+|---|---|---|
+| `--color-bg` | `#f5f2eb` (warm white) | `#efe9dc` (warm beige) |
+| `--color-text` | `#0a0a0a` (near-black) | `#1a1410` (deep ink) |
+| `--color-text-secondary` | `#3a3a3a` | `#4a3a2e` |
+| `--color-text-tertiary` | `#6a6a6a` | `#7a6a5c` |
+| `--color-border-subtle` | `#d0ccc4` | `rgba(26,20,16,0.18)` |
+| `--color-accent` | `#e63946` (bright red) | `#a83232` (muted oxblood) |
+
+New font family tokens:
+- `--font-serif: "Fraunces", Georgia, serif` (display)
+- `--font-serif-italic: "Cormorant", Georgia, serif` (italic deck + byline)
+- `--font-mono-plex: "IBM Plex Mono", ui-monospace, monospace` (meta + labels)
+
+`html` base font-family changed from `--font-sans` → `--font-serif`. Fraunces loaded with SOFT + opsz variable axes via Google Fonts.
+
+### Homepage — desktop (`frontend/src/routes/+page.svelte`)
+
+- **Day masthead** (new `DayMasthead.svelte`): huge Fraunces 64px prose date (`"Sunday, the nineteenth"` format, italic first letter + italic comma) + horizontal day strip (prev · Today · next 4 days · next) + `Pick date` button wired to `CalendarPopover`.
+- **Hybrid layout**: `grid-template-columns: 240px 1fr`. Left: `DesktopFilterSidebar.svelte` with search + `Where` (area chips resolving to cinema clusters) + `Time of day` (2×2) + `Format` + `Genre` + `Era` + Show/Reset footer. Right: `All / New / Repertory` bordered tabs + count line + 4-col grid of `DesktopHybridCard.svelte` (3-col between 1024–1279px).
+- Each card: aspect-2/3 poster, Fraunces 20px title with italic first letter, Cormorant byline, IBM Plex Mono meta, top-border-separated list of up to 3 inline screenings (first time in accent oxblood) with `+N more` overflow.
+
+### Homepage — mobile (same `+page.svelte`)
+
+- Cormorant italic ordinal date label ("Sunday, the nineteenth")
+- Search input + black `Filter ·N` button
+- `All / New / Repertory` bordered tabs (full width)
+- `MobileFilmRow.svelte` stack: left text column (title, byline, meta, time+cinema rows) + right 116px poster
+- `MobileFilterSheet.svelte` opens over the list: italic headline, chip-based filters across Where/When/Time of day/Format/Genre/Era/Director, sticky Reset + `Show N films` footer
+- `MobileDatePicker.svelte`: bottom sheet with grabber, monthly calendar (Mon-start, weekend in accent), Any-date button
+
+### Film detail (`frontend/src/routes/film/[id]/+page.svelte`)
+
+- **Desktop hero**: `grid-template-columns: 320px 1fr` — 320px poster, eyebrow, 96px italic-first-letter Fraunces title, Cormorant byline, IBM Plex Mono meta, Fraunces synopsis, CTA row (primary `Book next showing {time}, {cinema}` + `♡ Save` + `Trailer`)
+- **Screenings section**: Fraunces `Showings` heading (italic S), day strip, grouped by cinema with chip buttons per screening time (hollow border, mono time + italic format tail) + keep iCal button adjacent
+- **Sidebar** (≥1024px, 280px): Credits (Director / Cast / Country / Language), Status toggles (Want to see / Not interested)
+- **Mobile**: poster top (max 280px), title Fraunces 48px → 72px → 96px responsive, byline Cormorant, meta mono, synopsis Fraunces, CTAs flex-wrap
+
+### Layout chrome (`frontend/src/lib/components/layout/Header.svelte`)
+
+- Removed in-header `FilterBar` entirely — homepage owns filters via sidebar/sheet; non-homepage routes don't need filters in the chrome
+- Brand bar: logo + Watchlist (italic serif) + About/Map/Reachable + Sign-in (bordered pill) + DimmerDial (burger on mobile)
+- Fonts updated: nav items in Fraunces, Watchlist in Cormorant italic per design
+
+### FilmTypeFilter (`frontend/src/lib/components/filters/FilmTypeFilter.svelte`)
+
+Re-styled from underlined text tabs (uppercase "ALL/NEW/REPERTORY") → bordered segmented control ("All/New/Repertory" title-case) with active state filled black. Aligns with the V2a tab pattern used throughout sidebar + filter sheet.
+
+### Dev server (`frontend/vite.config.ts`)
+
+Added `process.env.API_PROXY_TARGET` override so devs without the local Next.js backend can point at `https://api.pictures.london` directly: `API_PROXY_TARGET=https://api.pictures.london npm run dev`.
+
+## Files
+
+**Created** (7):
+- `frontend/src/lib/components/calendar/DayMasthead.svelte`
+- `frontend/src/lib/components/calendar/DesktopHybridCard.svelte`
+- `frontend/src/lib/components/calendar/MobileFilmRow.svelte`
+- `frontend/src/lib/components/filters/DesktopFilterSidebar.svelte`
+- `frontend/src/lib/components/filters/MobileFilterSheet.svelte`
+- `frontend/src/lib/components/filters/MobileDatePicker.svelte`
+- `frontend/src/lib/components/filters/CalendarPopover.svelte`
+
+**Modified** (6):
+- `frontend/src/app.css` — tokens + fonts + utilities
+- `frontend/src/routes/+page.svelte` — full rewrite for hybrid desktop + V2a mobile
+- `frontend/src/routes/film/[id]/+page.svelte` — full rewrite for literary hero + grouped screenings
+- `frontend/src/lib/components/layout/Header.svelte` — drop in-header FilterBar, re-font nav
+- `frontend/src/lib/components/filters/FilmTypeFilter.svelte` — bordered segmented tabs
+- `frontend/vite.config.ts` — optional API proxy target env override
+
+## Verification
+
+Side-by-side browser comparison against the Claude Design prototype. Screenshots saved to `.design-verify/`:
+
+| # | Screen | Viewport | Source | Impl |
+|---|---|---|---|---|
+| 1 | Desktop Hybrid listings | 1440×900 | `.design-verify/source/desktop-hybrid-fullpage.png` | `.design-verify/impl/01-desktop-hybrid.png` |
+| 2 | Mobile Listings | 390×844 | `.design-verify/source/v2a-system-fullpage.png` (first cell) | `.design-verify/impl/02-mobile-listings.png` |
+| 3 | Mobile Filter Sheet | 390×844 | (second cell) | `.design-verify/impl/03-mobile-filter-sheet.png` |
+| 4 | Mobile Date picker | 390×844 | (third cell) | `.design-verify/impl/04-mobile-date-picker.png` |
+| 5 | Desktop Film detail | 1440×900 | (hybrid page, detail row) | `.design-verify/impl/05-desktop-film-detail.png` |
+| 6 | Mobile Film detail | 390×844 | (mobile detail row) | `.design-verify/impl/06-mobile-film-detail.png` |
+
+Typecheck (`npm run check`): clean in all files touched by this PR. Pre-existing errors in untouched files (FollowButton, CinemaMap, SyncProvider, letterboxd, and the WIP `+page.ts` files in cinemas/festivals/film) are not regressed.
+
+## Impact
+
+- **Users**: Visually dramatic — the site's whole character shifts from Swiss brutalist to literary editorial. Same data, same routes, same filter behaviour under the hood — just a new skin and a denser, more informative desktop layout.
+- **Mobile**: Less cramped. Bigger typography, clearer hierarchy, dedicated filter and date picker sheets instead of stuck-in-a-header dropdowns.
+- **Accessibility**: Focus-visible rings preserved; larger touch targets on mobile chip buttons (44px+); semantic HTML (sections/headings) retained.
+- **Tests**: 38 Playwright tests assert the old header FilterBar topology (`WHEN / ALL CINEMAS / FORMAT` dropdowns, ALL/NEW/REPERTORY uppercase text). Adding `.film-card` + `.film-title` classes to the new cards preserves most selector-level assertions; the filter-specific tests need rewriting against the new sidebar/sheet UI — follow-up scope.
+
+## Follow-up
+
+- Wire the homepage loader to expose `film.genres` and extend the filmMap filter chain to handle genres + decades, then restore the hidden Genre + Era sections in `DesktopFilterSidebar` + `MobileFilterSheet` (disabled in this PR since the chips were dead — clicking them persisted state to localStorage without affecting results).
+- Rewrite the 38 failing Playwright tests against the new filter topology (DesktopFilterSidebar on ≥1024px, MobileFilterSheet on <1024px, MobileDatePicker on "Pick a date" tap).
+- Add a focus trap + body-scroll lock + Escape-to-close to the mobile filter sheet, mobile date picker, and calendar popover.
+- Self-host Fraunces + Cormorant + IBM Plex Mono (match Inter's self-host pattern for consistent CWV / offline-friendliness).
+- Implement "If you like this" similar-films rail once backend exposes a similar-films field.
+- Wire area chips to distance-based filter when geolocation is added ("Within 2mi" is currently stubbed)
+- Migrate genre / decade / 4K-format filters from "persisted but not yet filtered" to active filtering once backend supports them

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,12 +1,14 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,300..700,0..100&family=Cormorant:ital,wght@0,400..600;1,400..600&family=IBM+Plex+Mono:wght@300..600&display=swap');
 @import "tailwindcss";
 
 /*
- * Pictures London — Swiss Brutalist Design System
- * International Typographic Style meets refined brutalism.
- * Typography-forward. Sharp edges. High contrast. Restrained motion.
+ * Pictures London — V2a Literary Antiqua
+ * Bookish editorial system: Fraunces SOFT display, Cormorant italic deck,
+ * IBM Plex Mono meta. Warm beige palette with oxblood accent.
+ * Zero radii preserved. Typography does the heavy lifting.
  */
 
-/* ── Self-hosted Inter Variable ── */
+/* ── Self-hosted Inter (retained for any sans fallback usage) ── */
 @font-face {
 	font-family: 'Inter Variable';
 	font-style: normal;
@@ -80,9 +82,14 @@
 	--radius-full: 0;
 
 	/* ── Font Families ── */
+	/* V2a literary system: Fraunces display + Cormorant italic + IBM Plex Mono */
+	--font-serif: "Fraunces", Georgia, "Times New Roman", serif;
+	--font-serif-italic: "Cormorant", Georgia, "Times New Roman", serif;
+	--font-mono-plex: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+	/* Retained aliases for any remaining sans usage */
 	--font-sans: "Inter Variable", "Inter", system-ui, -apple-system, sans-serif;
-	--font-mono: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
-	--font-display: "Space Grotesk", "Inter Variable", system-ui, sans-serif;
+	--font-mono: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace;
+	--font-display: "Fraunces", Georgia, serif;
 
 	/* ── Animation ── */
 	--duration-instant: 0ms;
@@ -95,42 +102,43 @@
 	--ease-snap: cubic-bezier(0.2, 0, 0, 1);
 }
 
-/* ── Color System (CSS custom properties for theming) ── */
+/* ── Color System (V2a literary antiqua — warm beige + oxblood) ── */
 :root {
-	--color-bg: #f5f2eb;
-	--color-bg-subtle: #ece8df;
+	--color-bg: #efe9dc;
+	--color-bg-subtle: #e5dfd0;
 	--color-surface: #ffffff;
-	--color-text: #0a0a0a;
-	--color-text-secondary: #3a3a3a;
-	--color-text-tertiary: #6a6a6a;
-	--color-border: #0a0a0a;
-	--color-border-subtle: #d0ccc4;
-	--color-accent: #e63946;
-	--color-accent-hover: #c62f3c;
-	--color-screening-bg: #0a0a0a;
-	--color-screening-text: #f5f2eb;
+	--color-text: #1a1410;
+	--color-text-secondary: #4a3a2e;
+	--color-text-tertiary: #7a6a5c;
+	--color-border: #1a1410;
+	--color-border-subtle: rgba(26, 20, 16, 0.18);
+	--color-accent: #a83232;
+	--color-accent-hover: #8a2828;
+	--color-screening-bg: #1a1410;
+	--color-screening-text: #efe9dc;
 }
 
 [data-theme="dark"] {
-	--color-bg: #0a0a0a;
-	--color-bg-subtle: #141414;
-	--color-surface: #1a1a1a;
-	--color-text: #f5f2eb;
-	--color-text-secondary: #c0bdb6;
-	--color-text-tertiary: #7a7a7a;
-	--color-border: #f5f2eb;
-	--color-border-subtle: #2a2a2a;
-	--color-accent: #ff4d5a;
-	--color-accent-hover: #ff6b75;
-	--color-screening-bg: #f5f2eb;
-	--color-screening-text: #0a0a0a;
+	--color-bg: #1a1410;
+	--color-bg-subtle: #241c17;
+	--color-surface: #2a211b;
+	--color-text: #efe9dc;
+	--color-text-secondary: #c9bfae;
+	--color-text-tertiary: #8a7c6b;
+	--color-border: #efe9dc;
+	--color-border-subtle: rgba(239, 233, 220, 0.18);
+	--color-accent: #d0494a;
+	--color-accent-hover: #e45d5e;
+	--color-screening-bg: #efe9dc;
+	--color-screening-text: #1a1410;
 }
 
 /* ── Base Styles ── */
 html {
 	background-color: var(--color-bg);
 	color: var(--color-text);
-	font-family: var(--font-sans);
+	font-family: var(--font-serif);
+	font-variation-settings: '"SOFT" 100', '"opsz" 24';
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	overflow-x: hidden;
@@ -140,9 +148,38 @@ body {
 	min-height: 100dvh;
 }
 
+/* ── Mobile input zoom guard ──
+   iOS Safari auto-zooms the viewport when a focused form control's computed
+   font-size is below 16px. Applying 16px universally on mobile prevents that
+   for every input in the app — including page-level search bars that ship
+   with a smaller component-scoped class selector (which would otherwise win
+   on specificity over a bare tag rule). The `!important` is a known and
+   acceptable workaround for this browser-compatibility quirk; desktop (≥768px)
+   is unaffected and keeps whatever size each component declares. */
+@media (max-width: 767px) {
+	input,
+	textarea,
+	select {
+		font-size: 16px !important;
+	}
+}
+
 /* ── Typography Utilities ── */
 .font-display {
 	font-family: var(--font-display);
+}
+
+.font-serif {
+	font-family: var(--font-serif);
+}
+
+.font-serif-italic {
+	font-family: var(--font-serif-italic);
+	font-style: italic;
+}
+
+.font-mono-plex {
+	font-family: var(--font-mono-plex);
 }
 
 .tracking-swiss {
@@ -156,6 +193,14 @@ body {
 .tracking-wide-swiss {
 	letter-spacing: 0.08em;
 }
+
+/* V2a variable-font axis helpers */
+.soft-display-144 { font-variation-settings: '"SOFT" 100', '"opsz" 144'; }
+.soft-display-96 { font-variation-settings: '"SOFT" 100', '"opsz" 96'; }
+.soft-display-72 { font-variation-settings: '"SOFT" 100', '"opsz" 72'; }
+.soft-display-48 { font-variation-settings: '"SOFT" 100', '"opsz" 48'; }
+.soft-display-36 { font-variation-settings: '"SOFT" 100', '"opsz" 36'; }
+.soft-display-24 { font-variation-settings: '"SOFT" 100', '"opsz" 24'; }
 
 /* ── Screening Pill ── */
 .screening-pill {

--- a/frontend/src/lib/components/calendar/DayMasthead.svelte
+++ b/frontend/src/lib/components/calendar/DayMasthead.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+	import { filters } from '$lib/stores/filters.svelte';
+	import { toLondonDateStr } from '$lib/utils';
+	import CalendarPopover from '$lib/components/filters/CalendarPopover.svelte';
+
+	// Effective date — filter if set, else today (London).
+	const today = $derived(toLondonDateStr(new Date()));
+	const activeDate = $derived(filters.dateFrom ?? today);
+
+	const activeDateObj = $derived(new Date(activeDate + 'T12:00:00'));
+
+	// Ordinal e.g. "nineteenth". Cover 1..31.
+	const ORDINALS: Record<number, string> = {
+		1: 'first', 2: 'second', 3: 'third', 4: 'fourth', 5: 'fifth', 6: 'sixth', 7: 'seventh',
+		8: 'eighth', 9: 'ninth', 10: 'tenth', 11: 'eleventh', 12: 'twelfth', 13: 'thirteenth',
+		14: 'fourteenth', 15: 'fifteenth', 16: 'sixteenth', 17: 'seventeenth', 18: 'eighteenth',
+		19: 'nineteenth', 20: 'twentieth', 21: 'twenty-first', 22: 'twenty-second',
+		23: 'twenty-third', 24: 'twenty-fourth', 25: 'twenty-fifth', 26: 'twenty-sixth',
+		27: 'twenty-seventh', 28: 'twenty-eighth', 29: 'twenty-ninth', 30: 'thirtieth',
+		31: 'thirty-first'
+	};
+
+	const weekday = $derived(
+		new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' }).format(activeDateObj)
+	);
+	const dayNum = $derived(Number(
+		new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' }).format(activeDateObj)
+	));
+	const ordinal = $derived(ORDINALS[dayNum] ?? `${dayNum}th`);
+
+	// Compose the day strip: prev arrow, Today, and next 4 days of the week.
+	interface StripItem { key: string; label: string; date: string; isActive: boolean; }
+
+	function addDays(iso: string, n: number) {
+		const d = new Date(iso + 'T12:00:00Z');
+		d.setUTCDate(d.getUTCDate() + n);
+		return d.toISOString().split('T')[0];
+	}
+
+	const stripItems = $derived.by<StripItem[]>(() => {
+		const items: StripItem[] = [];
+		const todayISO = today;
+		items.push({ key: 'today', label: 'Today', date: todayISO, isActive: activeDate === todayISO });
+		for (let i = 1; i <= 4; i++) {
+			const iso = addDays(todayISO, i);
+			const d = new Date(iso + 'T12:00:00Z');
+			const label = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' }).format(d);
+			items.push({ key: iso, label, date: iso, isActive: activeDate === iso });
+		}
+		return items;
+	});
+
+	function selectDate(iso: string | null) {
+		if (iso === null || iso === today) {
+			filters.dateFrom = null;
+			filters.dateTo = null;
+		} else {
+			filters.dateFrom = iso;
+			filters.dateTo = iso;
+		}
+	}
+
+	function stepDay(delta: number) {
+		const base = activeDate;
+		const next = addDays(base, delta);
+		if (next < today) return;
+		selectDate(next);
+	}
+
+	let pickerOpen = $state(false);
+</script>
+
+<section class="masthead">
+	<h1 class="masthead-title" aria-label="{weekday}, the {ordinal}">
+		<span class="italic-cap">{weekday.charAt(0)}</span><span>{weekday.slice(1)}</span><span class="italic-comma">,</span> <span class="masthead-muted">the {ordinal}</span>
+	</h1>
+
+	<div class="day-strip">
+		<button type="button" class="strip-btn strip-arrow" onclick={() => stepDay(-1)} aria-label="Previous day">‹</button>
+		{#each stripItems as item (item.key)}
+			<button
+				type="button"
+				class="strip-btn"
+				class:active={item.isActive}
+				onclick={() => selectDate(item.key === 'today' ? null : item.date)}
+				aria-pressed={item.isActive}
+			>
+				{item.label}
+			</button>
+		{/each}
+		<button type="button" class="strip-btn strip-arrow" onclick={() => stepDay(1)} aria-label="Next day">›</button>
+
+		<div class="picker-wrap">
+			<button
+				type="button"
+				class="pick-date-btn"
+				onclick={() => (pickerOpen = !pickerOpen)}
+				aria-expanded={pickerOpen}
+				aria-haspopup="dialog"
+			>
+				<svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">
+					<rect x="1.5" y="3" width="13" height="11" stroke="currentColor" stroke-width="1.1" fill="none"/>
+					<line x1="1.5" y1="6.5" x2="14.5" y2="6.5" stroke="currentColor" stroke-width="1.1"/>
+					<line x1="5" y1="1.5" x2="5" y2="4.5" stroke="currentColor" stroke-width="1.1"/>
+					<line x1="11" y1="1.5" x2="11" y2="4.5" stroke="currentColor" stroke-width="1.1"/>
+				</svg>
+				Pick date
+				<span class="chevron">▾</span>
+			</button>
+			{#if pickerOpen}
+				<div class="popover" role="dialog" aria-label="Pick a date">
+					<CalendarPopover
+						selected={activeDate}
+						today={today}
+						onSelect={(iso) => { selectDate(iso); pickerOpen = false; }}
+						onClose={() => (pickerOpen = false)}
+					/>
+				</div>
+			{/if}
+		</div>
+	</div>
+</section>
+
+<style>
+	.masthead {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 2rem;
+		padding: 1.5rem 0 1.125rem;
+		border-bottom: 1px solid var(--color-border);
+		position: relative;
+		flex-wrap: wrap;
+	}
+
+	.masthead-title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-weight: 300;
+		font-size: 4rem; /* 64px */
+		line-height: 0.9;
+		letter-spacing: -0.03em;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 144';
+	}
+
+	.masthead-title .italic-cap {
+		font-weight: 400;
+		font-style: italic;
+	}
+
+	.masthead-title .italic-comma {
+		font-weight: 400;
+		font-style: italic;
+		color: var(--color-text-tertiary);
+	}
+
+	.masthead-title .masthead-muted {
+		color: var(--color-text);
+	}
+
+	.day-strip {
+		display: flex;
+		gap: 4px;
+		align-items: stretch;
+		position: relative;
+	}
+
+	.strip-btn {
+		min-width: 58px;
+		padding: 7px 10px;
+		text-align: center;
+		background: transparent;
+		color: var(--color-text-secondary);
+		border: 1px solid var(--color-border);
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 13px;
+		letter-spacing: -0.005em;
+		font-weight: 400;
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
+	}
+
+	.strip-btn.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-weight: 500;
+	}
+
+	.strip-btn.strip-arrow {
+		min-width: 30px;
+		padding: 7px 8px;
+	}
+
+	.strip-btn:hover:not(.active) {
+		background: var(--color-bg-subtle);
+		color: var(--color-text);
+	}
+
+	.picker-wrap {
+		position: relative;
+		margin-left: 8px;
+	}
+
+	.pick-date-btn {
+		padding: 7px 12px;
+		background: var(--color-bg);
+		color: var(--color-text);
+		border: 1px solid var(--color-border);
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 13px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.pick-date-btn .chevron {
+		color: var(--color-text-tertiary);
+		margin-left: 2px;
+	}
+
+	.popover {
+		position: absolute;
+		top: calc(100% + 8px);
+		right: 0;
+		z-index: 20;
+	}
+
+	@media (max-width: 1023px) {
+		.masthead {
+			padding: 1rem 0;
+		}
+		.masthead-title {
+			font-size: 2.5rem;
+			font-variation-settings: '"SOFT" 100', '"opsz" 72';
+		}
+		.day-strip {
+			flex-wrap: wrap;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/calendar/DayMasthead.svelte
+++ b/frontend/src/lib/components/calendar/DayMasthead.svelte
@@ -7,7 +7,9 @@
 	const today = $derived(toLondonDateStr(new Date()));
 	const activeDate = $derived(filters.dateFrom ?? today);
 
-	const activeDateObj = $derived(new Date(activeDate + 'T12:00:00'));
+	// Anchor to UTC noon so the London Intl formatter resolves to the intended
+	// civil date regardless of the user's local timezone.
+	const activeDateObj = $derived(new Date(activeDate + 'T12:00:00Z'));
 
 	// Ordinal e.g. "nineteenth". Cover 1..31.
 	const ORDINALS: Record<number, string> = {

--- a/frontend/src/lib/components/calendar/DesktopHybridCard.svelte
+++ b/frontend/src/lib/components/calendar/DesktopHybridCard.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+	import { formatTime, getPosterImageAttributes } from '$lib/utils';
+	import { trackScreeningClick } from '$lib/analytics/posthog';
+
+	interface Screening {
+		id: string;
+		datetime: string;
+		cinemaName: string;
+		cinemaSlug?: string;
+		format?: string | null;
+		bookingUrl?: string;
+	}
+
+	interface Film {
+		id: string | number;
+		title: string;
+		year?: number | null;
+		director?: string | null;
+		runtime?: number | null;
+		country?: string | null;
+		certification?: string | null;
+		posterUrl?: string | null;
+	}
+
+	let {
+		film,
+		screenings,
+		maxScreenings = 3
+	}: {
+		film: Film;
+		screenings: Screening[];
+		maxScreenings?: number;
+	} = $props();
+
+	const upcoming = $derived.by(() =>
+		screenings
+			.filter((s) => new Date(s.datetime) > new Date())
+			.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
+	);
+
+	const visible = $derived(upcoming.slice(0, maxScreenings));
+	const overflow = $derived(Math.max(0, upcoming.length - maxScreenings));
+
+	const titleFirst = $derived(film.title.charAt(0));
+	const titleRest = $derived(film.title.slice(1));
+
+	const bylineText = $derived.by(() => {
+		const parts: string[] = [];
+		if (film.director) parts.push(film.director);
+		if (film.year) parts.push(String(film.year));
+		return parts.join(', ');
+	});
+
+	const metaParts = $derived.by(() => {
+		const parts: string[] = [];
+		if (film.runtime) parts.push(`${film.runtime}m`);
+		if (film.country) parts.push(film.country);
+		if (film.certification) parts.push(film.certification);
+		return parts;
+	});
+
+	const posterImage = $derived(
+		getPosterImageAttributes(film.posterUrl, {
+			baseSize: 'w342',
+			srcSetSizes: ['w185', 'w342', 'w500'],
+			sizes: '(min-width: 1280px) 220px, (min-width: 1024px) 240px, 50vw'
+		})
+	);
+
+	function normalisedFormat(fmt: string | null | undefined): string {
+		if (!fmt || fmt === 'unknown' || fmt === 'dcp') return 'DCP';
+		return fmt.toUpperCase().replace('_', ' ');
+	}
+
+	function handleScreeningClick(s: Screening) {
+		trackScreeningClick({
+			filmId: String(film.id),
+			filmTitle: film.title,
+			filmYear: film.year,
+			screeningId: s.id,
+			screeningTime: s.datetime,
+			cinemaName: s.cinemaName
+		}, 'calendar');
+	}
+</script>
+
+<article class="card film-card">
+	<a href="/film/{film.id}" class="poster-link" aria-label={film.title}>
+		<div class="poster">
+			{#if film.posterUrl}
+				<img
+					src={posterImage?.src ?? film.posterUrl}
+					srcset={posterImage?.srcset}
+					sizes={posterImage?.sizes}
+					alt=""
+					loading="lazy"
+					decoding="async"
+				/>
+			{:else}
+				<div class="poster-fallback"><span>{film.title}</span></div>
+			{/if}
+		</div>
+	</a>
+
+	<a href="/film/{film.id}" class="title-link">
+		<h3 class="title film-title">
+			<span class="title-italic-cap">{titleFirst}</span><span>{titleRest}</span>
+		</h3>
+	</a>
+
+	{#if bylineText}
+		<p class="byline">{bylineText}</p>
+	{/if}
+
+	{#if metaParts.length}
+		<p class="meta">{metaParts.join(' · ')}</p>
+	{/if}
+
+	{#if visible.length > 0}
+		<div class="screenings">
+			{#each visible as s, i (s.id)}
+				<a
+					class="screening"
+					href={s.bookingUrl ?? `/film/${film.id}`}
+					target={s.bookingUrl ? '_blank' : undefined}
+					rel={s.bookingUrl ? 'noopener noreferrer' : undefined}
+					onclick={() => handleScreeningClick(s)}
+				>
+					<time class="screening-time" class:lead={i === 0} datetime={s.datetime}>{formatTime(s.datetime)}</time>
+					<span class="screening-cinema">{s.cinemaName}</span>
+					{#if s.format}
+						<span class="screening-format">{normalisedFormat(s.format)}</span>
+					{/if}
+				</a>
+			{/each}
+			{#if overflow > 0}
+				<a class="more" href="/film/{film.id}">
+					+ <span class="more-count">{overflow}</span> more screening{overflow === 1 ? '' : 's'}
+				</a>
+			{/if}
+		</div>
+	{/if}
+</article>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+	}
+
+	.poster-link {
+		display: block;
+	}
+
+	.poster {
+		width: 100%;
+		aspect-ratio: 2 / 3;
+		overflow: hidden;
+		background: var(--color-bg-subtle);
+		border: 1px solid var(--color-border);
+		margin-bottom: 10px;
+	}
+
+	.poster img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.poster-fallback {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+	}
+
+	.poster-fallback span {
+		font-family: var(--font-serif);
+		font-size: 18px;
+		font-weight: 400;
+		text-align: center;
+		color: var(--color-text-tertiary);
+		letter-spacing: -0.02em;
+	}
+
+	.title-link { display: block; }
+
+	.title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 20px;
+		font-weight: 400;
+		letter-spacing: -0.02em;
+		line-height: 0.98;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 48';
+	}
+
+	.title-italic-cap {
+		font-style: italic;
+	}
+
+	.byline {
+		margin: 3px 0 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 12.5px;
+		color: var(--color-text-secondary);
+		font-weight: 400;
+		line-height: 1.2;
+	}
+
+	.meta {
+		margin: 3px 0 8px;
+		font-family: var(--font-mono-plex);
+		font-size: 9px;
+		color: var(--color-text-tertiary);
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+	}
+
+	.screenings {
+		padding-top: 8px;
+		border-top: 1px solid var(--color-border-subtle);
+	}
+
+	.screening {
+		display: flex;
+		align-items: baseline;
+		gap: 8px;
+		padding: 2px 0;
+		color: inherit;
+	}
+
+	.screening:hover .screening-cinema { color: var(--color-text); }
+
+	.screening-time {
+		font-family: var(--font-mono-plex);
+		font-size: 11.5px;
+		color: var(--color-text-secondary);
+		font-weight: 500;
+		min-width: 36px;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.screening-time.lead {
+		color: var(--color-accent);
+	}
+
+	.screening-cinema {
+		flex: 1;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 11.5px;
+		color: var(--color-text-secondary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.screening-format {
+		font-family: var(--font-mono-plex);
+		font-size: 9px;
+		color: var(--color-text-tertiary);
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+	}
+
+	.more {
+		display: block;
+		padding-top: 4px;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 11.5px;
+		color: var(--color-text-tertiary);
+	}
+
+	.more:hover { color: var(--color-text); }
+
+	.more-count {
+		color: var(--color-text-secondary);
+	}
+</style>

--- a/frontend/src/lib/components/calendar/MobileFilmRow.svelte
+++ b/frontend/src/lib/components/calendar/MobileFilmRow.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	import { formatTime, getPosterImageAttributes } from '$lib/utils';
+	import { trackScreeningClick } from '$lib/analytics/posthog';
+
+	interface Screening {
+		id: string;
+		datetime: string;
+		cinemaName: string;
+		bookingUrl?: string;
+	}
+
+	interface Film {
+		id: string | number;
+		title: string;
+		year?: number | null;
+		director?: string | null;
+		runtime?: number | null;
+		country?: string | null;
+		certification?: string | null;
+		posterUrl?: string | null;
+	}
+
+	let {
+		film,
+		screenings,
+		maxScreenings = 3
+	}: {
+		film: Film;
+		screenings: Screening[];
+		maxScreenings?: number;
+	} = $props();
+
+	const upcoming = $derived.by(() =>
+		screenings
+			.filter((s) => new Date(s.datetime) > new Date())
+			.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
+	);
+
+	const visible = $derived(upcoming.slice(0, maxScreenings));
+	const overflow = $derived(Math.max(0, upcoming.length - maxScreenings));
+
+	const posterImage = $derived(
+		getPosterImageAttributes(film.posterUrl, {
+			baseSize: 'w185',
+			srcSetSizes: ['w92', 'w185', 'w342'],
+			sizes: '116px'
+		})
+	);
+
+	const bylineText = $derived.by(() => {
+		const parts: string[] = [];
+		if (film.director) parts.push(film.director);
+		if (film.year) parts.push(String(film.year));
+		return parts.join(', ');
+	});
+
+	const metaParts = $derived.by(() => {
+		const parts: string[] = [];
+		if (film.runtime) parts.push(`${film.runtime}m`);
+		if (film.country) parts.push(film.country);
+		if (film.certification) parts.push(film.certification);
+		return parts;
+	});
+
+	function handleClick(s: Screening) {
+		trackScreeningClick({
+			filmId: String(film.id),
+			filmTitle: film.title,
+			filmYear: film.year,
+			screeningId: s.id,
+			screeningTime: s.datetime,
+			cinemaName: s.cinemaName
+		}, 'calendar');
+	}
+
+	const titleFirst = $derived(film.title.charAt(0));
+	const titleRest = $derived(film.title.slice(1));
+</script>
+
+<article class="row film-card">
+	<div class="text-col">
+		<a href="/film/{film.id}" class="title-link">
+			<h3 class="title film-title">
+				<span class="title-italic-cap">{titleFirst}</span><span>{titleRest}</span>
+			</h3>
+		</a>
+		{#if bylineText}
+			<p class="byline">a film by {bylineText}</p>
+		{/if}
+		{#if metaParts.length}
+			<p class="meta">{metaParts.join(' · ')}</p>
+		{/if}
+
+		{#if visible.length}
+			<div class="screenings">
+				{#each visible as s (s.id)}
+					<a
+						class="screening"
+						href={s.bookingUrl ?? `/film/${film.id}`}
+						target={s.bookingUrl ? '_blank' : undefined}
+						rel={s.bookingUrl ? 'noopener noreferrer' : undefined}
+						onclick={() => handleClick(s)}
+					>
+						<time class="screening-time" datetime={s.datetime}>{formatTime(s.datetime)}</time>
+						<span class="screening-cinema">{s.cinemaName}</span>
+					</a>
+				{/each}
+				{#if overflow > 0}
+					<a class="more" href="/film/{film.id}">
+						+ <span class="more-count">{overflow}</span> more
+					</a>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<a href="/film/{film.id}" class="poster-link" aria-label={film.title}>
+		<div class="poster">
+			{#if film.posterUrl}
+				<img
+					src={posterImage?.src ?? film.posterUrl}
+					srcset={posterImage?.srcset}
+					sizes={posterImage?.sizes}
+					alt=""
+					width="116"
+					height="174"
+					loading="lazy"
+					decoding="async"
+				/>
+			{:else}
+				<div class="poster-fallback"><span>{film.title}</span></div>
+			{/if}
+		</div>
+	</a>
+</article>
+
+<style>
+	.row {
+		display: flex;
+		gap: 14px;
+		align-items: flex-start;
+		padding: 18px 0 20px;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.text-col {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.title-link { display: block; }
+
+	.title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 32px;
+		font-weight: 300;
+		letter-spacing: -0.025em;
+		line-height: 0.92;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 144';
+	}
+
+	.title-italic-cap {
+		font-weight: 400;
+		font-style: italic;
+	}
+
+	.byline {
+		margin: 8px 0 2px;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text-secondary);
+		font-weight: 400;
+		line-height: 1.2;
+	}
+
+	.meta {
+		margin: 8px 0 10px;
+		font-family: var(--font-mono-plex);
+		font-size: 9px;
+		color: var(--color-text-tertiary);
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+	}
+
+	.screenings {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.screening {
+		display: flex;
+		align-items: baseline;
+		gap: 10px;
+		padding: 3px 0;
+		color: inherit;
+	}
+
+	.screening-time {
+		font-family: var(--font-mono-plex);
+		font-size: 12px;
+		font-weight: 400;
+		min-width: 44px;
+		color: var(--color-accent);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.screening-cinema {
+		flex: 1;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
+		color: var(--color-text-secondary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.more {
+		display: inline-block;
+		padding-top: 4px;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 12px;
+		color: var(--color-text-tertiary);
+	}
+
+	.more-count { color: var(--color-text-secondary); }
+
+	.poster-link { flex-shrink: 0; }
+
+	.poster {
+		width: 116px;
+		aspect-ratio: 2 / 3;
+		border: 1px solid var(--color-border);
+		overflow: hidden;
+		background: var(--color-bg-subtle);
+	}
+
+	.poster img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.poster-fallback {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.5rem;
+	}
+
+	.poster-fallback span {
+		font-family: var(--font-serif);
+		font-size: 12px;
+		text-align: center;
+		color: var(--color-text-tertiary);
+	}
+</style>

--- a/frontend/src/lib/components/filters/CalendarPopover.svelte
+++ b/frontend/src/lib/components/filters/CalendarPopover.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+	let {
+		selected,
+		today,
+		onSelect,
+		onClose,
+		width = 360
+	}: {
+		selected: string;            // YYYY-MM-DD
+		today: string;               // YYYY-MM-DD
+		onSelect: (iso: string) => void;
+		onClose?: () => void;
+		width?: number;
+	} = $props();
+
+	const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+
+	// Parse initial selected month/year. Reading `selected` once at mount time
+	// is fine here — users navigate months independently via prev/next after that.
+	let viewMonth = $state(0);
+	let viewYear = $state(2026);
+	$effect(() => {
+		// Initialise exactly once from the first render
+		const d = new Date(selected + 'T12:00:00Z');
+		viewMonth = d.getUTCMonth();
+		viewYear = d.getUTCFullYear();
+	});
+
+	function prev() {
+		if (viewMonth === 0) { viewMonth = 11; viewYear--; } else { viewMonth--; }
+	}
+	function next() {
+		if (viewMonth === 11) { viewMonth = 0; viewYear++; } else { viewMonth++; }
+	}
+
+	function pad(n: number) { return n < 10 ? '0' + n : String(n); }
+	function toISO(y: number, m: number, d: number) { return `${y}-${pad(m + 1)}-${pad(d)}`; }
+
+	interface Cell { date: string; day: number; isCurrent: boolean; isPast: boolean; isToday: boolean; isSelected: boolean; }
+
+	const days = $derived.by<Cell[]>(() => {
+		const first = new Date(Date.UTC(viewYear, viewMonth, 1));
+		const last = new Date(Date.UTC(viewYear, viewMonth + 1, 0));
+		let startDow = first.getUTCDay() - 1; // Mon = 0
+		if (startDow < 0) startDow = 6;
+
+		const out: Cell[] = [];
+		// Pad previous month
+		for (let i = startDow - 1; i >= 0; i--) {
+			const d = new Date(Date.UTC(viewYear, viewMonth, -i));
+			const iso = toISO(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+			out.push({ date: iso, day: d.getUTCDate(), isCurrent: false, isPast: iso < today, isToday: iso === today, isSelected: iso === selected });
+		}
+		for (let d = 1; d <= last.getUTCDate(); d++) {
+			const iso = toISO(viewYear, viewMonth, d);
+			out.push({ date: iso, day: d, isCurrent: true, isPast: iso < today, isToday: iso === today, isSelected: iso === selected });
+		}
+		// Pad next month up to a complete week row
+		while (out.length % 7 !== 0) {
+			const d = out.length - startDow - last.getUTCDate() + 1;
+			const nd = new Date(Date.UTC(viewYear, viewMonth + 1, d));
+			const iso = toISO(nd.getUTCFullYear(), nd.getUTCMonth(), nd.getUTCDate());
+			out.push({ date: iso, day: nd.getUTCDate(), isCurrent: false, isPast: iso < today, isToday: iso === today, isSelected: iso === selected });
+		}
+		return out;
+	});
+
+	function click(c: Cell) {
+		if (c.isPast) return;
+		onSelect(c.date);
+	}
+</script>
+
+<div class="calendar" style="width: {width}px">
+	<div class="cal-head">
+		<button class="cal-nav" onclick={prev} aria-label="Previous month" type="button">‹</button>
+		<div class="cal-title">
+			<span class="italic-cap">{MONTH_NAMES[viewMonth].charAt(0)}</span>{MONTH_NAMES[viewMonth].slice(1)}
+			<span class="year">{viewYear}</span>
+		</div>
+		<button class="cal-nav" onclick={next} aria-label="Next month" type="button">›</button>
+	</div>
+
+	<div class="cal-weekdays">
+		{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}
+			<div class="cal-weekday" class:is-weekend={i >= 5}>{d}</div>
+		{/each}
+	</div>
+
+	<div class="cal-grid">
+		{#each days as cell (cell.date)}
+			<button
+				class="cal-cell"
+				class:is-current={cell.isCurrent}
+				class:is-past={cell.isPast}
+				class:is-today={cell.isToday}
+				class:is-selected={cell.isSelected}
+				onclick={() => click(cell)}
+				disabled={cell.isPast}
+				type="button"
+				aria-label={cell.date}
+				aria-current={cell.isToday ? 'date' : undefined}
+			>
+				<span class="cal-day">{cell.day}</span>
+			</button>
+		{/each}
+	</div>
+
+	<div class="cal-foot">
+		<button class="cal-today" onclick={() => onSelect(today)} type="button">Today</button>
+		{#if onClose}
+			<button class="cal-close" onclick={onClose} type="button">Close</button>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.calendar {
+		background: var(--color-bg);
+		border: 1px solid var(--color-border);
+		font-family: var(--font-serif);
+		color: var(--color-text);
+	}
+
+	.cal-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 14px 8px;
+	}
+
+	.cal-nav {
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 22px;
+		color: var(--color-text-secondary);
+		padding: 0 4px;
+		line-height: 1;
+	}
+
+	.cal-title {
+		font-family: var(--font-serif);
+		font-size: 20px;
+		font-weight: 300;
+		letter-spacing: -0.02em;
+		font-variation-settings: '"SOFT" 100', '"opsz" 72';
+	}
+
+	.cal-title .italic-cap { font-style: italic; font-weight: 400; }
+	.cal-title .year {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		color: var(--color-text-tertiary);
+		margin-left: 6px;
+	}
+
+	.cal-weekdays {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		padding: 0 14px 6px;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.cal-weekday {
+		text-align: center;
+		font-family: var(--font-mono-plex);
+		font-size: 10px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--color-text-tertiary);
+	}
+
+	.cal-weekday.is-weekend {
+		color: var(--color-accent);
+	}
+
+	.cal-grid {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		padding: 6px 8px 6px;
+	}
+
+	.cal-cell {
+		aspect-ratio: 1 / 1;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 14px;
+		color: var(--color-text-secondary);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+	}
+
+	.cal-cell:not(.is-current) .cal-day { color: var(--color-text-tertiary); opacity: 0.45; }
+	.cal-cell.is-past:not(.is-today) { cursor: not-allowed; color: var(--color-text-tertiary); opacity: 0.35; }
+	.cal-cell.is-today .cal-day { font-weight: 600; color: var(--color-text); }
+	.cal-cell.is-selected {
+		background: var(--color-text);
+		color: var(--color-bg);
+	}
+	.cal-cell.is-selected .cal-day { color: var(--color-bg); font-weight: 500; }
+	.cal-cell:not(:disabled):not(.is-selected):hover { background: var(--color-bg-subtle); }
+
+	.cal-foot {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 8px 14px 10px;
+		border-top: 1px solid var(--color-border-subtle);
+	}
+
+	.cal-today, .cal-close {
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
+		color: var(--color-text-secondary);
+	}
+	.cal-today:hover, .cal-close:hover { color: var(--color-text); }
+</style>

--- a/frontend/src/lib/components/filters/DesktopFilterSidebar.svelte
+++ b/frontend/src/lib/components/filters/DesktopFilterSidebar.svelte
@@ -1,0 +1,459 @@
+<script lang="ts">
+	import { filters } from '$lib/stores/filters.svelte';
+	import { userLocation } from '$lib/stores/user-location.svelte';
+	import { haversineMiles } from '$lib/utils';
+
+	interface SidebarCinema {
+		id: string;
+		name: string;
+		shortName: string | null;
+		address: { area: string } | null;
+		coordinates?: { lat: number; lng: number } | null;
+	}
+
+	let {
+		cinemas = [],
+		filmCount = 0,
+		screeningCount = 0,
+		onHide
+	}: {
+		cinemas?: SidebarCinema[];
+		filmCount?: number;
+		screeningCount?: number;
+		onHide?: () => void;
+	} = $props();
+
+	// Where — area chips. Implemented as a cinemaId filter over the cinemas whose `address.area`
+	// matches each cluster. "Within 2mi" is stubbed (geolocation not wired yet).
+	const AREA_CLUSTERS: Array<{ label: string; areas: string[] }> = [
+		{ label: 'Soho & West End', areas: ['Soho', 'West End', 'Leicester Square', 'Covent Garden', 'Mayfair', 'Bloomsbury'] },
+		{ label: 'East', areas: ['Shoreditch', 'Hackney', 'Dalston', 'Hoxton', 'Bethnal Green', 'Mile End', 'Stratford', 'Whitechapel'] },
+		{ label: 'South', areas: ['Peckham', 'Brixton', 'Clapham', 'Waterloo', 'Southbank', 'South Bank', 'Elephant', 'Bermondsey', 'Camberwell'] },
+		{ label: 'North', areas: ['Camden', 'Islington', 'Angel', 'Kings Cross', 'Crouch End', 'Highgate', 'Archway'] }
+	];
+
+	function cinemasInCluster(label: string) {
+		const cluster = AREA_CLUSTERS.find(c => c.label === label);
+		if (!cluster) return [];
+		return cinemas.filter(c => {
+			const area = (c.address?.area ?? '').toLowerCase();
+			return cluster.areas.some(a => area.includes(a.toLowerCase()));
+		}).map(c => c.id);
+	}
+
+	function toggleArea(label: string) {
+		const ids = cinemasInCluster(label);
+		if (ids.length === 0) return;
+		const allActive = ids.every(id => filters.cinemaIds.includes(id));
+		if (allActive) {
+			filters.cinemaIds = filters.cinemaIds.filter(id => !ids.includes(id));
+		} else {
+			const set = new Set([...filters.cinemaIds, ...ids]);
+			filters.cinemaIds = Array.from(set);
+		}
+	}
+
+	function isAreaActive(label: string) {
+		const ids = cinemasInCluster(label);
+		return ids.length > 0 && ids.every(id => filters.cinemaIds.includes(id));
+	}
+
+	// "Within 2 miles" — requires browser geolocation. Once granted, we take the
+	// set of cinemas within 2mi of the user and set cinemaIds to them.
+	const WITHIN_RADIUS = 2;
+
+	function cinemasWithinRadius(radius: number): string[] {
+		const here = userLocation.coords;
+		if (!here) return [];
+		return cinemas
+			.filter(c => c.coordinates)
+			.filter(c => haversineMiles(here, c.coordinates!) <= radius)
+			.map(c => c.id);
+	}
+
+	const withinActive = $derived.by(() => {
+		if (userLocation.status !== 'granted') return false;
+		const ids = cinemasWithinRadius(WITHIN_RADIUS);
+		return ids.length > 0 && ids.every(id => filters.cinemaIds.includes(id));
+	});
+
+	async function toggleWithin() {
+		if (userLocation.status !== 'granted') {
+			await userLocation.request();
+			const s: string = userLocation.status;
+			if (s !== 'granted') return;
+		}
+		const ids = cinemasWithinRadius(WITHIN_RADIUS);
+		if (ids.length === 0) return;
+		const allActive = ids.every(id => filters.cinemaIds.includes(id));
+		filters.cinemaIds = allActive
+			? filters.cinemaIds.filter(id => !ids.includes(id))
+			: Array.from(new Set([...filters.cinemaIds, ...ids]));
+	}
+
+	// Time of day
+	const TIME_OPTIONS = [
+		{ key: 'morning', label: 'Before noon', range: '9–12', from: 0, to: 11 },
+		{ key: 'matinee', label: 'Matinée', range: '12–5', from: 12, to: 16 },
+		{ key: 'early-eve', label: 'Early eve', range: '5–8', from: 17, to: 20 },
+		{ key: 'late', label: 'Late', range: 'after 8', from: 21, to: 23 }
+	] as const;
+
+	function setTime(from: number, to: number) {
+		if (filters.timeFrom === from && filters.timeTo === to) {
+			filters.clearTimeRange();
+		} else {
+			filters.setTimePreset(from, to);
+		}
+	}
+
+	function isTimeActive(from: number, to: number) {
+		return filters.timeFrom === from && filters.timeTo === to;
+	}
+
+	// Format
+	const FORMATS = [
+		{ value: '35mm', label: '35mm' },
+		{ value: '70mm', label: '70mm' },
+		{ value: 'imax', label: 'IMAX' },
+		{ value: '4k', label: '4K' }
+	];
+
+	function toggleFormat(fmt: string) {
+		filters.toggleFormat(fmt);
+	}
+
+	// Genre + Era sections hidden until the homepage loader exposes genres and
+	// the filter pipeline is wired to year/decade. Follow-up PR will restore them.
+</script>
+
+<aside class="sidebar" aria-label="Filters">
+	{#if onHide}
+		<div class="sidebar-masthead">
+			<button type="button" class="sidebar-hide-link" onclick={onHide} aria-label="Hide filters">
+				<span class="hide-label">Hide</span>
+				<span class="hide-chevron" aria-hidden="true">‹</span>
+			</button>
+		</div>
+	{/if}
+
+	<!-- Search -->
+	<div class="search">
+		<svg width="11" height="11" viewBox="0 0 14 14" aria-hidden="true">
+			<circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.2" fill="none"/>
+			<path d="M9.5 9.5L13 13" stroke="currentColor" stroke-width="1.2"/>
+		</svg>
+		<input
+			type="search"
+			placeholder="Search films, cinemas…"
+			bind:value={filters.filmSearch}
+			aria-label="Search films, cinemas, directors"
+		/>
+	</div>
+
+	<section class="section">
+		<header class="section-head">
+			<h4>Where</h4>
+			<span class="hint">anywhere</span>
+		</header>
+		<div class="chips">
+			{#each AREA_CLUSTERS as cluster (cluster.label)}
+				{@const active = isAreaActive(cluster.label)}
+				<button type="button" class="chip" class:active onclick={() => toggleArea(cluster.label)} aria-pressed={active}>
+					{cluster.label}
+				</button>
+			{/each}
+			<button
+				type="button"
+				class="chip"
+				class:active={withinActive}
+				onclick={toggleWithin}
+				aria-pressed={withinActive}
+				aria-busy={userLocation.status === 'requesting'}
+				title={userLocation.status === 'denied' ? 'Location permission denied' : 'Within 2 miles of you'}
+			>
+				{userLocation.status === 'requesting' ? 'Locating…' : 'Within 2mi'}
+			</button>
+		</div>
+		{#if userLocation.status === 'denied'}
+			<p class="loc-note">Location denied — enable it in your browser to use this.</p>
+		{:else if userLocation.status === 'unsupported'}
+			<p class="loc-note">Your browser doesn't support location.</p>
+		{:else if userLocation.status === 'granted' && cinemasWithinRadius(WITHIN_RADIUS).length === 0}
+			<p class="loc-note">No cinemas within 2 miles of you.</p>
+		{/if}
+	</section>
+
+	<section class="section">
+		<header class="section-head">
+			<h4>Time of day</h4>
+		</header>
+		<div class="time-grid">
+			{#each TIME_OPTIONS as opt (opt.key)}
+				{@const active = isTimeActive(opt.from, opt.to)}
+				<button type="button" class="time-chip" class:active onclick={() => setTime(opt.from, opt.to)} aria-pressed={active}>
+					<span class="time-label">{opt.label}</span>
+					<span class="time-range">{opt.range}</span>
+				</button>
+			{/each}
+		</div>
+	</section>
+
+	<section class="section">
+		<header class="section-head"><h4>Format</h4></header>
+		<div class="chips">
+			{#each FORMATS as fmt (fmt.value)}
+				{@const active = filters.formats.includes(fmt.value)}
+				<button type="button" class="chip" class:active onclick={() => toggleFormat(fmt.value)} aria-pressed={active}>
+					{fmt.label}
+				</button>
+			{/each}
+		</div>
+	</section>
+
+	<div class="foot">
+		<button type="button" class="show-btn">
+			Show <span class="show-count">{filmCount}</span>
+		</button>
+		<button type="button" class="reset-btn" onclick={() => filters.clearAll()}>Reset</button>
+	</div>
+</aside>
+
+<style>
+	.sidebar {
+		padding: 1rem 1.375rem 2.5rem;
+		background: var(--color-bg);
+		border-right: 1px solid var(--color-border);
+		font-family: var(--font-serif);
+		color: var(--color-text);
+	}
+
+	.sidebar-masthead {
+		display: flex;
+		justify-content: flex-end;
+		padding-bottom: 8px;
+	}
+
+	.sidebar-hide-link {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 4px;
+		padding: 0;
+		background: transparent;
+		border: none;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text-tertiary);
+		cursor: pointer;
+		transition: color var(--duration-fast) var(--ease-sharp);
+	}
+
+	.sidebar-hide-link:hover { color: var(--color-text); }
+
+	.sidebar-hide-link .hide-chevron {
+		font-family: var(--font-serif);
+		font-style: normal;
+		font-size: 15px;
+		line-height: 1;
+	}
+
+	.search {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 9px 11px;
+		background: #fff;
+		border: 1px solid var(--color-border);
+		color: var(--color-text-tertiary);
+		margin-bottom: 12px;
+	}
+
+	.search input {
+		flex: 1;
+		background: transparent;
+		border: none;
+		outline: none;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 12.5px;
+		color: var(--color-text);
+		min-width: 0;
+	}
+
+	.search input::placeholder {
+		color: var(--color-text-tertiary);
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+	}
+
+	.section {
+		padding: 12px 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.section-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		margin-bottom: 8px;
+	}
+
+	.section-head h4 {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 13px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
+	}
+
+	.hint {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 11px;
+		color: var(--color-text-tertiary);
+	}
+
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 5px;
+	}
+
+	.chip {
+		padding: 7px 10px;
+		background: transparent;
+		color: var(--color-text-secondary);
+		border: 1px solid var(--color-border);
+		font-family: var(--font-serif);
+		font-size: 12.5px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		cursor: pointer;
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
+	}
+
+	.chip:hover:not(.active):not(:disabled) {
+		background: var(--color-bg-subtle);
+		color: var(--color-text);
+	}
+
+	.chip.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-weight: 500;
+	}
+
+	.chip:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+
+	.loc-note {
+		margin: 8px 0 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 11px;
+		color: var(--color-text-tertiary);
+		line-height: 1.3;
+	}
+
+	.time-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 5px;
+	}
+
+	.time-chip {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		text-align: left;
+		padding: 8px 10px;
+		background: transparent;
+		color: var(--color-text-secondary);
+		border: 1px solid var(--color-border);
+		cursor: pointer;
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
+	}
+
+	.time-chip:hover:not(.active) {
+		background: var(--color-bg-subtle);
+		color: var(--color-text);
+	}
+
+	.time-chip.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+	}
+
+	.time-label {
+		font-family: var(--font-serif);
+		font-size: 12.5px;
+		letter-spacing: -0.005em;
+		font-weight: 400;
+	}
+
+	.time-chip.active .time-label {
+		font-weight: 500;
+	}
+
+	.time-range {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 10.5px;
+		opacity: 0.55;
+	}
+
+	.time-chip.active .time-range { opacity: 0.7; }
+
+	.foot {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding-top: 14px;
+	}
+
+	.show-btn {
+		flex: 1;
+		padding: 9px;
+		background: var(--color-text);
+		color: var(--color-bg);
+		border: 1px solid var(--color-border);
+		font-family: var(--font-serif);
+		font-size: 12.5px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		cursor: pointer;
+		display: inline-flex;
+		justify-content: center;
+		align-items: baseline;
+		gap: 5px;
+	}
+
+	.show-btn .show-count {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-weight: 400;
+	}
+
+	.reset-btn {
+		padding: 9px 11px;
+		background: transparent;
+		border: 1px solid var(--color-border);
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 12px;
+		color: var(--color-text);
+		cursor: pointer;
+	}
+
+	.reset-btn:hover {
+		background: var(--color-bg-subtle);
+	}
+</style>

--- a/frontend/src/lib/components/filters/FilmTypeFilter.svelte
+++ b/frontend/src/lib/components/filters/FilmTypeFilter.svelte
@@ -3,9 +3,9 @@
 	import { trackFilterChange } from '$lib/analytics/posthog';
 
 	const options = [
-		{ value: 'all', label: 'ALL' },
-		{ value: 'new', label: 'NEW' },
-		{ value: 'repertory', label: 'REPERTORY' }
+		{ value: 'all', label: 'All' },
+		{ value: 'new', label: 'New' },
+		{ value: 'repertory', label: 'Repertory' }
 	];
 
 	const selected = $derived.by(() => {
@@ -43,35 +43,37 @@
 
 <style>
 	.type-filter {
-		display: flex;
+		display: inline-flex;
 		gap: 0;
 	}
 
-	.type-tab:first-child {
-		padding-left: 0;
-	}
-
 	.type-tab {
-		padding: 0.375rem 0.625rem;
-		font-size: var(--font-size-xs);
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--color-text-tertiary);
+		padding: 7px 16px;
+		font-family: var(--font-serif);
+		font-size: 13.5px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		color: var(--color-text-secondary);
 		background: transparent;
-		border: none;
-		border-bottom: 2px solid transparent;
+		border: 1px solid var(--color-border);
 		cursor: pointer;
-		transition: color var(--duration-fast) var(--ease-sharp),
-			border-color var(--duration-fast) var(--ease-sharp);
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
 	}
 
-	.type-tab:hover {
+	.type-tab:not(:last-child) {
+		border-right: none;
+	}
+
+	.type-tab:hover:not(.active) {
+		background: var(--color-bg-subtle);
 		color: var(--color-text);
 	}
 
 	.type-tab.active {
-		color: var(--color-text);
-		border-bottom-color: var(--color-accent);
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-weight: 500;
 	}
 </style>

--- a/frontend/src/lib/components/filters/MobileDatePicker.svelte
+++ b/frontend/src/lib/components/filters/MobileDatePicker.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+	import { filters } from '$lib/stores/filters.svelte';
+	import { toLondonDateStr } from '$lib/utils';
+
+	let { open, onClose }: { open: boolean; onClose: () => void } = $props();
+
+	const today = toLondonDateStr(new Date());
+	const initial = new Date((filters.dateFrom ?? today) + 'T12:00:00Z');
+	let viewMonth = $state(initial.getUTCMonth());
+	let viewYear = $state(initial.getUTCFullYear());
+
+	const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+
+	function prev() { if (viewMonth === 0) { viewMonth = 11; viewYear--; } else viewMonth--; }
+	function next() { if (viewMonth === 11) { viewMonth = 0; viewYear++; } else viewMonth++; }
+
+	function pad(n: number) { return n < 10 ? '0' + n : String(n); }
+	function toISO(y: number, m: number, d: number) { return `${y}-${pad(m + 1)}-${pad(d)}`; }
+
+	interface Cell { date: string; day: number; isCurrent: boolean; isPast: boolean; isToday: boolean; isSelected: boolean; dow: number; }
+
+	const cells = $derived.by<Cell[]>(() => {
+		const first = new Date(Date.UTC(viewYear, viewMonth, 1));
+		const last = new Date(Date.UTC(viewYear, viewMonth + 1, 0));
+		let startDow = first.getUTCDay() - 1;
+		if (startDow < 0) startDow = 6;
+
+		const out: Cell[] = [];
+		for (let i = startDow - 1; i >= 0; i--) {
+			const d = new Date(Date.UTC(viewYear, viewMonth, -i));
+			const iso = toISO(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+			const dow = (d.getUTCDay() + 6) % 7;
+			out.push({ date: iso, day: d.getUTCDate(), isCurrent: false, isPast: iso < today, isToday: iso === today, isSelected: iso === filters.dateFrom, dow });
+		}
+		for (let d = 1; d <= last.getUTCDate(); d++) {
+			const dt = new Date(Date.UTC(viewYear, viewMonth, d));
+			const iso = toISO(viewYear, viewMonth, d);
+			const dow = (dt.getUTCDay() + 6) % 7;
+			out.push({ date: iso, day: d, isCurrent: true, isPast: iso < today, isToday: iso === today, isSelected: iso === filters.dateFrom, dow });
+		}
+		while (out.length % 7 !== 0) {
+			const d = out.length - startDow - last.getUTCDate() + 1;
+			const dt = new Date(Date.UTC(viewYear, viewMonth + 1, d));
+			const iso = toISO(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate());
+			const dow = (dt.getUTCDay() + 6) % 7;
+			out.push({ date: iso, day: dt.getUTCDate(), isCurrent: false, isPast: iso < today, isToday: iso === today, isSelected: iso === filters.dateFrom, dow });
+		}
+		return out;
+	});
+
+	function select(c: Cell) {
+		if (c.isPast) return;
+		filters.dateFrom = c.date;
+		filters.dateTo = c.date;
+		onClose();
+	}
+
+	function clearDate() {
+		filters.dateFrom = null;
+		filters.dateTo = null;
+		onClose();
+	}
+</script>
+
+{#if open}
+	<div class="backdrop" onclick={onClose} role="presentation"></div>
+	<div class="sheet" role="dialog" aria-label="Pick a date" aria-modal="true">
+		<div class="grabber-wrap"><div class="grabber"></div></div>
+
+		<div class="sheet-head">
+			<h3 class="title"><span class="italic-cap">P</span>ick a date</h3>
+			<button class="close-btn" type="button" onclick={onClose}>Close</button>
+		</div>
+
+		<div class="month-head">
+			<button type="button" class="nav-btn" onclick={prev} aria-label="Previous month">‹</button>
+			<div class="month-name">
+				<span class="italic-cap">{MONTH_NAMES[viewMonth].charAt(0)}</span>{MONTH_NAMES[viewMonth].slice(1)}
+				<span class="year">{viewYear}</span>
+			</div>
+			<button type="button" class="nav-btn" onclick={next} aria-label="Next month">›</button>
+		</div>
+
+		<div class="weekdays">
+			{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}
+				<div class="wk" class:weekend={i >= 5}>{d}</div>
+			{/each}
+		</div>
+
+		<div class="grid">
+			{#each cells as c (c.date)}
+				<button
+					class="cell"
+					class:current={c.isCurrent}
+					class:past={c.isPast}
+					class:today={c.isToday}
+					class:selected={c.isSelected}
+					class:weekend={c.dow >= 5}
+					onclick={() => select(c)}
+					disabled={c.isPast}
+					type="button"
+					aria-label={c.date}
+				>
+					<span class="day-num">{c.day}</span>
+				</button>
+			{/each}
+		</div>
+
+		<div class="foot">
+			<button class="any-date" type="button" onclick={clearDate}>Any date</button>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(10, 6, 4, 0.55);
+		z-index: 90;
+	}
+
+	.sheet {
+		position: fixed;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		z-index: 91;
+		background: var(--color-bg);
+		border-top: 1px solid var(--color-border);
+		display: flex;
+		flex-direction: column;
+		max-height: 85%;
+	}
+
+	.grabber-wrap {
+		display: flex;
+		justify-content: center;
+		padding: 10px 0 2px;
+	}
+
+	.grabber {
+		width: 40px;
+		height: 3px;
+		background: var(--color-border-subtle);
+	}
+
+	.sheet-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		padding: 10px 18px 14px;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 22px;
+		font-weight: 300;
+		letter-spacing: -0.02em;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 48';
+	}
+
+	.title .italic-cap { font-style: italic; font-weight: 400; }
+
+	.close-btn {
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text-secondary);
+		padding: 0;
+	}
+
+	.month-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		padding: 14px 18px 10px;
+	}
+
+	.nav-btn {
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 22px;
+		color: var(--color-text-secondary);
+		padding: 0 6px;
+		line-height: 1;
+	}
+
+	.month-name {
+		font-family: var(--font-serif);
+		font-size: 20px;
+		font-weight: 300;
+		letter-spacing: -0.02em;
+		font-variation-settings: '"SOFT" 100', '"opsz" 72';
+	}
+
+	.month-name .italic-cap { font-style: italic; font-weight: 400; }
+	.month-name .year {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		color: var(--color-text-tertiary);
+		margin-left: 6px;
+	}
+
+	.weekdays {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		padding: 0 14px 6px;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.wk {
+		text-align: center;
+		font-family: var(--font-mono-plex);
+		font-size: 10px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--color-text-tertiary);
+	}
+
+	.wk.weekend { color: var(--color-accent); }
+
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		padding: 8px 8px;
+	}
+
+	.cell {
+		aspect-ratio: 1 / 1;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 15px;
+		color: var(--color-text);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+	}
+
+	.cell:not(.current) .day-num { color: var(--color-text-tertiary); opacity: 0.4; }
+	.cell.past:not(.today) { opacity: 0.35; cursor: not-allowed; }
+	.cell.today .day-num { font-weight: 600; }
+	.cell.selected {
+		background: var(--color-text);
+	}
+	.cell.selected .day-num { color: var(--color-bg); font-weight: 500; }
+	.cell.weekend.current:not(.selected) .day-num { color: var(--color-accent); }
+
+	.foot {
+		border-top: 1px solid var(--color-border-subtle);
+		padding: 12px 18px 22px;
+		display: flex;
+		justify-content: center;
+	}
+
+	.any-date {
+		background: transparent;
+		border: 1px solid var(--color-border);
+		padding: 10px 14px;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text);
+		cursor: pointer;
+	}
+</style>

--- a/frontend/src/lib/components/filters/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/filters/MobileFilterSheet.svelte
@@ -1,0 +1,417 @@
+<script lang="ts">
+	import { filters } from '$lib/stores/filters.svelte';
+	import { userLocation } from '$lib/stores/user-location.svelte';
+	import { haversineMiles, toLondonDateStr } from '$lib/utils';
+	import MobileDatePicker from './MobileDatePicker.svelte';
+
+	interface SheetCinema {
+		id: string;
+		name: string;
+		shortName: string | null;
+		address: { area: string } | null;
+		coordinates?: { lat: number; lng: number } | null;
+	}
+
+	let {
+		cinemas = [],
+		filmCount = 0,
+		open,
+		onClose
+	}: {
+		cinemas?: SheetCinema[];
+		filmCount?: number;
+		open: boolean;
+		onClose: () => void;
+	} = $props();
+
+	let datePickerOpen = $state(false);
+
+	// Re-use the same area clusters
+	const AREA_CLUSTERS: Array<{ label: string; areas: string[] }> = [
+		{ label: 'Soho & West End', areas: ['Soho', 'West End', 'Leicester Square', 'Covent Garden', 'Mayfair', 'Bloomsbury'] },
+		{ label: 'East', areas: ['Shoreditch', 'Hackney', 'Dalston', 'Hoxton', 'Bethnal Green', 'Mile End', 'Stratford', 'Whitechapel'] },
+		{ label: 'South', areas: ['Peckham', 'Brixton', 'Clapham', 'Waterloo', 'Southbank', 'South Bank', 'Elephant', 'Bermondsey', 'Camberwell'] },
+		{ label: 'North', areas: ['Camden', 'Islington', 'Angel', 'Kings Cross', 'Crouch End', 'Highgate', 'Archway'] }
+	];
+
+	function cinemasInCluster(label: string) {
+		const cluster = AREA_CLUSTERS.find(c => c.label === label);
+		if (!cluster) return [];
+		return cinemas.filter(c => {
+			const area = (c.address?.area ?? '').toLowerCase();
+			return cluster.areas.some(a => area.includes(a.toLowerCase()));
+		}).map(c => c.id);
+	}
+	function isAreaActive(label: string) {
+		const ids = cinemasInCluster(label);
+		return ids.length > 0 && ids.every(id => filters.cinemaIds.includes(id));
+	}
+	function toggleArea(label: string) {
+		const ids = cinemasInCluster(label);
+		if (ids.length === 0) return;
+		const allActive = ids.every(id => filters.cinemaIds.includes(id));
+		filters.cinemaIds = allActive
+			? filters.cinemaIds.filter(id => !ids.includes(id))
+			: Array.from(new Set([...filters.cinemaIds, ...ids]));
+	}
+
+	// "Within 2 miles" — browser geolocation required.
+	const WITHIN_RADIUS = 2;
+	function cinemasWithinRadius(radius: number): string[] {
+		const here = userLocation.coords;
+		if (!here) return [];
+		return cinemas
+			.filter(c => c.coordinates)
+			.filter(c => haversineMiles(here, c.coordinates!) <= radius)
+			.map(c => c.id);
+	}
+	const withinActive = $derived.by(() => {
+		if (userLocation.status !== 'granted') return false;
+		const ids = cinemasWithinRadius(WITHIN_RADIUS);
+		return ids.length > 0 && ids.every(id => filters.cinemaIds.includes(id));
+	});
+	async function toggleWithin() {
+		if (userLocation.status !== 'granted') {
+			await userLocation.request();
+			const s: string = userLocation.status;
+			if (s !== 'granted') return;
+		}
+		const ids = cinemasWithinRadius(WITHIN_RADIUS);
+		if (ids.length === 0) return;
+		const allActive = ids.every(id => filters.cinemaIds.includes(id));
+		filters.cinemaIds = allActive
+			? filters.cinemaIds.filter(id => !ids.includes(id))
+			: Array.from(new Set([...filters.cinemaIds, ...ids]));
+	}
+
+	// When
+	const today = toLondonDateStr(new Date());
+	const tomorrow = (() => {
+		const t = new Date(today + 'T12:00:00Z');
+		t.setUTCDate(t.getUTCDate() + 1);
+		return t.toISOString().split('T')[0];
+	})();
+	const dayFmt = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' });
+	const todayLabel = dayFmt.format(new Date(today + 'T12:00:00Z'));
+	const tomorrowLabel = dayFmt.format(new Date(tomorrow + 'T12:00:00Z'));
+
+	function pick(preset: 'today' | 'tomorrow' | 'weekend' | null) {
+		if (preset === 'today') {
+			filters.dateFrom = today;
+			filters.dateTo = today;
+		} else if (preset === 'tomorrow') {
+			filters.dateFrom = tomorrow;
+			filters.dateTo = tomorrow;
+		} else if (preset === 'weekend') {
+			filters.setDatePreset('weekend');
+		} else {
+			filters.setDatePreset(null);
+		}
+	}
+
+	const whenState = $derived.by<'today' | 'tomorrow' | 'weekend' | 'date' | 'none'>(() => {
+		if (!filters.dateFrom) return 'none';
+		if (filters.dateFrom === today && filters.dateTo === today) return 'today';
+		if (filters.dateFrom === tomorrow && filters.dateTo === tomorrow) return 'tomorrow';
+		if (filters.dateFrom !== filters.dateTo) return 'weekend';
+		return 'date';
+	});
+
+	// Time
+	const TIME_OPTIONS = [
+		{ label: 'Before noon', range: '9–12', from: 0, to: 11 },
+		{ label: 'Matinée', range: '12–5', from: 12, to: 16 },
+		{ label: 'Early evening', range: '5–8', from: 17, to: 20 },
+		{ label: 'Late', range: 'after 8', from: 21, to: 23 }
+	];
+	function isTimeActive(f: number, t: number) { return filters.timeFrom === f && filters.timeTo === t; }
+	function setTime(f: number, t: number) {
+		if (isTimeActive(f, t)) filters.clearTimeRange();
+		else filters.setTimePreset(f, t);
+	}
+
+	// Format
+	const FORMATS = [
+		{ value: '35mm', label: '35mm' },
+		{ value: '70mm', label: '70mm' },
+		{ value: 'imax', label: 'IMAX' },
+		{ value: '4k', label: '4K' }
+	];
+
+	// Genre + Era sections hidden until the homepage loader exposes genres and
+	// the filter pipeline is wired. Follow-up PR will restore them.
+
+</script>
+
+{#if open}
+	<div class="sheet" role="dialog" aria-label="Filter programme" aria-modal="true">
+		<header class="sheet-head">
+			<h2 class="sheet-title"><span class="italic-cap">F</span>ilter</h2>
+			<button class="close" onclick={onClose} aria-label="Close filters" type="button">×</button>
+		</header>
+
+		<div class="sheet-body">
+			<!-- Where -->
+			<section class="filter-section">
+				<div class="section-head">
+					<h4>Where</h4>
+					<span class="hint">anywhere in London</span>
+				</div>
+				<div class="mini-search">
+					<svg width="11" height="11" viewBox="0 0 14 14" aria-hidden="true">
+						<circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.2" fill="none"/>
+						<path d="M9.5 9.5L13 13" stroke="currentColor" stroke-width="1.2"/>
+					</svg>
+					<span>Search cinemas by name…</span>
+				</div>
+				<div class="chips">
+					{#each AREA_CLUSTERS as cluster (cluster.label)}
+						{@const active = isAreaActive(cluster.label)}
+						<button type="button" class="chip" class:active onclick={() => toggleArea(cluster.label)} aria-pressed={active}>{cluster.label}</button>
+					{/each}
+					<button
+						type="button"
+						class="chip"
+						class:active={withinActive}
+						onclick={toggleWithin}
+						aria-pressed={withinActive}
+						aria-busy={userLocation.status === 'requesting'}
+					>
+						{userLocation.status === 'requesting' ? 'Locating…' : 'Within 2 miles'}
+					</button>
+				</div>
+			</section>
+
+			<!-- When -->
+			<section class="filter-section">
+				<div class="section-head">
+					<h4>When</h4>
+					<span class="hint">today</span>
+				</div>
+				<div class="chips">
+					<button type="button" class="chip" class:active={whenState === 'today'} onclick={() => pick(whenState === 'today' ? null : 'today')}>Today<span class="sub">{todayLabel} {new Date(today + 'T12:00:00Z').getUTCDate()}</span></button>
+					<button type="button" class="chip" class:active={whenState === 'tomorrow'} onclick={() => pick(whenState === 'tomorrow' ? null : 'tomorrow')}>Tomorrow<span class="sub">{tomorrowLabel} {new Date(tomorrow + 'T12:00:00Z').getUTCDate()}</span></button>
+					<button type="button" class="chip" class:active={whenState === 'weekend'} onclick={() => pick(whenState === 'weekend' ? null : 'weekend')}>This weekend</button>
+					<button type="button" class="chip" onclick={() => (datePickerOpen = true)}>Pick a date</button>
+				</div>
+			</section>
+
+			<!-- Time of day -->
+			<section class="filter-section">
+				<div class="section-head"><h4>Time of day</h4></div>
+				<div class="chips">
+					{#each TIME_OPTIONS as opt (opt.label)}
+						{@const active = isTimeActive(opt.from, opt.to)}
+						<button type="button" class="chip" class:active onclick={() => setTime(opt.from, opt.to)} aria-pressed={active}>
+							{opt.label}<span class="sub">{opt.range}</span>
+						</button>
+					{/each}
+				</div>
+			</section>
+
+			<!-- Format -->
+			<section class="filter-section">
+				<div class="section-head"><h4>Format</h4></div>
+				<div class="chips">
+					{#each FORMATS as fmt (fmt.value)}
+						{@const active = filters.formats.includes(fmt.value)}
+						<button type="button" class="chip" class:active onclick={() => filters.toggleFormat(fmt.value)} aria-pressed={active}>{fmt.label}</button>
+					{/each}
+				</div>
+			</section>
+
+			<div class="bottom-spacer"></div>
+		</div>
+
+		<footer class="sheet-foot">
+			<button class="reset" type="button" onclick={() => filters.clearAll()}>Reset</button>
+			<button class="show" type="button" onclick={onClose}>
+				Show <span class="show-count">{filmCount}</span> films
+			</button>
+		</footer>
+	</div>
+{/if}
+
+{#if datePickerOpen}
+	<MobileDatePicker open={datePickerOpen} onClose={() => (datePickerOpen = false)} />
+{/if}
+
+<style>
+	.sheet {
+		position: fixed;
+		inset: 0;
+		z-index: 80;
+		background: var(--color-bg);
+		display: flex;
+		flex-direction: column;
+	}
+
+	.sheet-head {
+		padding: 52px 18px 14px;
+		border-bottom: 1px solid var(--color-border);
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+	}
+
+	.sheet-title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 36px;
+		font-weight: 300;
+		letter-spacing: -0.025em;
+		line-height: 0.92;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 144';
+	}
+
+	.sheet-title .italic-cap { font-style: italic; font-weight: 400; }
+
+	.close {
+		width: 36px;
+		height: 36px;
+		padding: 0;
+		background: transparent;
+		border: 1px solid var(--color-border);
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 18px;
+		color: var(--color-text);
+		line-height: 1;
+	}
+
+	.sheet-body {
+		flex: 1;
+		overflow-y: auto;
+	}
+
+	.filter-section {
+		padding: 18px 18px 16px;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.section-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		margin-bottom: 10px;
+	}
+
+	.section-head h4 {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 18px;
+		font-weight: 400;
+		letter-spacing: -0.015em;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 36';
+	}
+
+	.hint {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
+		color: var(--color-text-tertiary);
+	}
+
+	.mini-search {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 10px 12px;
+		background: #fff;
+		border: 1px solid var(--color-border);
+		color: var(--color-text-tertiary);
+		margin-bottom: 10px;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+	}
+
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+
+	.chip {
+		padding: 8px 12px;
+		background: transparent;
+		color: var(--color-text-secondary);
+		border: 1px solid var(--color-border);
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 14px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
+		display: inline-flex;
+		align-items: baseline;
+		gap: 6px;
+	}
+
+	.chip .sub {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-weight: 400;
+		font-size: 12px;
+		opacity: 0.5;
+	}
+
+	.chip.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-weight: 500;
+	}
+
+	.chip.active .sub { opacity: 0.65; }
+
+	.chip:disabled { opacity: 0.45; cursor: not-allowed; }
+
+	.bottom-spacer { height: 96px; }
+
+	.sheet-foot {
+		border-top: 1px solid var(--color-border);
+		background: var(--color-bg);
+		padding: 12px 18px 24px;
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.reset {
+		flex: 0 0 auto;
+		padding: 12px 14px;
+		background: transparent;
+		border: 1px solid var(--color-border);
+		color: var(--color-text);
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		cursor: pointer;
+	}
+
+	.show {
+		flex: 1;
+		padding: 14px 16px;
+		background: var(--color-text);
+		color: var(--color-bg);
+		border: 1px solid var(--color-border);
+		font-family: var(--font-serif);
+		font-size: 15px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		cursor: pointer;
+		font-variation-settings: '"SOFT" 100', '"opsz" 36';
+		display: inline-flex;
+		align-items: baseline;
+		justify-content: center;
+		gap: 8px;
+	}
+
+	.show .show-count {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-weight: 400;
+	}
+</style>

--- a/frontend/src/lib/components/layout/Header.svelte
+++ b/frontend/src/lib/components/layout/Header.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import BreathingGrid from '$lib/components/pretext/BreathingGrid.svelte';
-	import FilterBar from '$lib/components/filters/FilterBar.svelte';
 	import DimmerDial from '$lib/components/ui/DimmerDial.svelte';
 	import { page } from '$app/state';
 
+	// `cinemas` and `showFilters` were previously used to feed the in-header
+	// FilterBar. They're kept on the prop type for backwards compatibility with
+	// call sites, but the header no longer renders filters itself — the
+	// homepage owns them via its sidebar / bottom sheet.
 	interface HeaderCinema {
 		id: string;
 		name: string;
@@ -11,9 +14,8 @@
 		address: { area: string } | null;
 	}
 
-	let { cinemas = [], showFilters = true }: { cinemas?: HeaderCinema[]; showFilters?: boolean } = $props();
-
-	const isHome = $derived(page.url.pathname === '/');
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	let { cinemas: _cinemas = [], showFilters: _showFilters = true }: { cinemas?: HeaderCinema[]; showFilters?: boolean } = $props();
 
 	let mobileMenuOpen = $state(false);
 	let headerEl = $state<HTMLElement>();
@@ -25,11 +27,8 @@
 	});
 
 	// Measure header height and expose as CSS custom property for dropdown positioning.
-	// Re-runs when the filter bar appears/disappears (isHome, showFilters) or menu toggles.
 	$effect(() => {
 		// Track dependencies that change header height
-		void isHome;
-		void showFilters;
 		void mobileMenuOpen;
 		if (headerEl) {
 			// Read after a tick so the DOM has updated
@@ -56,14 +55,15 @@
 
 			<div class="brand-right">
 				<nav class="nav-links" aria-label="Main">
-					<a href="/about" class="nav-link" aria-current={page.url.pathname === '/about' ? 'page' : undefined}>ABOUT</a>
-					<a href="/map" class="nav-link" aria-current={page.url.pathname === '/map' ? 'page' : undefined}>MAP</a>
-					<a href="/reachable" class="nav-link" aria-current={page.url.pathname.startsWith('/reachable') ? 'page' : undefined}>REACHABLE</a>
+					<a href="/watchlist" class="nav-link watchlist-link" aria-current={page.url.pathname === '/watchlist' ? 'page' : undefined}>Watchlist</a>
+					<a href="/about" class="nav-link" aria-current={page.url.pathname === '/about' ? 'page' : undefined}>About</a>
+					<a href="/map" class="nav-link" aria-current={page.url.pathname === '/map' ? 'page' : undefined}>Map</a>
+					<a href="/reachable" class="nav-link" aria-current={page.url.pathname.startsWith('/reachable') ? 'page' : undefined}>Reachable</a>
 				</nav>
 
 				<div class="nav-divider"></div>
 
-					<a href="/sign-in" class="nav-link sign-in-link">SIGN IN</a>
+					<a href="/sign-in" class="nav-link sign-in-link">Sign in</a>
 
 				<DimmerDial />
 
@@ -86,12 +86,10 @@
 			</div>
 		</div>
 
-		<!-- ROW B: Filter bar (homepage only) -->
-		{#if showFilters && isHome}
-			<div class="filter-bar-row">
-				<FilterBar {cinemas} />
-			</div>
-		{/if}
+		<!-- Filter bar is owned by the homepage (sidebar on desktop, bottom sheet
+			on mobile) and not rendered in the header anymore. Other routes render
+			their own filters when needed. -->
+
 
 		<!-- Mobile nav menu -->
 		{#if mobileMenuOpen}
@@ -178,17 +176,27 @@
 	}
 
 	.nav-link {
-		padding: 0.25rem 0.75rem;
-		font-size: 11px;
-		font-weight: 500;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--color-text-tertiary);
+		padding: 0.25rem 0.625rem;
+		font-family: var(--font-serif);
+		font-size: 13px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		color: var(--color-text-secondary);
 		transition: color var(--duration-fast) var(--ease-sharp);
 		white-space: nowrap;
 	}
 
 	.nav-link:hover {
+		color: var(--color-text);
+	}
+
+	.nav-link.watchlist-link {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
+	}
+
+	.nav-link.sign-in-link {
 		color: var(--color-text);
 	}
 
@@ -198,7 +206,8 @@
 
 	@media (min-width: 768px) {
 		.sign-in-link {
-			display: inline;
+			display: inline-flex;
+			align-items: center;
 		}
 	}
 
@@ -273,10 +282,6 @@
 	.mobile-nav-link[aria-current='page'] {
 		color: var(--color-text);
 		font-weight: 600;
-	}
-
-	.filter-bar-row {
-		border-top: 1px solid var(--color-border-subtle);
 	}
 
 	.header-border {

--- a/frontend/src/lib/components/ui/DimmerDial.svelte
+++ b/frontend/src/lib/components/ui/DimmerDial.svelte
@@ -109,7 +109,7 @@
 
 <!-- Inline horizontal fader — lives in the header -->
 <div class="house-lights" class:dragging={isDragging}>
-	<span class="hl-label">HOUSE LIGHTS</span>
+	<span class="hl-label">House lights</span>
 
 	<div
 		bind:this={trackEl}
@@ -169,13 +169,12 @@
 	}
 
 	.hl-label {
-		font-size: 9px;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		color: var(--color-text-tertiary);
+		font-family: var(--font-serif);
+		font-size: 13px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		color: var(--color-text-secondary);
 		white-space: nowrap;
-		font-family: var(--font-mono);
 	}
 
 	.hl-track {

--- a/frontend/src/lib/stores/user-location.svelte.ts
+++ b/frontend/src/lib/stores/user-location.svelte.ts
@@ -1,0 +1,52 @@
+import { browser } from '$app/environment';
+
+// Simple geolocation state. We never persist the user's location — it's held in
+// memory for the duration of the session and discarded on reload.
+// Users can only enable "Within N miles" if the browser grants permission.
+
+export type LocStatus = 'idle' | 'requesting' | 'granted' | 'denied' | 'unsupported';
+
+let _status = $state<LocStatus>('idle');
+let _coords = $state<{ lat: number; lng: number } | null>(null);
+let _error = $state<string | null>(null);
+
+async function request(): Promise<void> {
+	if (!browser) return;
+	if (!('geolocation' in navigator)) {
+		_status = 'unsupported';
+		_error = 'Geolocation not supported';
+		return;
+	}
+	_status = 'requesting';
+	_error = null;
+	try {
+		const position = await new Promise<GeolocationPosition>((resolve, reject) =>
+			navigator.geolocation.getCurrentPosition(resolve, reject, {
+				enableHighAccuracy: false,
+				timeout: 8000,
+				maximumAge: 5 * 60 * 1000
+			})
+		);
+		_status = 'granted';
+		_coords = { lat: position.coords.latitude, lng: position.coords.longitude };
+		_error = null;
+	} catch (e) {
+		_status = 'denied';
+		_coords = null;
+		_error = e instanceof Error ? e.message : String(e);
+	}
+}
+
+function clear() {
+	_status = 'idle';
+	_coords = null;
+	_error = null;
+}
+
+export const userLocation = {
+	get status(): LocStatus { return _status; },
+	get coords() { return _coords; },
+	get error() { return _error; },
+	request,
+	clear
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -121,3 +121,21 @@ export function getPosterImageAttributes(
 		sizes: options.sizes
 	};
 }
+
+/**
+ * Haversine great-circle distance in miles between two lat/lng points.
+ * Used for the "within N miles" filter on the homepage sidebar.
+ */
+export function haversineMiles(
+	a: { lat: number; lng: number },
+	b: { lat: number; lng: number }
+): number {
+	const R = 3958.8; // Earth radius in miles
+	const toRad = (deg: number) => (deg * Math.PI) / 180;
+	const dLat = toRad(b.lat - a.lat);
+	const dLng = toRad(b.lng - a.lng);
+	const la1 = toRad(a.lat);
+	const la2 = toRad(b.lat);
+	const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLng / 2) ** 2;
+	return 2 * R * Math.asin(Math.sqrt(h));
+}

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -7,6 +7,7 @@ interface CinemasResponse {
 		name: string;
 		shortName: string | null;
 		address: { street?: string; area?: string; postcode?: string } | null;
+		coordinates: { lat: number; lng: number } | null;
 	}>;
 }
 
@@ -18,7 +19,8 @@ export const load: LayoutServerLoad = async ({ fetch }) => {
 			id: c.id,
 			name: c.name,
 			shortName: c.shortName,
-			address: c.address?.area ? { area: c.address.area } : null
+			address: c.address?.area ? { area: c.address.area } : null,
+			coordinates: c.coordinates
 		}))
 	};
 };

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,137 +1,120 @@
 <script lang="ts">
-	import FilmCard from '$lib/components/calendar/FilmCard.svelte';
-	import TableView from '$lib/components/calendar/TableView.svelte';
+	import DesktopHybridCard from '$lib/components/calendar/DesktopHybridCard.svelte';
+	import MobileFilmRow from '$lib/components/calendar/MobileFilmRow.svelte';
+	import DayMasthead from '$lib/components/calendar/DayMasthead.svelte';
+	import DesktopFilterSidebar from '$lib/components/filters/DesktopFilterSidebar.svelte';
+	import MobileFilterSheet from '$lib/components/filters/MobileFilterSheet.svelte';
+	import FilmTypeFilter from '$lib/components/filters/FilmTypeFilter.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import JsonLd from '$lib/seo/JsonLd.svelte';
 	import { webSiteSchema, faqSchema } from '$lib/seo/json-ld';
 	import { filters } from '$lib/stores/filters.svelte';
-	import { preferences } from '$lib/stores/preferences.svelte';
-	import { formatScreeningDate, toLondonDateStr, groupBy } from '$lib/utils';
+	import { toLondonDateStr, groupBy } from '$lib/utils';
 	import { trackFilterNoResults } from '$lib/analytics/posthog';
 	import { browser } from '$app/environment';
+	import { page } from '$app/state';
 
 	let { data } = $props();
 
-	// Group screenings by film, then by date
+	// Sidebar collapsed state — persist across sessions.
+	const SIDEBAR_STORAGE_KEY = 'pictures-sidebar-collapsed';
+	function loadCollapsed(): boolean {
+		if (!browser) return false;
+		try { return localStorage.getItem(SIDEBAR_STORAGE_KEY) === 'true'; } catch { return false; }
+	}
+	let sidebarCollapsed = $state(loadCollapsed());
+	$effect(() => {
+		if (!browser) return;
+		try { localStorage.setItem(SIDEBAR_STORAGE_KEY, String(sidebarCollapsed)); } catch { /* ignore */ }
+	});
+
+	const cinemas = $derived((page.data?.cinemas ?? []) as Array<{
+		id: string;
+		name: string;
+		shortName: string | null;
+		address: { area: string } | null;
+	}>);
+
+	let mobileFilterOpen = $state(false);
+
+	// Group screenings by film + apply filters.
 	const filmMap = $derived.by(() => {
 		const map = new Map<string, {
 			film: (typeof data.screenings)[0]['film'];
 			screenings: (typeof data.screenings)[0][];
 		}>();
-
-		// Drop screenings that have already started. ISR caches this page for 1h,
-		// so the server can't filter by "now" — it has to happen at render time.
 		const now = Date.now();
 
 		for (const s of data.screenings) {
 			if (!s.film) continue;
-
 			if (new Date(s.datetime).getTime() <= now) continue;
 
-			// Apply film search filter
 			if (filters.filmSearch && !s.film.title.toLowerCase().includes(filters.filmSearch.toLowerCase())) continue;
-
-			// Apply cinema filter
 			if (filters.cinemaIds.length > 0 && !filters.cinemaIds.includes(s.cinema?.id ?? '')) continue;
 
-			// Apply date filter
 			if (filters.dateFrom || filters.dateTo) {
-				const screeningDate = s.datetime.split('T')[0];
-				if (filters.dateFrom && screeningDate < filters.dateFrom) continue;
-				if (filters.dateTo && screeningDate > filters.dateTo) continue;
+				const dateStr = s.datetime.split('T')[0];
+				if (filters.dateFrom && dateStr < filters.dateFrom) continue;
+				if (filters.dateTo && dateStr > filters.dateTo) continue;
 			}
 
-			// Apply format filter — exclude screenings with no format when filtering
 			if (filters.formats.length > 0 && (!s.format || !filters.formats.includes(s.format))) continue;
 
-			// Apply time filter (use London timezone)
 			if (filters.timeFrom !== null && filters.timeTo !== null) {
 				const hour = parseInt(
-					new Date(s.datetime).toLocaleString('en-GB', {
-						hour: 'numeric', hour12: false, timeZone: 'Europe/London'
-					})
+					new Date(s.datetime).toLocaleString('en-GB', { hour: 'numeric', hour12: false, timeZone: 'Europe/London' })
 				);
 				if (hour < filters.timeFrom || hour > filters.timeTo) continue;
 			}
 
-			// Apply programming type filter (OR logic: show if film matches ANY selected type)
 			if (filters.programmingTypes.length > 0) {
 				const isRepertory = s.film.isRepertory;
-				const matchesAny = filters.programmingTypes.some((type) =>
-					type === 'repertory' ? isRepertory : !isRepertory
-				);
+				const matchesAny = filters.programmingTypes.some((type) => type === 'repertory' ? isRepertory : !isRepertory);
 				if (!matchesAny) continue;
 			}
 
 			const existing = map.get(s.film.id);
-			if (existing) {
-				existing.screenings.push(s);
-			} else {
-				map.set(s.film.id, { film: s.film, screenings: [s] });
-			}
+			if (existing) existing.screenings.push(s);
+			else map.set(s.film.id, { film: s.film, screenings: [s] });
 		}
-
 		return map;
 	});
 
-	// Group by date for day sections
 	const dayGroups = $derived.by(() => {
-		const allScreenings = [...filmMap.values()].flatMap((f) =>
-			f.screenings.map((s) => ({ ...s, film: f.film }))
-		);
-
-		const grouped = groupBy(allScreenings, (s) => toLondonDateStr(s.datetime));
-
+		const all = [...filmMap.values()].flatMap((f) => f.screenings.map((s) => ({ ...s, film: f.film })));
+		const grouped = groupBy(all, (s) => toLondonDateStr(s.datetime));
 		return Object.entries(grouped)
 			.sort(([a], [b]) => a.localeCompare(b))
 			.map(([date, screenings]) => {
-				// Group screenings by film within each day
 				const filmGroups = groupBy(screenings, (s) => s.film.id);
 				const films = Object.values(filmGroups).map((filmScreenings) => ({
 					film: filmScreenings[0].film,
-					screenings: filmScreenings.sort(
-						(a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime()
-					)
+					screenings: filmScreenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
 				}));
-
 				return { date, films };
 			});
 	});
 
-	// For table view: flatten to rows of film + screenings
-	const tableRows = $derived.by(() => {
+	// Flat list of unique films (ordered by next screening) for the desktop hybrid grid
+	const hybridFilms = $derived.by(() => {
 		return [...filmMap.values()].map(({ film, screenings }) => ({
-			film: {
-				id: film.id,
-				title: film.title,
-				year: film.year,
-				directors: film.director ? [film.director] : [],
-				runtime: film.runtime,
-				isRepertory: film.isRepertory ?? false,
-				genres: [],
-				posterUrl: film.posterUrl
-			},
-			screenings: screenings
-				.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
-				.map((s) => ({
-					id: s.id,
-					datetime: s.datetime,
-					format: s.format ?? null,
-					bookingUrl: s.bookingUrl,
-					cinema: s.cinema ?? { id: '', name: 'Unknown', shortName: null }
-				}))
+			film,
+			screenings: screenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
 		}));
 	});
 
-	// Track when filters produce no results
-	let lastTrackedEmpty = false;
+	const screeningCount = $derived.by(() => {
+		let n = 0;
+		for (const { screenings } of filmMap.values()) n += screenings.length;
+		return n;
+	});
 
+	let lastTrackedEmpty = false;
 	$effect(() => {
 		if (!browser) return;
 		const hasFilters = filters.cinemaIds.length > 0 || filters.dateFrom || filters.formats.length > 0 ||
 			filters.programmingTypes.length > 0 || filters.timeFrom !== null || filters.filmSearch;
 		const isEmpty = filmMap.size === 0;
-
 		if (isEmpty && hasFilters && !lastTrackedEmpty) {
 			trackFilterNoResults({
 				cinemaIds: filters.cinemaIds,
@@ -144,14 +127,12 @@
 			lastTrackedEmpty = false;
 		}
 	});
+
+	const activeFilterCount = $derived(filters.activeFilterCount);
 </script>
 
 <div class="sr-only" aria-live="polite" role="status">
-	{#if dayGroups.length === 0}
-		No screenings found
-	{:else}
-		{filmMap.size} films showing
-	{/if}
+	{#if dayGroups.length === 0}No screenings found{:else}{filmMap.size} films showing{/if}
 </div>
 
 <JsonLd data={webSiteSchema()} />
@@ -162,89 +143,380 @@
 	{ question: 'Can I import my Letterboxd watchlist?', answer: 'Yes! Visit the Letterboxd Import page, enter your username, and see which films on your watchlist are currently showing in London cinemas.' }
 ])} />
 
-<section class="py-6">
-	<div class="max-w-[1400px] mx-auto px-4 md:px-8">
-		{#if dayGroups.length === 0}
-			<EmptyState
-				title="No screenings found"
-				description="Try adjusting your filters or check back later."
-			/>
-		{:else if preferences.viewMode === 'text'}
-			<TableView rows={tableRows} />
-		{:else}
-			{#each dayGroups as { date, films } (date)}
-				<div class="day-section mb-8">
-					<div class="day-header flex items-baseline gap-3 mb-4 pb-1.5 border-b-2 border-[var(--color-border)]">
-						<h2 class="font-display text-sm font-bold tracking-wide-swiss uppercase">
-							{formatScreeningDate(date)}
-						</h2>
-						<span class="text-xs text-[var(--color-text-tertiary)] tracking-wide-swiss uppercase">
-							{new Date(date + 'T00:00:00').toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'Europe/London' }).toUpperCase()}
-						</span>
-					</div>
-
-					<div class="film-grid">
-						{#each films as { film, screenings } (film.id)}
-							<FilmCard
-								film={{
-									id: film.id,
-									title: film.title,
-									year: film.year,
-									director: film.director ?? null,
-									runtime: film.runtime,
-									genres: [],
-									posterUrl: film.posterUrl,
-									tmdbId: null
-								}}
-								screenings={screenings.map((s) => ({
-									id: s.id,
-									datetime: s.datetime,
-									cinemaName: s.cinema?.name ?? 'Unknown',
-									cinemaSlug: s.cinema?.id ?? '',
-									bookingUrl: s.bookingUrl
-								}))}
-								activeCinemaIds={filters.cinemaIds}
-							/>
-						{/each}
-					</div>
-				</div>
-			{/each}
-		{/if}
+<!-- ── DESKTOP LAYOUT (≥ 1024px) ── -->
+<div class="desktop-shell">
+	<div class="desktop-masthead-wrap">
+		<DayMasthead />
 	</div>
-</section>
+
+	<div class="desktop-grid" class:sidebar-collapsed={sidebarCollapsed}>
+		{#if !sidebarCollapsed}
+			<div class="sidebar-wrap">
+				<DesktopFilterSidebar
+					cinemas={cinemas}
+					filmCount={filmMap.size}
+					screeningCount={screeningCount}
+					onHide={() => (sidebarCollapsed = true)}
+				/>
+			</div>
+		{:else}
+			<button
+				type="button"
+				class="sidebar-rail"
+				onclick={() => (sidebarCollapsed = false)}
+				aria-label="Expand filters"
+				title="Expand filters"
+			>
+				<svg width="11" height="11" viewBox="0 0 14 14" aria-hidden="true">
+					<circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.2" fill="none"/>
+					<path d="M9.5 9.5L13 13" stroke="currentColor" stroke-width="1.2"/>
+				</svg>
+				<span class="rail-label">Filters</span>
+				{#if activeFilterCount > 0}
+					<span class="rail-count">·{activeFilterCount}</span>
+				{/if}
+				<span class="rail-chevron">›</span>
+			</button>
+		{/if}
+
+		<main class="desktop-main">
+			<div class="desktop-toolbar">
+				<FilmTypeFilter />
+				<span class="count-line">
+					<span class="count-num">{filmMap.size}</span> films ·
+					<span class="count-num">{screeningCount}</span> screenings
+				</span>
+			</div>
+
+			{#if filmMap.size === 0}
+				<EmptyState title="No screenings found" description="Try adjusting your filters or check back later." />
+			{:else}
+				<div class="desktop-film-grid">
+					{#each hybridFilms as { film, screenings } (film.id)}
+						<DesktopHybridCard
+							film={{
+								id: film.id,
+								title: film.title,
+								year: film.year,
+								director: film.director ?? null,
+								runtime: film.runtime,
+								posterUrl: film.posterUrl
+							}}
+							screenings={screenings.map((s) => ({
+								id: s.id,
+								datetime: s.datetime,
+								cinemaName: s.cinema?.name ?? 'Unknown',
+								cinemaSlug: s.cinema?.id ?? '',
+								format: s.format,
+								bookingUrl: s.bookingUrl
+							}))}
+						/>
+					{/each}
+				</div>
+			{/if}
+		</main>
+	</div>
+</div>
+
+<!-- ── MOBILE LAYOUT (< 1024px) ── -->
+<div class="mobile-shell">
+	<div class="mobile-header">
+		<div class="mobile-date-label">
+			{#if dayGroups.length > 0}
+				{@const d = new Date(dayGroups[0].date + 'T12:00:00Z')}
+				{@const weekday = new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' }).format(d)}
+				{@const dayNum = Number(new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' }).format(d))}
+				{@const ordinals = {1:'first',2:'second',3:'third',4:'fourth',5:'fifth',6:'sixth',7:'seventh',8:'eighth',9:'ninth',10:'tenth',11:'eleventh',12:'twelfth',13:'thirteenth',14:'fourteenth',15:'fifteenth',16:'sixteenth',17:'seventeenth',18:'eighteenth',19:'nineteenth',20:'twentieth',21:'twenty-first',22:'twenty-second',23:'twenty-third',24:'twenty-fourth',25:'twenty-fifth',26:'twenty-sixth',27:'twenty-seventh',28:'twenty-eighth',29:'twenty-ninth',30:'thirtieth',31:'thirty-first'} as Record<number, string>}
+				{weekday}<span class="italic-comma">,</span> the {ordinals[dayNum] ?? `${dayNum}th`}
+			{:else}
+				No films
+			{/if}
+		</div>
+
+		<div class="mobile-search-row">
+			<div class="mobile-search">
+				<svg width="11" height="11" viewBox="0 0 14 14" aria-hidden="true">
+					<circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.2" fill="none"/>
+					<path d="M9.5 9.5L13 13" stroke="currentColor" stroke-width="1.2"/>
+				</svg>
+				<input
+					type="search"
+					placeholder="Search films, cinemas, directors…"
+					bind:value={filters.filmSearch}
+					aria-label="Search films, cinemas, directors"
+				/>
+			</div>
+			<button class="mobile-filter-btn" onclick={() => (mobileFilterOpen = true)} aria-expanded={mobileFilterOpen}>
+				Filter
+				{#if activeFilterCount > 0}
+					<span class="count">·{activeFilterCount}</span>
+				{/if}
+			</button>
+		</div>
+
+		<div class="mobile-type-tabs">
+			<FilmTypeFilter />
+		</div>
+	</div>
+
+	{#if dayGroups.length === 0}
+		<EmptyState title="No screenings found" description="Try adjusting your filters or check back later." />
+	{:else}
+		<div class="mobile-list">
+			{#each dayGroups as { date, films } (date)}
+				<section class="mobile-day">
+					{#each films as { film, screenings } (film.id)}
+						<MobileFilmRow
+							film={{
+								id: film.id,
+								title: film.title,
+								year: film.year,
+								director: film.director ?? null,
+								runtime: film.runtime,
+								posterUrl: film.posterUrl
+							}}
+							screenings={screenings.map((s) => ({
+								id: s.id,
+								datetime: s.datetime,
+								cinemaName: s.cinema?.name ?? 'Unknown',
+								bookingUrl: s.bookingUrl
+							}))}
+						/>
+					{/each}
+				</section>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<MobileFilterSheet
+	cinemas={cinemas}
+	filmCount={filmMap.size}
+	open={mobileFilterOpen}
+	onClose={() => (mobileFilterOpen = false)}
+/>
 
 <style>
-	.film-grid {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		column-gap: 1rem;
-		row-gap: 0;
-		grid-auto-rows: auto;
-	}
-
-	@media (min-width: 768px) {
-		.film-grid {
-			grid-template-columns: repeat(3, 1fr);
-			column-gap: 1.25rem;
-		}
+	/* ---------- Desktop ---------- */
+	.desktop-shell {
+		display: none;
 	}
 
 	@media (min-width: 1024px) {
-		.film-grid {
-			grid-template-columns: repeat(4, 1fr);
-			column-gap: 1.25rem;
+		.desktop-shell {
+			display: block;
+			max-width: 1400px;
+			margin: 0 auto;
+			padding: 0 2rem 4rem;
 		}
 	}
 
-	@media (max-width: 320px) {
-		.film-grid {
-			grid-template-columns: 1fr;
+	.desktop-masthead-wrap {
+		padding: 1.5rem 0 0;
+	}
+
+	.desktop-grid {
+		display: grid;
+		grid-template-columns: 240px 1fr;
+		min-height: 600px;
+	}
+
+	.desktop-grid.sidebar-collapsed {
+		grid-template-columns: 44px 1fr;
+	}
+
+	.sidebar-wrap {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.sidebar-rail {
+		position: sticky;
+		top: var(--header-height, 56px);
+		align-self: start;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 10px;
+		padding: 18px 8px;
+		background: transparent;
+		border: none;
+		border-right: 1px solid var(--color-border);
+		color: var(--color-text-secondary);
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 13px;
+		letter-spacing: -0.005em;
+		writing-mode: vertical-rl;
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
+		min-height: 180px;
+	}
+
+	.sidebar-rail:hover {
+		background: var(--color-bg-subtle);
+		color: var(--color-text);
+	}
+
+	.sidebar-rail svg {
+		writing-mode: horizontal-tb;
+	}
+
+	.sidebar-rail .rail-count {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		color: var(--color-accent);
+	}
+
+	.sidebar-rail .rail-chevron {
+		color: var(--color-text-tertiary);
+		writing-mode: horizontal-tb;
+	}
+
+	.desktop-main {
+		padding: 18px 0 60px;
+		padding-left: 2.5rem;
+	}
+
+	.sidebar-collapsed .desktop-main {
+		padding-left: 1.5rem;
+	}
+
+	.desktop-toolbar {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		margin-bottom: 18px;
+	}
+
+	.count-line {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text-tertiary);
+	}
+	.count-line .count-num { color: var(--color-text-secondary); }
+
+	.desktop-film-grid {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 32px 22px;
+	}
+
+	@media (min-width: 1024px) and (max-width: 1279px) {
+		.desktop-film-grid {
+			grid-template-columns: repeat(3, 1fr);
+		}
+		.sidebar-collapsed .desktop-film-grid {
+			grid-template-columns: repeat(4, 1fr);
 		}
 	}
 
 	@media (min-width: 1280px) {
-		.film-grid {
-			grid-template-columns: repeat(6, 1fr);
+		.sidebar-collapsed .desktop-film-grid {
+			grid-template-columns: repeat(5, 1fr);
 		}
+	}
+
+	/* ---------- Mobile ---------- */
+	.mobile-shell {
+		display: block;
+		padding: 0.25rem 1.125rem 2rem;
+	}
+
+	@media (min-width: 1024px) {
+		.mobile-shell {
+			display: none;
+		}
+	}
+
+	.mobile-header {
+		padding: 12px 0 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.mobile-date-label {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 22px;
+		font-weight: 400;
+		line-height: 1;
+		color: var(--color-text);
+		letter-spacing: -0.01em;
+		padding: 4px 0 14px;
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.mobile-date-label .italic-comma { font-style: italic; color: var(--color-text-tertiary); }
+
+	.mobile-search-row {
+		display: flex;
+		gap: 8px;
+		padding: 10px 0;
+	}
+
+	.mobile-search {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 9px 12px;
+		background: transparent;
+		border: 1px solid var(--color-border);
+		color: var(--color-text-tertiary);
+		min-width: 0;
+	}
+
+	.mobile-search input {
+		flex: 1;
+		background: transparent;
+		border: none;
+		outline: none;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text);
+		min-width: 0;
+	}
+
+	.mobile-search input::placeholder {
+		color: var(--color-text-tertiary);
+	}
+
+	.mobile-filter-btn {
+		padding: 0 16px;
+		border: 1px solid var(--color-border);
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-family: var(--font-serif);
+		font-size: 13px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		cursor: pointer;
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.mobile-filter-btn .count {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-weight: 400;
+		opacity: 0.7;
+	}
+
+	.mobile-type-tabs {
+		padding: 0 0 12px;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.mobile-list {
+		padding-top: 0;
+	}
+
+	.mobile-day {
+		display: flex;
+		flex-direction: column;
 	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -49,7 +49,14 @@
 			if (!s.film) continue;
 			if (new Date(s.datetime).getTime() <= now) continue;
 
-			if (filters.filmSearch && !s.film.title.toLowerCase().includes(filters.filmSearch.toLowerCase())) continue;
+			if (filters.filmSearch) {
+				const q = filters.filmSearch.toLowerCase();
+				const matches =
+					s.film.title.toLowerCase().includes(q) ||
+					(s.cinema?.name?.toLowerCase().includes(q) ?? false) ||
+					(s.film.director?.toLowerCase().includes(q) ?? false);
+				if (!matches) continue;
+			}
 			if (filters.cinemaIds.length > 0 && !filters.cinemaIds.includes(s.cinema?.id ?? '')) continue;
 
 			if (filters.dateFrom || filters.dateTo) {
@@ -474,7 +481,8 @@
 		outline: none;
 		font-family: var(--font-serif-italic);
 		font-style: italic;
-		font-size: 14px;
+		/* 16px minimum to prevent iOS Safari auto-zoom on focus. */
+		font-size: 16px;
 		color: var(--color-text);
 		min-width: 0;
 	}

--- a/frontend/src/routes/cinemas/[slug]/+page.ts
+++ b/frontend/src/routes/cinemas/[slug]/+page.ts
@@ -1,0 +1,44 @@
+import { apiGet } from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { Cinema } from '$lib/types';
+
+interface CinemaScreening {
+	id: string;
+	datetime: string;
+	format: string | null;
+	bookingUrl: string;
+	screen: string | null;
+	film: {
+		id: string;
+		title: string;
+		year: number | null;
+		directors: string[];
+		runtime: number | null;
+		posterUrl: string | null;
+	};
+}
+
+interface CinemaDetailResponse {
+	cinema: Cinema;
+	screenings: CinemaScreening[];
+}
+
+export async function load({ params, fetch }) {
+	try {
+		const [cinemaRes, screeningsRes] = await Promise.all([
+			apiGet<{ cinemas: Cinema[] }>(`/api/cinemas?id=${params.slug}`, { fetch }),
+			apiGet<{ screenings: CinemaScreening[] }>(`/api/screenings?cinemas=${params.slug}&limit=200`, { fetch })
+		]);
+
+		const cinema = cinemaRes.cinemas?.[0];
+		if (!cinema) throw new Error('Not found');
+
+		return {
+			cinema,
+			screenings: screeningsRes.screenings ?? []
+		};
+	} catch (e) {
+		console.error('[cinema-detail] Failed to load cinema:', e instanceof Error ? e.message : e);
+		throw error(404, 'Cinema not found');
+	}
+}

--- a/frontend/src/routes/festivals/[slug]/+page.ts
+++ b/frontend/src/routes/festivals/[slug]/+page.ts
@@ -1,0 +1,23 @@
+import { apiGet } from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { ScreeningWithDetails } from '$lib/types';
+
+export interface FestivalDetail {
+	id: string;
+	slug: string;
+	name: string;
+	startDate: string | null;
+	endDate: string | null;
+	venue: string | null;
+	description: string | null;
+}
+
+export async function load({ params, fetch }) {
+	try {
+		const res = await apiGet<{ festival: FestivalDetail; screenings: ScreeningWithDetails[] }>(`/api/festivals/${params.slug}`, { fetch });
+		return res;
+	} catch (e) {
+		console.error('[festival-detail] Failed to load festival:', e instanceof Error ? e.message : e);
+		throw error(404, 'Festival not found');
+	}
+}

--- a/frontend/src/routes/film/[id]/+page.svelte
+++ b/frontend/src/routes/film/[id]/+page.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import Badge from '$lib/components/ui/Badge.svelte';
 	import LetterboxdRatingReveal from '$lib/components/film/LetterboxdRatingReveal.svelte';
+	import CalendarPopover from '$lib/components/filters/CalendarPopover.svelte';
 	import JsonLd from '$lib/seo/JsonLd.svelte';
 	import { movieSchema, breadcrumbSchema } from '$lib/seo/json-ld';
 	import { filmStatuses } from '$lib/stores/film-status.svelte';
 	import { formatTime, formatScreeningDate, toLondonDateStr, groupBy, getPosterImageAttributes } from '$lib/utils';
 	import { trackFilmView, trackBookingClick, trackFilmStatusChange, trackCalendarExport } from '$lib/analytics/posthog';
-	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';
 	import type { FilmStatus } from '$lib/types';
 
@@ -42,18 +41,86 @@
 			.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
 	);
 
+	const nextScreening = $derived(futureScreenings[0]);
+
+	const nextScreeningLabel = $derived.by(() => {
+		if (!nextScreening) return null;
+		const today = toLondonDateStr(new Date());
+		const nextDate = toLondonDateStr(nextScreening.datetime);
+		if (nextDate === today) return 'today';
+		const tomorrowD = new Date(today + 'T12:00:00Z');
+		tomorrowD.setUTCDate(tomorrowD.getUTCDate() + 1);
+		if (nextDate === tomorrowD.toISOString().split('T')[0]) return 'tomorrow';
+		return new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' })
+			.format(new Date(nextScreening.datetime))
+			.toLowerCase();
+	});
+
+	// Day groups for the day strip
 	const groupedByDate = $derived.by(() => {
 		const grouped = groupBy(futureScreenings, (s) => toLondonDateStr(s.datetime));
 		return Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b));
 	});
 
+	let selectedDay = $state<string | null>(null);
+	let datePickerOpen = $state(false);
+
+	const activeDay = $derived(selectedDay ?? (groupedByDate[0]?.[0] ?? null));
+
+	// If the user picked a date outside the strip, look it up in the grouped
+	// screenings; if there are none, render an empty state with the date label.
+	const activeDayScreenings = $derived(
+		activeDay ? (groupedByDate.find(([d]) => d === activeDay)?.[1] ?? []) : futureScreenings
+	);
+
+	function pickDate(iso: string) {
+		selectedDay = iso;
+		datePickerOpen = false;
+	}
+
+	// Group the active day's screenings by cinema
+	const screeningsByCinema = $derived.by(() => {
+		const byCinema = groupBy(activeDayScreenings, (s) => s.cinema?.name ?? 'Unknown');
+		return Object.entries(byCinema);
+	});
+
 	const posterImage = $derived(
 		getPosterImageAttributes(film.posterUrl, {
-			baseSize: 'w342',
+			baseSize: 'w500',
 			srcSetSizes: ['w342', 'w500', 'w780'],
-			sizes: '(min-width: 768px) 280px, 50vw'
+			sizes: '(min-width: 1024px) 320px, (min-width: 768px) 280px, 100vw'
 		})
 	);
+
+	const bylineText = $derived.by(() => {
+		const parts: string[] = [];
+		if (film.directors?.length) parts.push(film.directors.join(', '));
+		if (film.year) parts.push(String(film.year));
+		return parts.join(', ');
+	});
+
+	const metaParts = $derived.by(() => {
+		const parts: string[] = [];
+		if (film.runtime) parts.push(`${film.runtime} min`);
+		if (film.countries?.length) parts.push(film.countries[0]);
+		if (film.certification) parts.push(film.certification);
+		if (film.genres?.length) parts.push(film.genres.slice(0, 2).map((g) => g.charAt(0).toUpperCase() + g.slice(1)).join(' / '));
+		return parts;
+	});
+
+	const titleFirst = $derived(film.title.charAt(0));
+	const titleRest = $derived(film.title.slice(1));
+
+	const todayStr = toLondonDateStr(new Date());
+	function dayLabel(date: string) {
+		if (date === todayStr) return 'Today';
+		return new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' }).format(new Date(date + 'T12:00:00Z'));
+	}
+
+	function normalisedFormat(fmt: string | null | undefined): string {
+		if (!fmt || fmt === 'unknown' || fmt === 'dcp') return 'DCP';
+		return fmt.toUpperCase().replace('_', ' ');
+	}
 </script>
 
 <svelte:head>
@@ -62,187 +129,226 @@
 	<meta property="og:title" content="{film.title} — pictures · london" />
 	<meta property="og:description" content="{film.title} ({film.year}){film.directors?.length ? ` directed by ${film.directors[0]}` : ''} — {futureScreenings.length} screenings in London" />
 	<meta property="og:type" content="video.movie" />
-	{#if film.posterUrl}
-		<meta property="og:image" content={film.posterUrl} />
-	{/if}
+	{#if film.posterUrl}<meta property="og:image" content={film.posterUrl} />{/if}
 	<meta name="twitter:card" content="summary_large_image" />
 </svelte:head>
 
 <JsonLd data={movieSchema(film)} />
-<JsonLd data={breadcrumbSchema([
-	{ name: 'Home', url: '/' },
-	{ name: film.title, url: `/film/${film.id}` }
-])} />
+<JsonLd data={breadcrumbSchema([{ name: 'Home', url: '/' }, { name: film.title, url: `/film/${film.id}` }])} />
 
-<div class="max-w-[1400px] mx-auto px-4 md:px-8 py-8">
-	<!-- Hero -->
-	<div class="film-hero">
+<!-- Breadcrumb -->
+<div class="breadcrumb">
+	<a href="/">Programme</a>
+	<span class="sep">›</span>
+	<span class="current">{film.title}</span>
+</div>
+
+<!-- Hero -->
+<section class="hero">
+	<div class="poster-col">
 		{#if film.posterUrl}
-			<div class="poster-col">
+			<div class="poster-frame">
 				<img
 					src={posterImage?.src ?? film.posterUrl}
 					srcset={posterImage?.srcset}
 					sizes={posterImage?.sizes}
 					alt="{film.title} poster"
-					class="w-full border border-[var(--color-border-subtle)]"
-					width="280"
-					height="420"
+					width="320"
+					height="480"
 					fetchpriority="high"
 					decoding="async"
 				/>
 			</div>
 		{/if}
-
-		<div class="info-col">
-			<h1 class="film-title font-display">{film.title}</h1>
-
-			{#if film.originalTitle && film.originalTitle !== film.title}
-				<p class="original-title">{film.originalTitle}</p>
-			{/if}
-
-			{#if film.tagline}
-				<p class="tagline">{film.tagline}</p>
-			{/if}
-
-			<div class="meta-row">
-				{#if film.year}<span>{film.year}</span>{/if}
-				{#if film.runtime}<span>{film.runtime}m</span>{/if}
-				{#if film.certification}<span>{film.certification}</span>{/if}
-				{#if film.countries?.length}<span>{film.countries[0]}</span>{/if}
-			</div>
-
-			{#if film.directors?.length}
-				<p class="directors">
-					<span class="label">Director{film.directors.length > 1 ? 's' : ''}</span>
-					{film.directors.join(', ')}
-				</p>
-			{/if}
-
-			{#if film.cast?.length}
-				<p class="cast">
-					<span class="label">Cast</span>
-					{film.cast.slice(0, 5).map((c) => c.name).join(', ')}
-				</p>
-			{/if}
-
-			{#if film.genres?.length}
-				<div class="genres">
-					{#each film.genres as genre}
-						<Badge variant="muted">{genre}</Badge>
-					{/each}
-				</div>
-			{/if}
-
-			{#if film.synopsis}
-				<p class="synopsis">{film.synopsis}</p>
-			{/if}
-
-			<!-- Status toggle -->
-			<div class="status-row" role="group" aria-label="Film status">
-				<button
-					class="status-btn"
-					class:active={currentStatus === 'want_to_see'}
-					aria-pressed={currentStatus === 'want_to_see'}
-					onclick={() => toggleStatus('want_to_see')}
-				>
-					WANT TO SEE
-				</button>
-				<button
-					class="status-btn"
-					class:active={currentStatus === 'not_interested'}
-					aria-pressed={currentStatus === 'not_interested'}
-					onclick={() => toggleStatus('not_interested')}
-				>
-					NOT INTERESTED
-				</button>
-			</div>
-
-			<!-- Letterboxd rating (hidden by default) -->
-			{#if film.letterboxdRating && film.letterboxdRating > 0}
-				<div class="letterboxd-rating">
-					<LetterboxdRatingReveal rating={film.letterboxdRating} filmId={film.id} />
-				</div>
-			{/if}
-
-			<!-- External links -->
-			<div class="external-links">
-				{#if film.letterboxdUrl}
-					<a href={film.letterboxdUrl} target="_blank" rel="noopener noreferrer" class="ext-link">Letterboxd<span class="sr-only"> (opens in new tab)</span></a>
-				{/if}
-				{#if film.imdbId}
-					<a href="https://www.imdb.com/title/{film.imdbId}" target="_blank" rel="noopener noreferrer" class="ext-link">IMDb<span class="sr-only"> (opens in new tab)</span></a>
-				{/if}
-				{#if film.tmdbId}
-					<a href="https://www.themoviedb.org/movie/{film.tmdbId}" target="_blank" rel="noopener noreferrer" class="ext-link">TMDB<span class="sr-only"> (opens in new tab)</span></a>
-				{/if}
-			</div>
-		</div>
 	</div>
 
-	<!-- Screenings -->
-	{#if futureScreenings.length > 0}
-		<section class="screenings-section" aria-labelledby="screenings-heading">
-			<h2 id="screenings-heading" class="section-heading font-display">
-				UPCOMING SCREENINGS
-				<span class="screening-count">{futureScreenings.length}</span>
+	<div class="info-col">
+		<div class="eyebrow">
+			{#if film.isRepertory}Repertory{:else}Now showing{/if}
+			{#if nextScreening} · next screening {nextScreeningLabel}{/if}
+		</div>
+
+		<h1 class="film-title">
+			<span class="italic-cap">{titleFirst}</span><span>{titleRest}</span>
+		</h1>
+
+		{#if film.originalTitle && film.originalTitle !== film.title}
+			<p class="original-title">{film.originalTitle}</p>
+		{/if}
+
+		{#if bylineText}
+			<p class="byline">a film by {bylineText}</p>
+		{/if}
+
+		{#if metaParts.length}
+			<p class="meta">{metaParts.join(' · ')}</p>
+		{/if}
+
+		{#if film.synopsis}
+			<p class="synopsis">{film.synopsis}</p>
+		{/if}
+
+		<div class="cta-row">
+			{#if nextScreening}
+				<a
+					class="cta primary"
+					href={nextScreening.bookingUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					onclick={() => trackBookingClick({
+						filmId: film.id,
+						filmTitle: film.title,
+						screeningId: nextScreening.id,
+						screeningTime: nextScreening.datetime,
+						cinemaId: nextScreening.cinema?.id,
+						cinemaName: nextScreening.cinema?.name,
+						format: nextScreening.format,
+						bookingUrl: nextScreening.bookingUrl
+					}, 'film_detail')}
+				>
+					Book next showing <span class="cta-detail">{formatTime(nextScreening.datetime)}, {nextScreening.cinema?.shortName ?? nextScreening.cinema?.name}</span>
+				</a>
+			{/if}
+			<button
+				type="button"
+				class="cta secondary"
+				class:active={currentStatus === 'want_to_see'}
+				onclick={() => toggleStatus('want_to_see')}
+				aria-pressed={currentStatus === 'want_to_see'}
+			>
+				♡ Save
+			</button>
+			{#if film.trailerUrl}
+				<a class="cta secondary" href={film.trailerUrl} target="_blank" rel="noopener noreferrer">Trailer</a>
+			{/if}
+		</div>
+
+		{#if film.letterboxdRating && film.letterboxdRating > 0}
+			<div class="letterboxd-rating">
+				<LetterboxdRatingReveal rating={film.letterboxdRating} filmId={film.id} />
+			</div>
+		{/if}
+	</div>
+</section>
+
+<!-- Showings + Sidebar grid -->
+<div class="body-grid">
+	<section class="showings" aria-labelledby="showings-heading">
+		<div class="showings-head">
+			<h2 id="showings-heading" class="showings-title">
+				<span class="italic-cap">S</span>howings
 			</h2>
 
-			{#each groupedByDate as [date, dayScreenings] (date)}
-				<div class="day-group">
-					<h3 class="day-label">{formatScreeningDate(date)}</h3>
-					<div class="screening-rows">
-						{#each dayScreenings as screening (screening.id)}
-							<div class="screening-row-wrapper">
+			<div class="day-strip">
+				{#if groupedByDate.length > 1}
+					{#each groupedByDate.slice(0, 7) as [date] (date)}
+						<button
+							type="button"
+							class="strip-btn"
+							class:active={activeDay === date}
+							onclick={() => (selectedDay = date)}
+						>
+							{dayLabel(date)}
+						</button>
+					{/each}
+				{/if}
+
+				<div class="picker-wrap">
+					<button
+						type="button"
+						class="pick-date-btn"
+						onclick={() => (datePickerOpen = !datePickerOpen)}
+						aria-expanded={datePickerOpen}
+						aria-haspopup="dialog"
+					>
+						<svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">
+							<rect x="1.5" y="3" width="13" height="11" stroke="currentColor" stroke-width="1.1" fill="none"/>
+							<line x1="1.5" y1="6.5" x2="14.5" y2="6.5" stroke="currentColor" stroke-width="1.1"/>
+							<line x1="5" y1="1.5" x2="5" y2="4.5" stroke="currentColor" stroke-width="1.1"/>
+							<line x1="11" y1="1.5" x2="11" y2="4.5" stroke="currentColor" stroke-width="1.1"/>
+						</svg>
+						Pick date
+						<span class="chevron">▾</span>
+					</button>
+					{#if datePickerOpen}
+						<div class="popover" role="dialog" aria-label="Pick a date">
+							<CalendarPopover
+								selected={activeDay ?? todayStr}
+								today={todayStr}
+								onSelect={(iso) => pickDate(iso)}
+								onClose={() => (datePickerOpen = false)}
+							/>
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+
+		{#if activeDayScreenings.length === 0}
+			<p class="empty">
+				{#if selectedDay}
+					No screenings on {new Intl.DateTimeFormat('en-GB', { weekday: 'long', day: 'numeric', month: 'long', timeZone: 'Europe/London' }).format(new Date(selectedDay + 'T12:00:00Z'))}.
+					<button type="button" class="empty-clear" onclick={() => (selectedDay = null)}>Show all upcoming</button>
+				{:else}
+					No upcoming screenings.
+				{/if}
+			</p>
+		{:else}
+			{#each screeningsByCinema as [cinemaName, slots] (cinemaName)}
+				<div class="cinema-block">
+					<header class="cinema-head">
+						<div class="cinema-name-wrap">
+							<span class="cinema-name">{cinemaName}</span>
+							{#if slots[0]?.cinema?.shortName && slots[0].cinema.shortName !== cinemaName}
+								<span class="cinema-sub">{slots[0].cinema.shortName}</span>
+							{/if}
+						</div>
+					</header>
+					<div class="slots">
+						{#each slots as s (s.id)}
+							<div class="slot-wrap">
 								<a
-									href={screening.bookingUrl}
+									class="slot"
+									href={s.bookingUrl}
 									target="_blank"
 									rel="noopener noreferrer"
-									class="screening-row"
-									aria-label="Book {formatTime(screening.datetime)} at {screening.cinema?.name ?? 'cinema'}"
+									aria-label="Book {formatTime(s.datetime)} at {cinemaName}"
 									onclick={() => trackBookingClick({
 										filmId: film.id,
 										filmTitle: film.title,
-										screeningId: screening.id,
-										screeningTime: screening.datetime,
-										cinemaId: screening.cinema?.id,
-										cinemaName: screening.cinema?.name,
-										format: screening.format,
-										bookingUrl: screening.bookingUrl
+										screeningId: s.id,
+										screeningTime: s.datetime,
+										cinemaId: s.cinema?.id,
+										cinemaName: s.cinema?.name,
+										format: s.format,
+										bookingUrl: s.bookingUrl
 									}, 'film_detail')}
 								>
-									<time class="screening-time" datetime={screening.datetime}>{formatTime(screening.datetime)}</time>
-									<span class="screening-cinema">{screening.cinema?.name ?? 'Unknown'}</span>
-									{#if screening.format && screening.format !== 'unknown' && screening.format !== 'dcp'}
-										<Badge variant="muted">{screening.format.toUpperCase()}</Badge>
+									<time class="slot-time" datetime={s.datetime}>{formatTime(s.datetime)}</time>
+									{#if s.format && s.format !== 'unknown'}
+										<span class="slot-format">{normalisedFormat(s.format)}</span>
 									{/if}
-									{#if screening.screen}
-										<span class="screening-screen">{screening.screen}</span>
-									{/if}
-									<svg aria-hidden="true" class="booking-arrow" width="12" height="12" viewBox="0 0 12 12" fill="none">
-										<path d="M2 10L10 2M10 2H4M10 2V8" stroke="currentColor" stroke-width="1.2" stroke-linecap="square"/>
-									</svg>
 								</a>
 								<a
-									href="/api/calendar?screening={screening.id}"
+									href="/api/calendar?screening={s.id}"
 									download
 									class="ical-btn"
-									title="Add to calendar"
-									aria-label="Add {formatTime(screening.datetime)} at {screening.cinema?.name ?? 'cinema'} to calendar"
+									aria-label="Add to calendar"
 									onclick={(e) => {
 										e.stopPropagation();
 										trackCalendarExport({
 											filmId: film.id,
 											filmTitle: film.title,
-											screeningId: screening.id,
-											cinemaName: screening.cinema?.name
+											screeningId: s.id,
+											cinemaName: s.cinema?.name
 										});
 									}}
 								>
-									<svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-										<rect x="1" y="2.5" width="12" height="10" rx="0" stroke="currentColor" stroke-width="1.2"/>
-										<line x1="1" y1="5.5" x2="13" y2="5.5" stroke="currentColor" stroke-width="1.2"/>
-										<line x1="4" y1="1" x2="4" y2="4" stroke="currentColor" stroke-width="1.2"/>
-										<line x1="10" y1="1" x2="10" y2="4" stroke="currentColor" stroke-width="1.2"/>
+									<svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">
+										<rect x="1.5" y="3" width="13" height="11" stroke="currentColor" stroke-width="1.1" fill="none"/>
+										<line x1="1.5" y1="6.5" x2="14.5" y2="6.5" stroke="currentColor" stroke-width="1.1"/>
+										<line x1="5" y1="1.5" x2="5" y2="4.5" stroke="currentColor" stroke-width="1.1"/>
+										<line x1="11" y1="1.5" x2="11" y2="4.5" stroke="currentColor" stroke-width="1.1"/>
 									</svg>
 								</a>
 							</div>
@@ -250,253 +356,623 @@
 					</div>
 				</div>
 			{/each}
+		{/if}
+
+		<!-- External links -->
+		<div class="external-links">
+			{#if film.letterboxdUrl}<a href={film.letterboxdUrl} target="_blank" rel="noopener noreferrer" class="ext">Letterboxd</a>{/if}
+			{#if film.imdbId}<a href="https://www.imdb.com/title/{film.imdbId}" target="_blank" rel="noopener noreferrer" class="ext">IMDb</a>{/if}
+			{#if film.tmdbId}<a href="https://www.themoviedb.org/movie/{film.tmdbId}" target="_blank" rel="noopener noreferrer" class="ext">TMDB</a>{/if}
+		</div>
+	</section>
+
+	<aside class="sidebar">
+		<section class="credits-section">
+			<h3 class="credits-title">Credits</h3>
+
+			{#if film.directors?.length}
+				<div class="credit-row">
+					<span class="credit-key">Director{film.directors.length > 1 ? 's' : ''}</span>
+					<span class="credit-val">{film.directors.join(', ')}</span>
+				</div>
+			{/if}
+
+			{#if film.cast?.length}
+				<div class="credit-row">
+					<span class="credit-key">Cast</span>
+					<span class="credit-val">{film.cast.slice(0, 5).map((c) => c.name).join(', ')}</span>
+				</div>
+			{/if}
+
+			{#if film.countries?.length}
+				<div class="credit-row">
+					<span class="credit-key">Country</span>
+					<span class="credit-val">{film.countries.join(', ')}</span>
+				</div>
+			{/if}
+
+			{#if film.languages?.length}
+				<div class="credit-row">
+					<span class="credit-key">Language</span>
+					<span class="credit-val">{film.languages.join(', ')}</span>
+				</div>
+			{/if}
 		</section>
-	{/if}
+
+		{#if film.tagline}
+			<section class="tagline-section">
+				<p class="tagline">{film.tagline}</p>
+			</section>
+		{/if}
+
+		<section class="status-section">
+			<h3 class="credits-title"><span class="italic-cap">S</span>tatus</h3>
+			<div class="status-row">
+				<button
+					type="button"
+					class="status-btn"
+					class:active={currentStatus === 'want_to_see'}
+					onclick={() => toggleStatus('want_to_see')}
+					aria-pressed={currentStatus === 'want_to_see'}
+				>
+					Want to see
+				</button>
+				<button
+					type="button"
+					class="status-btn"
+					class:active={currentStatus === 'not_interested'}
+					onclick={() => toggleStatus('not_interested')}
+					aria-pressed={currentStatus === 'not_interested'}
+				>
+					Not interested
+				</button>
+			</div>
+		</section>
+	</aside>
 </div>
 
 <style>
-	.film-hero {
+	.breadcrumb {
+		max-width: 1400px;
+		margin: 0 auto;
+		padding: 14px 2rem;
+		border-bottom: 1px solid var(--color-border-subtle);
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
+		color: var(--color-text-tertiary);
+	}
+
+	.breadcrumb a { color: var(--color-text-tertiary); }
+	.breadcrumb a:hover { color: var(--color-text); }
+	.breadcrumb .sep { margin: 0 8px; }
+	.breadcrumb .current {
+		color: var(--color-text-secondary);
+		font-style: normal;
+		font-family: var(--font-serif);
+	}
+
+	.hero {
+		max-width: 1400px;
+		margin: 0 auto;
+		padding: 28px 2rem 32px;
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: 2rem;
+		gap: 1.5rem;
+		border-bottom: 1px solid var(--color-border);
 	}
 
 	@media (min-width: 768px) {
-		.film-hero {
+		.hero {
 			grid-template-columns: 280px 1fr;
+			gap: 32px;
+			padding: 40px 2rem 32px;
 		}
 	}
 
-	.poster-col img {
-		max-width: 280px;
+	@media (min-width: 1024px) {
+		.hero {
+			grid-template-columns: 320px 1fr;
+			gap: 40px;
+		}
+	}
+
+	.poster-col { align-self: start; }
+
+	.poster-frame {
+		width: 100%;
+		aspect-ratio: 2 / 3;
+		border: 1px solid var(--color-border);
+		overflow: hidden;
+		background: var(--color-bg-subtle);
+	}
+
+	@media (max-width: 767px) {
+		.poster-frame {
+			max-width: 280px;
+			margin: 0 auto;
+		}
+	}
+
+	.poster-frame img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.info-col { min-width: 0; }
+
+	.eyebrow {
+		font-family: var(--font-mono-plex);
+		font-size: 10px;
+		color: var(--color-text-tertiary);
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		margin-bottom: 12px;
 	}
 
 	.film-title {
-		font-size: var(--font-size-3xl);
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: -0.02em;
-		line-height: 1.1;
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 48px;
+		font-weight: 300;
+		letter-spacing: -0.035em;
+		line-height: 0.9;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 144';
 	}
+
+	@media (min-width: 768px) {
+		.film-title { font-size: 72px; }
+	}
+
+	@media (min-width: 1024px) {
+		.film-title { font-size: 96px; }
+	}
+
+	.film-title .italic-cap { font-weight: 400; font-style: italic; }
 
 	.original-title {
-		font-size: var(--font-size-lg);
+		font-family: var(--font-serif-italic);
 		font-style: italic;
-		color: var(--color-text-secondary);
-		margin-top: 0.25rem;
+		font-size: 16px;
+		color: var(--color-text-tertiary);
+		margin: 8px 0 0;
 	}
 
-	.tagline {
-		font-size: var(--font-size-base);
+	.byline {
+		margin: 18px 0 0;
+		font-family: var(--font-serif-italic);
 		font-style: italic;
-		color: var(--color-text-tertiary);
-		margin-top: 0.5rem;
-	}
-
-	.meta-row {
-		display: flex;
-		gap: 0.75rem;
-		margin-top: 1rem;
-		font-family: var(--font-mono);
-		font-size: var(--font-size-sm);
+		font-size: 18px;
 		color: var(--color-text-secondary);
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
+		font-weight: 400;
+		line-height: 1.2;
 	}
 
-	.meta-row span:not(:last-child)::after {
-		content: '·';
-		margin-left: 0.75rem;
+	@media (min-width: 1024px) {
+		.byline { font-size: 24px; margin-top: 20px; }
+	}
+
+	.meta {
+		margin: 10px 0 0;
+		font-family: var(--font-mono-plex);
+		font-size: 10px;
 		color: var(--color-text-tertiary);
-	}
-
-	.directors, .cast {
-		margin-top: 0.75rem;
-		font-size: var(--font-size-sm);
-		color: var(--color-text);
-	}
-
-	.label {
+		letter-spacing: 0.16em;
 		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		font-size: var(--font-size-xs);
-		color: var(--color-text-tertiary);
-		display: block;
-		margin-bottom: 0.125rem;
 	}
 
-	.genres {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.375rem;
-		margin-top: 1rem;
+	@media (min-width: 1024px) {
+		.meta { font-size: 11px; }
 	}
 
 	.synopsis {
-		margin-top: 1.25rem;
-		font-size: var(--font-size-base);
-		line-height: 1.6;
+		margin: 20px 0 0;
+		font-family: var(--font-serif);
+		font-size: 16px;
+		font-weight: 400;
 		color: var(--color-text-secondary);
-		max-width: 40rem;
+		line-height: 1.45;
+		max-width: 560px;
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
 	}
 
-	.status-row {
-		display: inline-flex;
-		margin-top: 1.5rem;
+	@media (min-width: 1024px) {
+		.synopsis { font-size: 18px; margin-top: 24px; }
+	}
+
+	.cta-row {
+		margin-top: 24px;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 10px;
+	}
+
+	.cta {
+		padding: 12px 18px;
 		border: 1px solid var(--color-border);
+		font-family: var(--font-serif);
+		font-size: 14px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		cursor: pointer;
+		font-variation-settings: '"SOFT" 100', '"opsz" 36';
+		display: inline-flex;
+		align-items: baseline;
+		gap: 6px;
+		background: transparent;
+		color: var(--color-text);
 	}
 
-	.status-btn {
-		padding: 0.5rem 1rem;
-		font-size: var(--font-size-xs);
-		font-weight: 500;
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
+	.cta.primary {
+		background: var(--color-text);
+		color: var(--color-bg);
+	}
+
+	.cta.primary:hover { background: var(--color-text-secondary); }
+
+	.cta.secondary {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-weight: 400;
+	}
+
+	.cta.secondary:hover { background: var(--color-bg-subtle); }
+
+	.cta.secondary.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+	}
+
+	.cta-detail {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-weight: 400;
+	}
+
+	.letterboxd-rating { margin-top: 20px; }
+
+	/* Body grid */
+	.body-grid {
+		max-width: 1400px;
+		margin: 0 auto;
+		padding: 32px 2rem 60px;
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 32px;
+	}
+
+	@media (min-width: 1024px) {
+		.body-grid {
+			grid-template-columns: 1fr 280px;
+			gap: 40px;
+		}
+	}
+
+	.showings { min-width: 0; }
+
+	.showings-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 16px;
+		margin-bottom: 12px;
+		flex-wrap: wrap;
+	}
+
+	.showings-title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-size: 28px;
+		font-weight: 400;
+		letter-spacing: -0.025em;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 96';
+	}
+
+	@media (min-width: 1024px) {
+		.showings-title { font-size: 32px; }
+	}
+
+	.showings-title .italic-cap { font-style: italic; }
+
+	.day-strip {
+		display: flex;
+		gap: 4px;
+		flex-wrap: wrap;
+	}
+
+	.strip-btn {
+		min-width: 52px;
+		padding: 6px 8px;
+		text-align: center;
+		background: transparent;
 		color: var(--color-text-secondary);
+		border: 1px solid var(--color-border);
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 12px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
+	}
+
+	.strip-btn.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-weight: 500;
+	}
+
+	.strip-btn:hover:not(.active) {
+		background: var(--color-bg-subtle);
+		color: var(--color-text);
+	}
+
+	.picker-wrap {
+		position: relative;
+		margin-left: 6px;
+	}
+
+	.pick-date-btn {
+		padding: 6px 10px;
+		background: var(--color-bg);
+		color: var(--color-text);
+		border: 1px solid var(--color-border);
+		cursor: pointer;
+		font-family: var(--font-serif);
+		font-size: 12px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.pick-date-btn .chevron {
+		color: var(--color-text-tertiary);
+		margin-left: 2px;
+	}
+
+	.popover {
+		position: absolute;
+		top: calc(100% + 8px);
+		right: 0;
+		z-index: 20;
+	}
+
+	@media (max-width: 767px) {
+		.popover {
+			right: auto;
+			left: 0;
+		}
+	}
+
+	.empty-clear {
+		display: inline-block;
+		margin-left: 8px;
 		background: transparent;
 		border: none;
-		border-right: 1px solid var(--color-border);
+		padding: 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text-secondary);
 		cursor: pointer;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+	.empty-clear:hover { color: var(--color-text); }
+
+	.cinema-block {
+		padding: 18px 0;
+		border-top: 1px solid var(--color-border-subtle);
+	}
+
+	.cinema-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		margin-bottom: 10px;
+	}
+
+	.cinema-name {
+		font-family: var(--font-serif);
+		font-size: 20px;
+		font-weight: 500;
+		color: var(--color-text);
+		letter-spacing: -0.012em;
+	}
+
+	.cinema-sub {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text-tertiary);
+		margin-left: 10px;
+	}
+
+	.slots {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.slot-wrap {
+		display: inline-flex;
+		align-items: stretch;
+	}
+
+	.slot {
+		padding: 10px 14px;
+		background: transparent;
+		border: 1px solid var(--color-border);
+		border-right: none;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: baseline;
+		gap: 8px;
+		color: inherit;
+	}
+
+	.slot:hover { background: var(--color-bg-subtle); }
+
+	.slot-time {
+		font-family: var(--font-mono-plex);
+		font-size: 14px;
+		color: var(--color-text);
+		font-weight: 500;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.slot-format {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 12px;
+		color: var(--color-text-tertiary);
+	}
+
+	.ical-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 40px;
+		border: 1px solid var(--color-border);
+		color: var(--color-text-tertiary);
+		cursor: pointer;
+		background: transparent;
 		transition: color var(--duration-fast) var(--ease-sharp),
 			background-color var(--duration-fast) var(--ease-sharp);
 	}
 
-	.status-btn:last-child {
-		border-right: none;
-	}
-
-	.status-btn:hover {
+	.ical-btn:hover {
 		color: var(--color-text);
 		background: var(--color-bg-subtle);
 	}
 
-	.status-btn.active {
-		background: var(--color-screening-bg);
-		color: var(--color-screening-text);
-	}
-
-	.letterboxd-rating {
-		margin-top: 1.25rem;
+	.empty {
+		margin: 24px 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 14px;
+		color: var(--color-text-tertiary);
 	}
 
 	.external-links {
 		display: flex;
-		gap: 1rem;
-		margin-top: 1rem;
+		gap: 16px;
+		margin-top: 28px;
+		padding-top: 16px;
+		border-top: 1px dotted var(--color-border-subtle);
 	}
 
-	.ext-link {
-		font-size: var(--font-size-xs);
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
+	.ext {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
 		color: var(--color-text-tertiary);
 		text-decoration: underline;
 		text-underline-offset: 2px;
 	}
 
-	.ext-link:hover {
-		color: var(--color-text);
+	.ext:hover { color: var(--color-text); }
+
+	/* Sidebar */
+	.sidebar {
+		padding-left: 0;
 	}
 
-	/* Screenings section */
-	.screenings-section {
-		margin-top: 3rem;
-		border-top: 2px solid var(--color-border);
-		padding-top: 1.5rem;
+	@media (min-width: 1024px) {
+		.sidebar {
+			border-left: 1px solid var(--color-border-subtle);
+			padding-left: 32px;
+		}
 	}
 
-	.section-heading {
-		font-size: var(--font-size-sm);
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		margin-bottom: 1.5rem;
-	}
-
-	.screening-count {
-		font-family: var(--font-mono);
-		color: var(--color-text-tertiary);
-		margin-left: 0.5rem;
-	}
-
-	.day-group {
-		margin-bottom: 1.5rem;
-	}
-
-	.day-label {
-		font-size: var(--font-size-xs);
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--color-text-tertiary);
-		margin-bottom: 0.5rem;
-	}
-
-	.screening-rows {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.screening-row {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		padding: 0.625rem 0;
+	.credits-section, .status-section, .tagline-section {
+		padding-bottom: 20px;
 		border-bottom: 1px solid var(--color-border-subtle);
-		transition: background-color var(--duration-fast) var(--ease-sharp);
+		margin-bottom: 18px;
 	}
 
-	.screening-row:hover {
-		background: var(--color-bg-subtle);
-		margin: 0 -0.75rem;
-		padding-left: 0.75rem;
-		padding-right: 0.75rem;
-	}
-
-	.screening-time {
-		font-family: var(--font-mono);
-		font-size: var(--font-size-sm);
-		font-weight: 600;
-		min-width: 3rem;
-	}
-
-	.screening-cinema {
-		font-size: var(--font-size-sm);
+	.credits-title {
+		margin: 0 0 10px;
+		font-family: var(--font-serif);
+		font-size: 14px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
 		color: var(--color-text);
+	}
+	.credits-title .italic-cap { font-style: italic; }
+
+	.credit-row {
+		padding: 5px 0;
+		display: flex;
+		gap: 8px;
+		align-items: baseline;
+	}
+
+	.credit-key {
+		font-family: var(--font-mono-plex);
+		font-size: 10px;
+		color: var(--color-text-tertiary);
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		min-width: 90px;
+		padding-top: 3px;
+	}
+
+	.credit-val {
 		flex: 1;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
+		color: var(--color-text-secondary);
+		line-height: 1.3;
 	}
 
-	.screening-screen {
-		font-size: var(--font-size-xs);
-		color: var(--color-text-tertiary);
+	.tagline {
+		margin: 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 16px;
+		color: var(--color-text-secondary);
+		line-height: 1.35;
 	}
 
-	.booking-arrow {
-		color: var(--color-text-tertiary);
-		flex-shrink: 0;
+	.status-row {
+		display: flex;
+		border: 1px solid var(--color-border);
 	}
 
-	.screening-row:hover .booking-arrow {
+	.status-btn {
+		flex: 1;
+		padding: 8px 10px;
+		font-family: var(--font-serif);
+		font-size: 12.5px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		color: var(--color-text-secondary);
+		background: transparent;
+		border: none;
+		border-right: 1px solid var(--color-border);
+		cursor: pointer;
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
+	}
+
+	.status-btn:last-child { border-right: none; }
+
+	.status-btn:hover {
+		background: var(--color-bg-subtle);
 		color: var(--color-text);
 	}
 
-	.screening-row-wrapper {
-		display: flex;
-		align-items: center;
-	}
-
-	.ical-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 2.75rem;
-		height: 2.75rem;
-		flex-shrink: 0;
-		color: var(--color-text-tertiary);
-		transition: color var(--duration-fast) var(--ease-sharp);
-	}
-
-	.ical-btn:hover {
-		color: var(--color-text);
+	.status-btn.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-weight: 500;
 	}
 </style>

--- a/frontend/src/routes/film/[id]/+page.ts
+++ b/frontend/src/routes/film/[id]/+page.ts
@@ -1,0 +1,20 @@
+import { apiGet } from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { Film, Screening } from '$lib/types';
+
+interface FilmDetailResponse {
+	film: Film;
+	screenings: Array<Screening & {
+		cinema: { id: string; name: string; shortName: string | null };
+	}>;
+	meta: { screeningCount: number };
+}
+
+export async function load({ params, fetch }) {
+	try {
+		const res = await apiGet<FilmDetailResponse>(`/api/films/${params.id}`, { fetch });
+		return res;
+	} catch (e) {
+		throw error(404, 'Film not found');
+	}
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 	server: {
 		proxy: {
 			'/api': {
-				target: 'http://localhost:3000',
+				target: process.env.API_PROXY_TARGET ?? 'http://localhost:3000',
 				changeOrigin: true
 			}
 		}


### PR DESCRIPTION
## Summary

- Full brand + typography redesign of pictures.london following the Claude Design handoff bundle (`pictures-london-v2a-hybrid.html` + siblings) — the user landed on V2a after iterating through five competing V2 directions.
- Palette: warm beige (`#efe9dc`) + oxblood accent (`#a83232`) + deep ink text (`#1a1410`) — replaces Swiss-brutalist warm-white + bright-red.
- Typography: Fraunces SOFT (display) + Cormorant italic (byline/deck) + IBM Plex Mono (meta) — replaces Inter + Space Grotesk + JetBrains Mono.
- Homepage desktop: new 240px editorial sidebar (Where / Time of day / Format / Within 2mi with browser geolocation), italic-first-letter prose day masthead ("Sunday, the nineteenth"), 4-col hybrid grid (expands to 5-col when sidebar is collapsed), inline screenings per card.
- Homepage mobile: serif italic date label, search + Filter button, bordered All / New / Repertory tabs, text-forward film rows. New mobile filter sheet + date picker.
- Film detail: literary 320px-poster hero + 96px italic title + Cormorant byline + Plex Mono meta + Fraunces synopsis, Pick-date filter for screenings, grouped-by-cinema chip buttons, Credits sidebar.
- Unified all page shells to the same `max-width: 1400px` so the header wordmark, breadcrumb, and body headings share a left gutter.
- Sidebar is collapsible (persists via localStorage); a right-aligned italic "Hide ‹" link inside the sidebar mirrors a sticky vertical "Filters" rail when collapsed.

## Out of scope (see changelog follow-ups)

- **Genre + Era filter sections hidden**: loader doesn't expose `film.genres`, and toggling dead chips persisted state to localStorage without affecting results. Code-review blocker fixed by hiding until wiring lands.
- **Modal a11y** (focus trap / body-scroll lock / Escape): known follow-up for mobile sheets + calendar popover.
- **Playwright tests**: 38 existing tests assert the old filter topology (header FilterBar dropdowns, uppercase tab labels). Selectors for `.film-card` + `.film-title` preserved where cheap; the filter-specific tests need a rewrite in a follow-up PR.

## Test plan

- [x] `npx svelte-check` — clean in all files touched by this PR (pre-existing errors in FollowButton / CinemaMap / SyncProvider / letterboxd are not regressed)
- [x] Side-by-side browser comparison against the design prototype at 1440×900 and 390×844 (screenshots archived in `.design-verify/`)
- [x] Manual verification of sidebar collapse + expand + localStorage persistence, "Within 2mi" geolocation flow (granted / denied / unsupported states), Pick-date calendar popover on desktop and film detail
- [ ] Rewrite the 38 failing Playwright tests against the new filter topology — follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)