### PR TITLE
fix: restore PostHog event capture (opt-in guard regression)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-04-19: Fix PostHog opt-in guard that blocked all event capture
+**PR**: TBD | **Files**: `frontend/src/lib/analytics/PostHogProvider.svelte`, `frontend/src/lib/analytics/posthog.ts`
+- PostHogProvider's consent effect called `posthog.has_opted_out_capturing()` before calling `opt_in_capturing()`, intending to preserve admin opt-out — but with `opt_out_capturing_by_default: true`, that check returns `true` for every default user, so `opt_in_capturing()` was never called
+- Result: since PR #422 (2026-04-11), no custom events (`film_viewed`, `booking_link_clicked`, search/filter events, etc.) were reaching PostHog from pictures.london — autocapture and pageviews were also blocked for users who accepted consent
+- Fix: track admin opt-out with an explicit `adminOptedOut` module flag set inside `identifyUser()`, replacing the `has_opted_out_capturing()` check with `isAdminOptedOut()`
+- Verified live on localhost: accepting consent now persists PostHog opt-in, upgrades storage to `localStorage+cookie`, and POSTs `$opt_in`, `$autocapture`, `$pageview`, `$exception` to `/ingest/e/` with the correct Pictures project token
+
+---
+
 ## 2026-04-19: V2a Literary Antiqua redesign — mobile + desktop listings and film detail
 **PR**: TBD | **Files**: `frontend/src/app.css`, `frontend/src/routes/+page.svelte`, `frontend/src/routes/film/[id]/+page.svelte`, `frontend/src/lib/components/layout/Header.svelte`, `frontend/src/lib/components/filters/{DesktopFilterSidebar,MobileFilterSheet,MobileDatePicker,CalendarPopover,FilmTypeFilter}.svelte`, `frontend/src/lib/components/calendar/{DayMasthead,DesktopHybridCard,MobileFilmRow}.svelte`, `frontend/vite.config.ts`
 - Full rebrand of pictures.london following the Claude Design handoff bundle (`pictures-london-v2a-hybrid.html` + siblings) the user landed on after iterating through 5 V2a typographic directions

--- a/changelogs/2026-04-19-fix-posthog-opt-in-guard.md
+++ b/changelogs/2026-04-19-fix-posthog-opt-in-guard.md
@@ -1,0 +1,62 @@
+# Fix PostHog opt-in guard that blocked all event capture
+
+**PR**: TBD
+**Date**: 2026-04-19
+**Branch**: `fix/playwright-tests-v2a`
+
+## Symptom
+PostHog captured zero custom events from pictures.london in production — including `film_viewed`, `booking_link_clicked`, `screening_card_clicked`, `search_performed`, `filter_changed`, `cinema_viewed`, `film_status_changed`, `calendar_export_clicked`, and all sync lifecycle events. Autocapture, pageviews, and web-vitals were also blocked for any user who accepted consent.
+
+## Root cause
+In `frontend/src/lib/analytics/PostHogProvider.svelte`, the consent `$effect` short-circuited before calling `opt_in_capturing()`:
+
+```ts
+if (decision === 'enable') {
+  // Don't re-enable if admin was opted out by identifyUser()
+  if (posthogLib.has_opted_out_capturing()) return;
+  posthogLib.opt_in_capturing();
+  ...
+}
+```
+
+The `has_opted_out_capturing()` check was meant to preserve admin opt-out (done inside `identifyUser()` for `jdwbarge@gmail.com`). But in `posthog.ts` we init PostHog with `opt_out_capturing_by_default: true` — and posthog-js's `has_opted_out_capturing()` falls back to that default setting when no explicit decision has been stored. So for every default user with no prior PostHog state, `has_opted_out_capturing()` returned `true`, the effect early-returned, and `opt_in_capturing()` was never called.
+
+Introduced in PR #422 / commit `c448a2be` (2026-04-11) — the commit message explicitly names this check as a "fix: admin opt-out race condition", but the fix has the opposite effect.
+
+## Evidence
+Live-browser verification on production pictures.london before the fix:
+- After clicking "Accept All" on the cookie banner → 120s of observation.
+- Only network hits: `/ingest/array/.../config` (200, once) + `/ingest/api/surveys/` (404, polling).
+- Zero POSTs to `/ingest/e/`, `/ingest/batch/`, `/ingest/flags/`, `/ingest/decide`.
+- No `posthog_*` / `ph_*` keys in `localStorage` despite `opt_in_capturing()` being supposed to persist opt-in state and upgrade persistence to `localStorage+cookie`.
+
+## Fix
+Disentangle admin opt-out from PostHog's by-default opt-out state by tracking admin opt-out explicitly.
+
+### `frontend/src/lib/analytics/posthog.ts`
+- Add `let adminOptedOut = false` module flag.
+- Export `isAdminOptedOut()` getter.
+- Set `adminOptedOut = true` inside `identifyUser()` when `isAdminEmail(email)` matches, alongside the existing `opt_out_capturing()` + `reset()` calls.
+
+### `frontend/src/lib/analytics/PostHogProvider.svelte`
+- Replace `if (posthogLib.has_opted_out_capturing()) return;` with `if (posthogModule?.isAdminOptedOut()) return;`.
+
+## Verification
+Local dev server with Pictures project key in `.env.local`:
+1. Clear localStorage → navigate to `/` → consent banner appears.
+2. Click "ACCEPT ALL".
+3. Confirmed:
+   - `localStorage` now has `__ph_opt_in_out_phc_m9yV…pgN` and `ph_phc_m9yV…pgN_posthog` keys.
+   - `consent` status = `accepted`.
+   - Network POSTs fire to `/ingest/flags/` and `/ingest/e/` with token `phc_m9yV…pgN` (Pictures project).
+   - Events captured: `$opt_in`, `$autocapture`, `$pageview`, `$exception` (via `trackException()` — proving the custom-track wrappers reach the wire).
+4. Local 404s on `/ingest/*` are expected in dev (Vercel's `vercel.json` rewrites are only applied in preview/prod).
+
+## Impact
+- All custom events wired up in PR #422 will start flowing in PostHog immediately after deploy.
+- 8 days of lost data between 2026-04-11 (PR #422 merge) and 2026-04-19 (this fix) are unrecoverable.
+- Admin opt-out for `jdwbarge@gmail.com` continues to work unchanged — `identifyUser()` sets the new `adminOptedOut` flag, and the consent effect still respects it.
+
+## Related
+- PR #422: "restore PostHog analytics with GDPR consent" (introduced the regression)
+- Pictures PostHog project token: `phc_m9yVROnvEmJSiJWfGXy3FQszpIyhcOMZi3xKxhvnpgN` (already deployed in Vercel env — no env change required)

--- a/frontend/src/lib/analytics/PostHogProvider.svelte
+++ b/frontend/src/lib/analytics/PostHogProvider.svelte
@@ -54,7 +54,7 @@
 
 		if (decision === 'enable') {
 			// Don't re-enable if admin was opted out by identifyUser()
-			if (posthogLib.has_opted_out_capturing()) return;
+			if (posthogModule?.isAdminOptedOut()) return;
 			posthogLib.opt_in_capturing();
 			posthogLib.set_config({ persistence: 'localStorage+cookie' });
 			posthogLib.startSessionRecording();

--- a/frontend/src/lib/analytics/posthog.ts
+++ b/frontend/src/lib/analytics/posthog.ts
@@ -18,6 +18,11 @@ export function isAdminEmail(email: string | undefined | null): boolean {
 // ── Init ────────────────────────────────────────────────────────
 
 let initialized = false;
+let adminOptedOut = false;
+
+export function isAdminOptedOut() {
+	return adminOptedOut;
+}
 
 export function initPostHog() {
 	if (!browser || initialized || !PUBLIC_POSTHOG_KEY) return;
@@ -255,6 +260,7 @@ export function identifyUser(userId: string, properties?: Record<string, unknown
 	// If admin, opt out entirely to prevent polluting analytics
 	const email = properties?.email as string | undefined;
 	if (isAdminEmail(email)) {
+		adminOptedOut = true;
 		posthog.opt_out_capturing();
 		posthog.reset();
 		return;
@@ -265,6 +271,7 @@ export function identifyUser(userId: string, properties?: Record<string, unknown
 
 export function resetUser() {
 	if (!browser) return;
+	adminOptedOut = false;
 	posthog.reset();
 }
 


### PR DESCRIPTION
## Summary
- **Zero custom events have been captured from pictures.london in PostHog since PR #422 (2026-04-11).** The same regression also blocked autocapture, pageviews, and web-vitals for any user who accepted cookie consent.
- Root cause: `PostHogProvider.svelte` called `posthog.has_opted_out_capturing()` before `opt_in_capturing()`, but `opt_out_capturing_by_default: true` makes that check return `true` for every default user — so `opt_in_capturing()` was never called.
- Fix: explicit `adminOptedOut` module flag set inside `identifyUser()`. Replaces the ambiguous `has_opted_out_capturing()` check. Cleared in `resetUser()` so sign-out releases the latch.

## Verification
Live test on localhost with the Pictures project key in `.env.local`:

1. Cleared `localStorage` → navigated to `/` → consent banner appears.
2. Clicked **ACCEPT ALL**.
3. Confirmed:
   - `localStorage` now has `__ph_opt_in_out_phc_m9yV…pgN` and `ph_phc_m9yV…pgN_posthog`.
   - Network POSTs fire to `/ingest/flags/` and `/ingest/e/` with the Pictures token.
   - Events captured on the wire: `$opt_in`, `$autocapture`, `$pageview`, `$exception` (via `trackException()` — proves the custom-track wrappers reach the wire).

The 404s on `/ingest/*` locally are expected — the `vercel.json` rewrite to `eu.i.posthog.com` only applies in Vercel preview/prod. In production those same requests land at PostHog.

## Test plan
- [ ] Deploy preview, accept cookies, and confirm `$opt_in` appears in the Pictures PostHog project within ~1 minute.
- [ ] Navigate to a film detail page and confirm `film_viewed` appears.
- [ ] Click a booking link and confirm `booking_link_clicked` appears.
- [ ] Sign in as `jdwbarge@gmail.com` and confirm **no** events are captured from that session (admin latch still works).
- [ ] Sign out and confirm events capture again for the next (non-admin) user on the same browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)