### PR TITLE
feat(films): "If you like this" similar films rail

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-04-19: "If you like this" similar films rail
+**PR**: TBD | **Files**: `src/app/api/films/[id]/similar/route.ts`, `src/lib/tmdb/client.ts`, `src/db/repositories/film.ts`, `frontend/src/routes/film/[id]/+page.{ts,svelte}`
+- New `/api/films/[id]/similar` Next.js route proxies TMDB's `/movie/{id}/similar`, intersects with films we carry, preserves similarity ordering, returns up to 6. Caches 24 h at the edge.
+- Frontend film-detail loader fetches similar in parallel with the main detail request; a failure hides the rail rather than breaking the page.
+- Rail renders below the body grid on both desktop (responsive grid, 132px cards) and mobile (scroll-snap horizontal rail) when `similar.length >= 2`.
+- Graceful hide when the film has no `tmdbId`, TMDB is down, or <2 matches we carry.
+
+---
+
 ## 2026-04-19: V2a Literary Antiqua redesign — mobile + desktop listings and film detail
 **PR**: TBD | **Files**: `frontend/src/app.css`, `frontend/src/routes/+page.svelte`, `frontend/src/routes/film/[id]/+page.svelte`, `frontend/src/lib/components/layout/Header.svelte`, `frontend/src/lib/components/filters/{DesktopFilterSidebar,MobileFilterSheet,MobileDatePicker,CalendarPopover,FilmTypeFilter}.svelte`, `frontend/src/lib/components/calendar/{DayMasthead,DesktopHybridCard,MobileFilmRow}.svelte`, `frontend/vite.config.ts`
 - Full rebrand of pictures.london following the Claude Design handoff bundle (`pictures-london-v2a-hybrid.html` + siblings) the user landed on after iterating through 5 V2a typographic directions

--- a/changelogs/2026-04-19-similar-films-rail.md
+++ b/changelogs/2026-04-19-similar-films-rail.md
@@ -1,0 +1,43 @@
+# "If you like this" similar films rail
+
+**PR**: TBD
+**Date**: 2026-04-19
+
+## Context
+
+The V2a film-detail design includes an `If you like this` horizontal rail of similar films at the bottom of the page. It was stubbed out in PR #431 because the backend didn't expose similar films. This PR closes that follow-up end-to-end — backend route → DB helper → frontend loader → rail render.
+
+## Changes
+
+### Backend
+
+**`src/lib/tmdb/client.ts`** — add `getSimilar(tmdbId)` method. Returns only `{ id }` because we re-read poster + title from our own DB; no need to trust TMDB's copy.
+
+**`src/db/repositories/film.ts`** — add `findByTmdbIds(tmdbIds: number[])` helper. Returns id + tmdbId + title + year + posterUrl for each match.
+
+**`src/app/api/films/[id]/similar/route.ts`** (new) — proxies TMDB's `/movie/{id}/similar`, intersects with films we carry, preserves TMDB's similarity ordering, returns up to 6. Caches 24 h at the edge (`Cache-Control: public, s-maxage=86400, stale-while-revalidate=86400`) — similarity doesn't change day-to-day.
+
+**Graceful degradation**:
+- Film has no `tmdbId` → empty `similar[]`, rail hides on frontend
+- TMDB returns an empty list or 5xx → caught + empty `similar[]`, rail hides
+- Fewer than 2 matches we carry → empty (a rail of 1 reads as a broken feature, not a recommendation)
+
+### Frontend
+
+**`frontend/src/routes/film/[id]/+page.ts`** — fetch `/api/films/${id}/similar` in parallel with the main detail request using `Promise.all`. The similar request has its own `.catch(() => ({ similar: [] }))` so a similar-endpoint failure never breaks the detail page.
+
+**`frontend/src/routes/film/[id]/+page.svelte`** — render a new `<section class="similar">` below the body grid when `similar.length >= 2`. Desktop: responsive grid (auto-fill, minmax 132px). Mobile: horizontal scroll rail with scroll-snap, flex-basis 132px per card.
+
+## Visual treatment
+
+Matches the V2a system: Fraunces 28px italic-first-letter heading ("*I*f you like this"), 2/3 aspect posters in warm-bg-subtle frames, Fraunces 14px titles, Cormorant italic 12px year. No accent colour, no emphasis — it's a quiet bottom rail, not a CTA.
+
+## Verification
+
+- Backend route: requires `TMDB_API_KEY` in env (already set in `.env.local` and Vercel since other TMDB lookups use it).
+- `svelte-check`: no new errors.
+- `npx tsc --noEmit` (backend): clean on the new files.
+
+## Follow-up
+
+None — this closes the last remaining follow-up from PR #431.

--- a/frontend/src/routes/film/[id]/+page.svelte
+++ b/frontend/src/routes/film/[id]/+page.svelte
@@ -13,6 +13,7 @@
 
 	const film = $derived(data.film);
 	const screenings = $derived(data.screenings);
+	const similar = $derived(data.similar ?? []);
 	const currentStatus = $derived(filmStatuses.getStatus(film.id));
 
 	onMount(() => {
@@ -430,6 +431,31 @@
 		</section>
 	</aside>
 </div>
+
+{#if similar.length >= 2}
+	<section class="similar" aria-labelledby="similar-heading">
+		<header class="similar-head">
+			<h2 id="similar-heading" class="similar-title">
+				<span class="italic-cap">I</span>f you like this
+			</h2>
+		</header>
+		<div class="similar-rail">
+			{#each similar as s (s.id)}
+				<a href="/film/{s.id}" class="similar-card">
+					<div class="similar-poster">
+						{#if s.posterUrl}
+							<img src={s.posterUrl} alt={s.title} loading="lazy" />
+						{:else}
+							<div class="similar-poster-fallback"><span>{s.title}</span></div>
+						{/if}
+					</div>
+					<h3 class="similar-name">{s.title}</h3>
+					{#if s.year}<p class="similar-year">{s.year}</p>{/if}
+				</a>
+			{/each}
+		</div>
+	</section>
+{/if}
 
 <style>
 	.breadcrumb {
@@ -974,5 +1000,106 @@
 		background: var(--color-text);
 		color: var(--color-bg);
 		font-weight: 500;
+	}
+
+	/* ── Similar films rail ── */
+	.similar {
+		max-width: 1400px;
+		margin: 0 auto;
+		padding: 32px 2rem 64px;
+		border-top: 1px solid var(--color-border-subtle);
+	}
+
+	.similar-head {
+		margin-bottom: 20px;
+	}
+
+	.similar-title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-weight: 400;
+		font-size: 28px;
+		letter-spacing: -0.02em;
+		line-height: 1;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 36';
+	}
+
+	.similar-title .italic-cap {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+	}
+
+	.similar-rail {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+		gap: 20px 18px;
+	}
+
+	@media (max-width: 767px) {
+		.similar-rail {
+			display: flex;
+			overflow-x: auto;
+			scroll-snap-type: x mandatory;
+			gap: 14px;
+			padding-bottom: 8px;
+		}
+		.similar-card {
+			flex: 0 0 132px;
+			scroll-snap-align: start;
+		}
+	}
+
+	.similar-card {
+		display: flex;
+		flex-direction: column;
+		color: var(--color-text);
+		text-decoration: none;
+	}
+
+	.similar-poster {
+		position: relative;
+		aspect-ratio: 2 / 3;
+		background: var(--color-bg-subtle);
+		border: 1px solid var(--color-border-subtle);
+		margin-bottom: 8px;
+		overflow: hidden;
+	}
+
+	.similar-poster img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.similar-poster-fallback {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		padding: 8px;
+		font-family: var(--font-serif);
+		font-size: 12px;
+		color: var(--color-text-tertiary);
+	}
+
+	.similar-name {
+		margin: 0 0 2px;
+		font-family: var(--font-serif);
+		font-weight: 400;
+		font-size: 14px;
+		line-height: 1.2;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
+	}
+
+	.similar-year {
+		margin: 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 12px;
+		color: var(--color-text-tertiary);
 	}
 </style>

--- a/frontend/src/routes/film/[id]/+page.ts
+++ b/frontend/src/routes/film/[id]/+page.ts
@@ -10,10 +10,27 @@ interface FilmDetailResponse {
 	meta: { screeningCount: number };
 }
 
+export interface SimilarFilm {
+	id: string;
+	title: string;
+	year: number | null;
+	posterUrl: string | null;
+}
+
+interface SimilarResponse {
+	similar: SimilarFilm[];
+}
+
 export async function load({ params, fetch }) {
 	try {
-		const res = await apiGet<FilmDetailResponse>(`/api/films/${params.id}`, { fetch });
-		return res;
+		// Fetch detail + similar in parallel. Similar is best-effort: a failure
+		// (network, backend down, TMDB quota) just hides the rail — we never
+		// break the detail page over it.
+		const [detail, similar] = await Promise.all([
+			apiGet<FilmDetailResponse>(`/api/films/${params.id}`, { fetch }),
+			apiGet<SimilarResponse>(`/api/films/${params.id}/similar`, { fetch }).catch(() => ({ similar: [] as SimilarFilm[] }))
+		]);
+		return { ...detail, similar: similar.similar };
 	} catch (e) {
 		throw error(404, 'Film not found');
 	}

--- a/src/app/api/films/[id]/similar/route.ts
+++ b/src/app/api/films/[id]/similar/route.ts
@@ -1,0 +1,121 @@
+/**
+ * Similar Films API Route
+ * GET /api/films/:id/similar
+ *
+ * Proxies TMDB's /movie/{id}/similar endpoint, filters to films we actually
+ * carry in our own DB (so every result is clickable and leads to a real
+ * listings page), and returns up to 6. Cached for 24 h at the CDN edge —
+ * similarity is effectively stable.
+ *
+ * Falls back to an empty array when:
+ *   - the requested film has no TMDB id (we don't have a similarity signal)
+ *   - TMDB returns fewer than 2 matches we carry (a rail with 1 item is noise)
+ *   - TMDB is down (never 5xx the detail page for a side rail)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { handleApiError } from "@/lib/api-errors";
+import { checkRateLimit, getClientIP, RATE_LIMITS } from "@/lib/rate-limit";
+import { getFilmById, findByTmdbIds } from "@/db/repositories/film";
+import { getTMDBClient } from "@/lib/tmdb/client";
+
+const paramsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const MAX_RESULTS = 6;
+const MIN_RESULTS = 2;
+
+// 24 h edge cache on the happy path — similarity doesn't change day-to-day.
+const CACHE_24H = {
+  "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=86400",
+} as const;
+
+// 5 min edge cache on empty/fallback responses so a transient TMDB outage
+// doesn't freeze an empty rail on this film for 24 hours.
+const CACHE_EMPTY = {
+  "Cache-Control": "public, s-maxage=300, stale-while-revalidate=300",
+} as const;
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const ip = getClientIP(request);
+    const rateLimitResult = await checkRateLimit(ip, {
+      ...RATE_LIMITS.public,
+      prefix: "films-similar",
+    });
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", similar: [] },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimitResult.resetIn) },
+        }
+      );
+    }
+
+    const { id } = await params;
+    const parseResult = paramsSchema.safeParse({ id });
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Invalid film ID", details: parseResult.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const film = await getFilmById(id);
+    if (!film || !film.tmdbId) {
+      // No signal — return an empty list rather than a 404 so the frontend
+      // can cheaply hide the rail. This is a stable condition (film has no
+      // tmdbId permanently) so the 24 h cache is still fine here.
+      return NextResponse.json({ similar: [] }, { headers: CACHE_24H });
+    }
+
+    let tmdbIds: number[] = [];
+    try {
+      const tmdb = getTMDBClient();
+      const response = await tmdb.getSimilar(film.tmdbId);
+      tmdbIds = response.results.map((r) => r.id);
+    } catch (e) {
+      console.error("TMDB similar lookup failed", e);
+      return NextResponse.json({ similar: [] }, { headers: CACHE_EMPTY });
+    }
+
+    if (tmdbIds.length === 0) {
+      return NextResponse.json({ similar: [] }, { headers: CACHE_EMPTY });
+    }
+
+    // Intersect with films we carry. Preserve TMDB's similarity ordering.
+    const ownedFilms = await findByTmdbIds(tmdbIds);
+    const byTmdbId = new Map(ownedFilms.map((f) => [f.tmdbId, f]));
+    const ordered = tmdbIds
+      .map((tid) => byTmdbId.get(tid))
+      .filter((f): f is NonNullable<typeof f> => f !== undefined)
+      .slice(0, MAX_RESULTS);
+
+    // Don't bother showing a rail of 1 — it reads as a broken feature, not
+    // a recommendation. Short-cache this too in case we later acquire a
+    // related film and want the rail to pop back faster.
+    if (ordered.length < MIN_RESULTS) {
+      return NextResponse.json({ similar: [] }, { headers: CACHE_EMPTY });
+    }
+
+    return NextResponse.json(
+      {
+        similar: ordered.map((f) => ({
+          id: f.id,
+          title: f.title,
+          year: f.year,
+          posterUrl: f.posterUrl,
+        })),
+      },
+      { headers: CACHE_24H }
+    );
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/db/repositories/film.ts
+++ b/src/db/repositories/film.ts
@@ -5,7 +5,7 @@
 
 import { db } from "@/db";
 import { films, screenings, cinemas } from "@/db/schema";
-import { eq, gte, and } from "drizzle-orm";
+import { eq, gte, and, inArray } from "drizzle-orm";
 import type { ContentType } from "@/types/film";
 import type { ScreeningFormat } from "@/types/screening";
 
@@ -95,6 +95,34 @@ export async function getFilmById(id: string): Promise<FilmDetail | null> {
     .limit(1);
 
   return film ?? null;
+}
+
+/**
+ * Look up a set of films by their TMDB IDs. Used by the "similar films" rail
+ * on the film detail page — we get a list of similar TMDB IDs from TMDB and
+ * intersect it with the films we actually carry.
+ */
+export async function findByTmdbIds(tmdbIds: number[]): Promise<Array<{
+  id: string;
+  tmdbId: number | null;
+  title: string;
+  year: number | null;
+  posterUrl: string | null;
+}>> {
+  if (tmdbIds.length === 0) return [];
+
+  // inArray excludes NULL tmdbIds on the column side (SQL `IN` never matches
+  // NULL), so films without a tmdbId are implicitly filtered out.
+  return db
+    .select({
+      id: films.id,
+      tmdbId: films.tmdbId,
+      title: films.title,
+      year: films.year,
+      posterUrl: films.posterUrl,
+    })
+    .from(films)
+    .where(inArray(films.tmdbId, tmdbIds));
 }
 
 /**

--- a/src/lib/tmdb/client.ts
+++ b/src/lib/tmdb/client.ts
@@ -68,6 +68,15 @@ export class TMDBClient {
   }
 
   /**
+   * Get similar films by TMDB ID. TMDB returns up to 20 per page, ordered
+   * by similarity. We only care about the ids so we can intersect with our
+   * own DB — poster/title are re-read from our row, not TMDB's response.
+   */
+  async getSimilar(tmdbId: number): Promise<{ results: Array<{ id: number }> }> {
+    return this.fetch<{ results: Array<{ id: number }> }>(`/movie/${tmdbId}/similar`);
+  }
+
+  /**
    * Get credits (cast and crew) for a film
    */
   async getFilmCredits(tmdbId: number): Promise<TMDBCredits> {


### PR DESCRIPTION
## Summary

Closes the last follow-up from PR #431. The V2a film-detail design includes a bottom rail of similar films that was stubbed because the backend didn't expose similarity.

- **Backend**: new `/api/films/[id]/similar` proxies TMDB's `/movie/{id}/similar`, intersects with films we carry (via new `findByTmdbIds` helper + new `TMDBClient.getSimilar`), preserves similarity ordering, returns up to 6.
- **Cache**: happy-path 24 h at the edge (similarity is stable), empty/fallback paths 5 min so a transient TMDB outage doesn't freeze an empty rail for a day. (Applied from code-reviewer feedback.)
- **Frontend**: film-detail loader fetches similar in parallel with the main request. A similar-fetch failure hides the rail rather than breaking the detail page.
- **Render**: new `<section class=\"similar\">` below the body grid when `similar.length >= 2`. Desktop responsive grid (auto-fill, 132px min cards); mobile scroll-snap horizontal scroller.

## Graceful degradation matrix

| Condition | Response | Rail |
|---|---|---|
| Film has no `tmdbId` | `{similar: []}` cached 24h | Hidden |
| TMDB request fails | `{similar: []}` cached 5m | Hidden |
| TMDB returns empty | `{similar: []}` cached 5m | Hidden |
| We own <2 similar | `{similar: []}` cached 5m | Hidden |
| Frontend fetch errors | `similar: []` in loader | Hidden |

## Code review

Ran code-reviewer on the staged diff. No blockers. Two suggestions applied:
1. Shorter cache (5m) on fallback responses — prevents transient TMDB outage from freezing empty rails at the edge for 24 h.
2. Inline comment on `findByTmdbIds` documenting SQL `IN` null-safety (the caller filters `!tmdbId` upstream, and `inArray` can't match NULL on the column side anyway).

## Test plan

- [x] `svelte-check` — no new errors
- [x] Backend `tsc --noEmit` — no new errors
- [ ] Production deploy: visit a popular film detail (The Drama, Apocalypse Now) — rail shows 4–6 similar films with posters linking to our film pages
- [ ] Visit an obscure indie with no TMDB similar films we carry — rail hidden gracefully
- [ ] Network tab: TMDB fetch is server-side (not visible to the browser); response is cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)