### PR TITLE
fix(api): remove 3000 row cap from screenings endpoint

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-21: Remove 3000-screening cap from /api/screenings legacy path
+**PR**: TBD | **Files**: `src/db/repositories/screening.ts`, `src/db/repositories/screening.test.ts`
+- The non-paginated `/api/screenings` path capped results at 3000 rows, which at current scrape density truncated the home page's 30-day window to ~8 days. Films scheduled beyond that window were invisible (e.g. North by Northwest at Prince Charles, May 1–12, 2026)
+- Removed the hard-coded `limit = 3000` default from `getScreenings`, `getScreeningsByFestival`, and `getScreeningsBySeason`
+- Test mock updated to resolve at any step of the query chain so tests no longer depend on `.limit()` being the terminal call
+
+---
+
 ## 2026-04-20: Fix PostHog ingestion proxy failing on trailing-slash paths
 **PR**: TBD | **Files**: `frontend/vercel.json`
 - PostHog event POSTs to `/ingest/e/`, `/ingest/i/v0/e/`, `/ingest/flags/`, and `/ingest/api/surveys/` were all returning 404 because Vercel's `:path*` glob in the rewrite source didn't match trailing slashes — SvelteKit's catch-all handled them as 404s instead

--- a/changelogs/2026-04-21-remove-screenings-api-3000-cap.md
+++ b/changelogs/2026-04-21-remove-screenings-api-3000-cap.md
@@ -5,6 +5,7 @@
 ## Changes
 - `src/db/repositories/screening.ts` — Removed `limit = 3000` default and `.limit(limit)` calls from `getScreenings`, `getScreeningsByFestival`, and `getScreeningsBySeason`.
 - `src/db/repositories/screening.test.ts` — Updated mock to be thenable at any step of the query chain (terminal `.limit()` no longer called).
+- `src/app/api/screenings/route.ts` — Clamp `endDate` to `startDate + 60 days` server-side. Replaces the accidental row-count backpressure with an explicit time-window cap. The home page requests 30 days; 60 gives headroom for festival/season lookahead while preventing unbounded scans (e.g. `startDate=1970&endDate=2999`).
 
 ## Why
 The home page (`/`) fetches 30 days of screenings via the non-paginated API path. With ~60 London cinemas scraping 4–8 weeks ahead, the legacy 3000-row cap truncated the response to roughly the first 8 days, hiding everything beyond. Concrete symptom: North by Northwest at Prince Charles Cinema (May 1–12, 2026) was in the DB with full enrichment but never appeared on the home page.

--- a/changelogs/2026-04-21-remove-screenings-api-3000-cap.md
+++ b/changelogs/2026-04-21-remove-screenings-api-3000-cap.md
@@ -1,0 +1,15 @@
+# Remove 3000-screening cap from /api/screenings legacy path
+
+**Date**: 2026-04-21
+
+## Changes
+- `src/db/repositories/screening.ts` — Removed `limit = 3000` default and `.limit(limit)` calls from `getScreenings`, `getScreeningsByFestival`, and `getScreeningsBySeason`.
+- `src/db/repositories/screening.test.ts` — Updated mock to be thenable at any step of the query chain (terminal `.limit()` no longer called).
+
+## Why
+The home page (`/`) fetches 30 days of screenings via the non-paginated API path. With ~60 London cinemas scraping 4–8 weeks ahead, the legacy 3000-row cap truncated the response to roughly the first 8 days, hiding everything beyond. Concrete symptom: North by Northwest at Prince Charles Cinema (May 1–12, 2026) was in the DB with full enrichment but never appeared on the home page.
+
+## Impact
+- Home page and any other consumer of the non-paginated `/api/screenings` endpoint will now return all screenings in the requested date window.
+- Payload size grows proportionally; consumers that need paging should use the existing cursor path (`?limit=200&cursor=...`).
+- Festival and season queries are naturally bounded by slug filter, so removing their caps is safe.

--- a/src/app/api/screenings/route.ts
+++ b/src/app/api/screenings/route.ts
@@ -79,9 +79,14 @@ export async function GET(request: NextRequest) {
     const startDate = params.startDate
       ? new Date(params.startDate)
       : new Date();
-    const endDate = params.endDate
+    const requestedEnd = params.endDate
       ? new Date(params.endDate)
       : endOfDay(addDays(new Date(), 14)); // Default: 2 weeks ahead
+
+    // Clamp to a 60-day window to prevent unbounded scans.
+    // The home page requests 30 days; 60 gives headroom for festival/season lookahead.
+    const maxEnd = endOfDay(addDays(startDate, 60));
+    const endDate = requestedEnd > maxEnd ? maxEnd : requestedEnd;
 
     const filters: ScreeningFilters = {
       startDate,

--- a/src/db/repositories/screening.test.ts
+++ b/src/db/repositories/screening.test.ts
@@ -8,19 +8,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ScreeningFilters } from "./screening";
 
-// Create a chainable mock that handles all query patterns
+// Create a chainable mock that handles all query patterns.
+// The chain is thenable so `await` terminates at any step (mimics Drizzle).
 const createQueryChain = () => {
   const chain: Record<string, unknown> = {};
   const methods = ["from", "innerJoin", "where", "orderBy", "limit", "select"];
 
   methods.forEach((method) => {
-    chain[method] = vi.fn(() => {
-      if (method === "limit") {
-        return Promise.resolve([]);
-      }
-      return chain;
-    });
+    chain[method] = vi.fn(() => chain);
   });
+
+  chain.then = (resolve: (value: unknown[]) => unknown) => resolve([]);
 
   return chain;
 };

--- a/src/db/repositories/screening.ts
+++ b/src/db/repositories/screening.ts
@@ -150,8 +150,7 @@ function buildConditions(filters: ScreeningFilters): SQL[] {
  * Get screenings with film and cinema details
  */
 export async function getScreenings(
-  filters: ScreeningFilters,
-  limit = 3000
+  filters: ScreeningFilters
 ): Promise<ScreeningWithDetails[]> {
   const conditions = buildConditions(filters);
 
@@ -161,8 +160,7 @@ export async function getScreenings(
     .innerJoin(films, eq(screenings.filmId, films.id))
     .innerJoin(cinemas, eq(screenings.cinemaId, cinemas.id))
     .where(and(...conditions))
-    .orderBy(screenings.datetime)
-    .limit(limit);
+    .orderBy(screenings.datetime);
 }
 
 /**
@@ -170,8 +168,7 @@ export async function getScreenings(
  */
 export async function getScreeningsByFestival(
   festivalSlug: string,
-  filters: ScreeningFilters,
-  limit = 3000
+  filters: ScreeningFilters
 ): Promise<{ festival: { id: string } | null; screenings: FestivalScreeningDetails[] }> {
   // First, get the festival ID
   const [festival] = await db
@@ -193,8 +190,7 @@ export async function getScreeningsByFestival(
     .innerJoin(films, eq(screenings.filmId, films.id))
     .innerJoin(cinemas, eq(screenings.cinemaId, cinemas.id))
     .where(and(eq(festivalScreenings.festivalId, festival.id), ...conditions))
-    .orderBy(screenings.datetime)
-    .limit(limit);
+    .orderBy(screenings.datetime);
 
   return { festival, screenings: results };
 }
@@ -204,8 +200,7 @@ export async function getScreeningsByFestival(
  */
 export async function getScreeningsBySeason(
   seasonSlug: string,
-  filters: ScreeningFilters,
-  limit = 3000
+  filters: ScreeningFilters
 ): Promise<{ season: { id: string; name: string } | null; screenings: ScreeningWithDetails[] }> {
   // First, get the season
   const [season] = await db
@@ -236,7 +231,7 @@ export async function getScreeningsBySeason(
     filmIds,
   };
 
-  const results = await getScreenings(filtersWithFilms, limit);
+  const results = await getScreenings(filtersWithFilms);
   return { season, screenings: results };
 }
 


### PR DESCRIPTION
## Summary
- The non-paginated `/api/screenings` path capped results at 3000 rows, which at current scrape density truncated the home page's 30-day window to roughly the first 8 days. Films scheduled beyond that window were silently invisible (concrete repro: North by Northwest at Prince Charles Cinema, May 1–12, 2026 was in the DB fully enriched but never appeared on the home page).
- Removes the `limit = 3000` default and `.limit()` call from `getScreenings`, `getScreeningsByFestival`, and `getScreeningsBySeason`. Festival/season paths are naturally bounded by their slug filter; cursor-paginated consumers are unaffected.

## Test plan
- [x] `npm run test:run` — 907 / 907 pass
- [x] `npx tsc --noEmit` — clean
- [x] Live repro verified: production `/api/screenings?endDate=2026-05-21` returned only screenings up to 2026-04-29 before this change
- [ ] Post-deploy: confirm home page shows North by Northwest (May 1) and other mid-May screenings

🤖 Generated with [Claude Code](https://claude.com/claude-code)