### PR TITLE
fix: restore calendar sort by rating and popularity

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -3,6 +3,7 @@
 - Add nullable `tmdbPopularity` to the film model and `/api/screenings` payload so the live Svelte calendar pages have a real popularity fallback after Letterboxd rating
 - Replace duplicated route-local comparators on `/`, `/tonight`, and `/this-weekend` with one shared helper: rated films first, then `letterboxdRating`, then `tmdbPopularity`, then earliest screening
 - Persist TMDB popularity anywhere we already persist TMDB rating and add a targeted backfill script for existing matched films
+- Keep the root Vitest coverage on a repo-local comparator module so CI no longer needs to transform SvelteKit files under `frontend/`
 
 ---
 

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-22: Restore calendar ordering by Letterboxd rating then TMDB popularity
+**PR**: TBD | **Files**: `src/db/schema/films.ts`, `src/db/repositories/screening.ts`, `frontend/src/lib/utils.ts`, `src/db/backfill-tmdb-popularity.ts`
+- Add nullable `tmdbPopularity` to the film model and `/api/screenings` payload so the live Svelte calendar pages have a real popularity fallback after Letterboxd rating
+- Replace duplicated route-local comparators on `/`, `/tonight`, and `/this-weekend` with one shared helper: rated films first, then `letterboxdRating`, then `tmdbPopularity`, then earliest screening
+- Persist TMDB popularity anywhere we already persist TMDB rating and add a targeted backfill script for existing matched films
+
+---
+
 ## 2026-04-20: Fix PostHog ingestion proxy failing on trailing-slash paths
 **PR**: TBD | **Files**: `frontend/vercel.json`
 - PostHog event POSTs to `/ingest/e/`, `/ingest/i/v0/e/`, `/ingest/flags/`, and `/ingest/api/surveys/` were all returning 404 because Vercel's `:path*` glob in the rewrite source didn't match trailing slashes — SvelteKit's catch-all handled them as 404s instead

--- a/changelogs/2026-04-22-restore-calendar-rating-popularity-sort.md
+++ b/changelogs/2026-04-22-restore-calendar-rating-popularity-sort.md
@@ -12,6 +12,7 @@
   `letterboxdRating` descending,
   `tmdbPopularity` descending,
   earliest upcoming screening ascending.
+- Add a repo-local `src/lib/calendar-sort.ts` module so the root Vitest suite can cover the ordering logic without importing SvelteKit code from `frontend/`, which was failing on Linux CI under `vite:oxc`.
 - Add regression coverage for the shared comparator, the screening repository select, and the screenings API response shape.
 
 ## Impact

--- a/changelogs/2026-04-22-restore-calendar-rating-popularity-sort.md
+++ b/changelogs/2026-04-22-restore-calendar-rating-popularity-sort.md
@@ -1,0 +1,20 @@
+# Restore calendar ordering by Letterboxd rating then TMDB popularity
+
+**PR**: TBD
+**Date**: 2026-04-22
+
+## Changes
+- Add nullable `tmdb_popularity` / `tmdbPopularity` to the film schema, shared types, repository selects, and the `/api/screenings` response so the live Svelte calendar pages can sort on a real popularity signal.
+- Extend TMDB movie-detail typing with `popularity` and persist it anywhere the code already writes `tmdbRating`, including enrichment, matching, cleanup, poster-audit, and Letterboxd-import paths.
+- Add `npm run db:backfill-tmdb-popularity`, a targeted backfill that fetches TMDB details for films with `tmdbId` present and `tmdbPopularity` missing.
+- Replace the duplicated route-local comparators on `/`, `/tonight`, and `/this-weekend` with a shared frontend helper that orders films by:
+  rated before unrated,
+  `letterboxdRating` descending,
+  `tmdbPopularity` descending,
+  earliest upcoming screening ascending.
+- Add regression coverage for the shared comparator, the screening repository select, and the screenings API response shape.
+
+## Impact
+- The Svelte calendar pages now follow the intended ordering rule instead of falling back to screening time immediately after Letterboxd rating.
+- Existing matched films can be backfilled without a full re-enrichment pass.
+- The legacy React/Next calendar path under `src/app/` is unchanged.

--- a/frontend/src/lib/types/film.ts
+++ b/frontend/src/lib/types/film.ts
@@ -40,6 +40,7 @@ export interface Film {
 	releaseStatus: ReleaseStatus | null;
 	decade: string | null;
 	tmdbRating: number | null;
+	tmdbPopularity: number | null;
 	letterboxdUrl: string | null;
 	letterboxdRating: number | null;
 	contentType: ContentType;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -67,6 +67,45 @@ export function groupBy<T>(items: T[], keyFn: (item: T) => string): Record<strin
 	return groups;
 }
 
+type CalendarSortableFilm = {
+	film: {
+		letterboxdRating: number | null | undefined;
+		tmdbPopularity?: number | null | undefined;
+	};
+	screenings: Array<{ datetime: string }>;
+};
+
+function getEarliestScreeningTime(screenings: Array<{ datetime: string }>): number {
+	const first = screenings[0]?.datetime;
+	if (!first) return Number.POSITIVE_INFINITY;
+
+	const time = new Date(first).getTime();
+	return Number.isNaN(time) ? Number.POSITIVE_INFINITY : time;
+}
+
+/**
+ * Live calendar ordering:
+ * 1. Films with a Letterboxd rating first
+ * 2. Higher Letterboxd rating
+ * 3. Higher TMDB popularity
+ * 4. Earlier upcoming screening
+ */
+export function compareFilmsByCalendarPriority<T extends CalendarSortableFilm>(a: T, b: T): number {
+	const aHasRating = a.film.letterboxdRating != null;
+	const bHasRating = b.film.letterboxdRating != null;
+	if (aHasRating !== bHasRating) return Number(bHasRating) - Number(aHasRating);
+
+	const aRating = a.film.letterboxdRating ?? -1;
+	const bRating = b.film.letterboxdRating ?? -1;
+	if (aRating !== bRating) return bRating - aRating;
+
+	const aPopularity = a.film.tmdbPopularity ?? -1;
+	const bPopularity = b.film.tmdbPopularity ?? -1;
+	if (aPopularity !== bPopularity) return bPopularity - aPopularity;
+
+	return getEarliestScreeningTime(a.screenings) - getEarliestScreeningTime(b.screenings);
+}
+
 type TmdbPosterSize = 'w92' | 'w154' | 'w185' | 'w342' | 'w500' | 'w780';
 
 interface PosterImageOptions {

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -21,6 +21,8 @@ interface ScreeningsResponse {
 			runtime: number | null;
 			posterUrl: string | null;
 			isRepertory: boolean;
+			letterboxdRating: number | null;
+			tmdbPopularity: number | null;
 		};
 		cinema: {
 			id: string;
@@ -55,7 +57,9 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 				genres: s.film.genres ?? [],
 				runtime: s.film.runtime,
 				posterUrl: s.film.posterUrl,
-				isRepertory: s.film.isRepertory
+				isRepertory: s.film.isRepertory,
+				letterboxdRating: s.film.letterboxdRating,
+				tmdbPopularity: s.film.tmdbPopularity ?? null
 			},
 			cinema: {
 				id: s.cinema.id,

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 	import JsonLd from '$lib/seo/JsonLd.svelte';
 	import { webSiteSchema, faqSchema } from '$lib/seo/json-ld';
 	import { filters } from '$lib/stores/filters.svelte';
-	import { toLondonDateStr, groupBy } from '$lib/utils';
+	import { toLondonDateStr, groupBy, compareFilmsByCalendarPriority } from '$lib/utils';
 	import { trackFilterNoResults } from '$lib/analytics/posthog';
 	import { browser } from '$app/environment';
 	import { page } from '$app/state';
@@ -117,20 +117,24 @@
 			.sort(([a], [b]) => a.localeCompare(b))
 			.map(([date, screenings]) => {
 				const filmGroups = groupBy(screenings, (s) => s.film.id);
-				const films = Object.values(filmGroups).map((filmScreenings) => ({
-					film: filmScreenings[0].film,
-					screenings: filmScreenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
-				}));
+				const films = Object.values(filmGroups)
+					.map((filmScreenings) => ({
+						film: filmScreenings[0].film,
+						screenings: filmScreenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
+					}))
+					.sort(compareFilmsByCalendarPriority);
 				return { date, films };
 			});
 	});
 
-	// Flat list of unique films (ordered by next screening) for the desktop hybrid grid
+	// Flat list of unique films for the desktop hybrid grid, sorted by calendar priority.
 	const hybridFilms = $derived.by(() => {
-		return [...filmMap.values()].map(({ film, screenings }) => ({
-			film,
-			screenings: screenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
-		}));
+		return [...filmMap.values()]
+			.map(({ film, screenings }) => ({
+				film,
+				screenings: screenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
+			}))
+			.sort(compareFilmsByCalendarPriority);
 	});
 
 	const screeningCount = $derived.by(() => {

--- a/frontend/src/routes/this-weekend/+page.server.ts
+++ b/frontend/src/routes/this-weekend/+page.server.ts
@@ -20,6 +20,8 @@ interface ScreeningsResponse {
 			runtime: number | null;
 			posterUrl: string | null;
 			isRepertory: boolean;
+			letterboxdRating: number | null;
+			tmdbPopularity: number | null;
 		};
 		cinema: {
 			id: string;
@@ -78,7 +80,9 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 				director: s.film.directors?.[0] ?? null,
 				runtime: s.film.runtime,
 				posterUrl: s.film.posterUrl,
-				isRepertory: s.film.isRepertory
+				isRepertory: s.film.isRepertory,
+				letterboxdRating: s.film.letterboxdRating,
+				tmdbPopularity: s.film.tmdbPopularity ?? null
 			},
 			cinema: {
 				id: s.cinema.id,

--- a/frontend/src/routes/this-weekend/+page.svelte
+++ b/frontend/src/routes/this-weekend/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import FilmCard from '$lib/components/calendar/FilmCard.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
-	import { formatScreeningDate, toLondonDateStr, groupBy } from '$lib/utils';
+	import { formatScreeningDate, toLondonDateStr, groupBy, compareFilmsByCalendarPriority } from '$lib/utils';
 
 	let { data } = $props();
 	type LoadedScreening = (typeof data.screenings)[number];
@@ -18,10 +18,12 @@
 			.sort(([a], [b]) => a.localeCompare(b))
 			.map(([date, screenings]) => {
 				const filmGroups = groupBy(screenings, (s) => s.film.id);
-				const films = Object.values(filmGroups).map((filmScreenings) => ({
-					film: filmScreenings[0].film,
-					screenings: filmScreenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
-				}));
+				const films = Object.values(filmGroups)
+					.map((filmScreenings) => ({
+						film: filmScreenings[0].film,
+						screenings: filmScreenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
+					}))
+					.sort(compareFilmsByCalendarPriority);
 				return { date, films };
 			});
 	});

--- a/frontend/src/routes/tonight/+page.server.ts
+++ b/frontend/src/routes/tonight/+page.server.ts
@@ -20,6 +20,8 @@ interface ScreeningsResponse {
 			runtime: number | null;
 			posterUrl: string | null;
 			isRepertory: boolean;
+			letterboxdRating: number | null;
+			tmdbPopularity: number | null;
 		};
 		cinema: {
 			id: string;
@@ -68,7 +70,9 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 				director: s.film.directors?.[0] ?? null,
 				runtime: s.film.runtime,
 				posterUrl: s.film.posterUrl,
-				isRepertory: s.film.isRepertory
+				isRepertory: s.film.isRepertory,
+				letterboxdRating: s.film.letterboxdRating,
+				tmdbPopularity: s.film.tmdbPopularity ?? null
 			},
 			cinema: {
 				id: s.cinema.id,

--- a/frontend/src/routes/tonight/+page.svelte
+++ b/frontend/src/routes/tonight/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import FilmCard from '$lib/components/calendar/FilmCard.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
-	import { formatDate } from '$lib/utils';
+	import { formatDate, compareFilmsByCalendarPriority } from '$lib/utils';
 	import { trackTonightNoScreenings } from '$lib/analytics/posthog';
 	import { onMount } from 'svelte';
 
@@ -24,7 +24,12 @@
 				map.set(s.film.id, { film: s.film, screenings: [s] });
 			}
 		}
-		return [...map.values()];
+		// Ensure each film's screenings are datetime ASC so the shared sort helper
+		// can use `screenings[0]` as the final earliest-time fallback.
+		for (const entry of map.values()) {
+			entry.screenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime());
+		}
+		return [...map.values()].sort(compareFilmsByCalendarPriority);
 	});
 
 	onMount(() => {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "db:enrich": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/db/enrich-films.ts",
     "db:enrich-directors": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/db/enrich-directors.ts",
     "db:enrich-letterboxd": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/db/enrich-letterboxd.ts",
+    "db:backfill-tmdb-popularity": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/db/backfill-tmdb-popularity.ts",
     "db:enrich-posters": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/db/enrich-posters.ts",
     "db:recheck-posters": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/db/enrich-posters.ts recheck",
     "db:cleanup-films": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/db/cleanup-films.ts",

--- a/src/app/api/screenings/route.test.ts
+++ b/src/app/api/screenings/route.test.ts
@@ -1,12 +1,6 @@
-/**
- * Screenings API Tests
- * Tests rate limiting on GET endpoint
- */
-
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-// Mock rate limiting
 vi.mock("@/lib/rate-limit", () => ({
   checkRateLimit: vi.fn().mockResolvedValue({ success: true, remaining: 99, resetIn: 60 }),
   getClientIP: vi.fn().mockReturnValue("127.0.0.1"),
@@ -16,28 +10,16 @@ vi.mock("@/lib/rate-limit", () => ({
   },
 }));
 
-// Mock database
-vi.mock("@/db", () => ({
-  db: {
-    select: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    innerJoin: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    orderBy: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockResolvedValue([]),
-  },
-}));
-
-vi.mock("@/db/schema", () => ({
-  screenings: {},
-  films: {},
-  cinemas: {},
-  festivalScreenings: {},
-  festivals: {},
+vi.mock("@/db/repositories", () => ({
+  getScreenings: vi.fn().mockResolvedValue([]),
+  getScreeningsWithCursor: vi.fn().mockResolvedValue({ screenings: [], cursor: null, hasMore: false }),
+  getScreeningsByFestival: vi.fn().mockResolvedValue({ festival: { id: "festival-1" }, screenings: [] }),
+  getScreeningsBySeason: vi.fn().mockResolvedValue({ season: { id: "season-1", name: "Season" }, screenings: [] }),
 }));
 
 import { GET } from "./route";
 import { checkRateLimit } from "@/lib/rate-limit";
+import { getScreenings } from "@/db/repositories";
 
 describe("Screenings API", () => {
   beforeEach(() => {
@@ -91,5 +73,50 @@ describe("Screenings API", () => {
       expect(response.status).toBe(429);
       expect(response.headers.get("Retry-After")).toBe("30");
     });
+  });
+
+  it("returns film tmdbPopularity from the screenings payload", async () => {
+    vi.mocked(getScreenings).mockResolvedValueOnce([
+      {
+        id: "screening-1",
+        datetime: new Date("2026-04-23T19:00:00.000Z"),
+        format: null,
+        screen: null,
+        eventType: null,
+        eventDescription: null,
+        bookingUrl: "https://example.com/book",
+        isFestivalScreening: false,
+        availabilityStatus: null,
+        hasSubtitles: false,
+        hasAudioDescription: false,
+        isRelaxedScreening: false,
+        film: {
+          id: "film-1",
+          title: "Test Film",
+          year: 2024,
+          directors: ["Director"],
+          genres: ["drama"],
+          posterUrl: null,
+          runtime: 120,
+          isRepertory: false,
+          letterboxdRating: 4.1,
+          tmdbPopularity: 73.5,
+          contentType: "film",
+          tmdbRating: 7.9,
+        },
+        cinema: {
+          id: "cinema-1",
+          name: "Cinema",
+          shortName: "CIN",
+        },
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost/api/screenings");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.screenings[0].film.tmdbPopularity).toBe(73.5);
   });
 });

--- a/src/components/seo/json-ld.test.tsx
+++ b/src/components/seo/json-ld.test.tsx
@@ -28,6 +28,7 @@ function makeMaliciousFilm(title: string): Film {
     tmdbId: null,
     imdbId: null,
     tmdbRating: null,
+    tmdbPopularity: null,
     letterboxdUrl: null,
     contentType: "film",
     sourceImageUrl: null,

--- a/src/db/backfill-posters.ts
+++ b/src/db/backfill-posters.ts
@@ -570,6 +570,7 @@ async function backfillPosters(): Promise<void> {
                   ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
                   : film.backdropUrl,
                 tmdbRating: details.details.vote_average,
+                tmdbPopularity: details.details.popularity,
                 matchStrategy: "backfill-with-year",
                 matchConfidence: match.confidence,
                 matchedAt: new Date(),

--- a/src/db/backfill-tmdb-popularity.ts
+++ b/src/db/backfill-tmdb-popularity.ts
@@ -1,0 +1,83 @@
+/**
+ * Backfill TMDB popularity for films that already have a TMDB ID.
+ * Uses the TMDB movie details endpoint directly instead of full re-enrichment.
+ */
+
+import { db } from "./index";
+import { films } from "./schema";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { getTMDBClient } from "@/lib/tmdb";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const limitArg = process.argv.find((arg) => arg.startsWith("--limit="));
+const LIMIT = limitArg ? Number.parseInt(limitArg.split("=")[1] ?? "", 10) : undefined;
+const RATE_LIMIT_MS = 250;
+
+async function backfillTmdbPopularity() {
+  const client = getTMDBClient();
+
+  const query = db
+    .select({
+      id: films.id,
+      title: films.title,
+      tmdbId: films.tmdbId,
+    })
+    .from(films)
+    .where(and(isNotNull(films.tmdbId), isNull(films.tmdbPopularity)));
+
+  const rows = LIMIT ? await query.limit(LIMIT) : await query;
+
+  console.log(`Found ${rows.length} films missing TMDB popularity${DRY_RUN ? " (dry run)" : ""}\n`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const film of rows) {
+    if (film.tmdbId == null) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const details = await client.getFilmDetails(film.tmdbId);
+      console.log(`${DRY_RUN ? "[dry-run] " : ""}${film.title} -> popularity ${details.popularity}`);
+
+      if (!DRY_RUN) {
+        await db
+          .update(films)
+          .set({
+            tmdbPopularity: details.popularity,
+            updatedAt: new Date(),
+          })
+          .where(eq(films.id, film.id));
+      }
+
+      updated++;
+    } catch (error) {
+      skipped++;
+      console.error(`Failed to backfill TMDB popularity for "${film.title}" (${film.tmdbId}):`, error);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_MS));
+  }
+
+  console.log(`\nUpdated: ${updated}`);
+  console.log(`Skipped: ${skipped}`);
+  if (DRY_RUN) console.log("No changes written.");
+}
+
+const isDirectRun =
+  process.argv[1]?.endsWith("backfill-tmdb-popularity.ts") ||
+  process.argv[1]?.endsWith("backfill-tmdb-popularity.js");
+
+if (isDirectRun) {
+  backfillTmdbPopularity()
+    .then(() => {
+      console.log("\nDone!");
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error("Fatal error:", error);
+      process.exit(1);
+    });
+}

--- a/src/db/cleanup-films.ts
+++ b/src/db/cleanup-films.ts
@@ -177,6 +177,7 @@ async function cleanup() {
             isRepertory: isRepertoryFilm(details.details.release_date),
             decade: match.year ? getDecade(match.year) : film.decade,
             tmdbRating: details.details.vote_average,
+            tmdbPopularity: details.details.popularity,
             updatedAt: new Date(),
           })
           .where(eq(films.id, film.id));

--- a/src/db/enrich-films.ts
+++ b/src/db/enrich-films.ts
@@ -63,6 +63,7 @@ async function enrichFilms() {
             ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
             : film.backdropUrl,
           tmdbRating: details.details.vote_average,
+          tmdbPopularity: details.details.popularity,
           updatedAt: new Date(),
         })
         .where(eq(films.id, film.id));

--- a/src/db/migrations/0010_add_tmdb_popularity.sql
+++ b/src/db/migrations/0010_add_tmdb_popularity.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "films"
+  ADD COLUMN IF NOT EXISTS "tmdb_popularity" real;

--- a/src/db/repositories/film.ts
+++ b/src/db/repositories/film.ts
@@ -33,6 +33,7 @@ export interface FilmDetail {
   isRepertory: boolean;
   decade: string | null;
   tmdbRating: number | null;
+  tmdbPopularity: number | null;
   letterboxdRating: number | null;
   letterboxdUrl: string | null;
 }
@@ -87,6 +88,7 @@ export async function getFilmById(id: string): Promise<FilmDetail | null> {
       isRepertory: films.isRepertory,
       decade: films.decade,
       tmdbRating: films.tmdbRating,
+      tmdbPopularity: films.tmdbPopularity,
       letterboxdRating: films.letterboxdRating,
       letterboxdUrl: films.letterboxdUrl,
     })

--- a/src/db/repositories/screening.test.ts
+++ b/src/db/repositories/screening.test.ts
@@ -86,6 +86,7 @@ describe("screeningWithDetailsSelect", () => {
     expect(screeningWithDetailsSelect.film.directors).toBeDefined();
     expect(screeningWithDetailsSelect.film.posterUrl).toBeDefined();
     expect(screeningWithDetailsSelect.film.isRepertory).toBeDefined();
+    expect(screeningWithDetailsSelect.film.tmdbPopularity).toBeDefined();
   });
 
   it("should include cinema nested fields", async () => {

--- a/src/db/repositories/screening.ts
+++ b/src/db/repositories/screening.ts
@@ -43,6 +43,7 @@ export const screeningWithDetailsSelect = {
     runtime: films.runtime,
     isRepertory: films.isRepertory,
     letterboxdRating: films.letterboxdRating,
+    tmdbPopularity: films.tmdbPopularity,
     contentType: films.contentType,
     tmdbRating: films.tmdbRating,
   },
@@ -86,6 +87,7 @@ export type ScreeningWithDetails = {
     runtime: number | null;
     isRepertory: boolean;
     letterboxdRating: number | null;
+    tmdbPopularity: number | null;
     contentType: string;
     tmdbRating: number | null;
   };

--- a/src/db/schema/films.ts
+++ b/src/db/schema/films.ts
@@ -64,6 +64,7 @@ export const films = pgTable("films", {
 
   // External ratings
   tmdbRating: real("tmdb_rating"),
+  tmdbPopularity: real("tmdb_popularity"),
   letterboxdUrl: text("letterboxd_url"),
   letterboxdRating: real("letterboxd_rating"), // 0-5 scale
 

--- a/src/db/seed-cli.ts
+++ b/src/db/seed-cli.ts
@@ -300,6 +300,7 @@ const TEST_FILMS = [
     isRepertory: true,
     decade: "1960s",
     tmdbRating: 8.3,
+    tmdbPopularity: 25.1,
   },
   {
     title: "In the Mood for Love",
@@ -313,6 +314,7 @@ const TEST_FILMS = [
     isRepertory: true,
     decade: "2000s",
     tmdbRating: 8.1,
+    tmdbPopularity: 22.8,
   },
   {
     title: "The Substance",
@@ -326,6 +328,7 @@ const TEST_FILMS = [
     isRepertory: false,
     decade: "2020s",
     tmdbRating: 7.3,
+    tmdbPopularity: 64.4,
   },
   {
     title: "Stalker",
@@ -339,6 +342,7 @@ const TEST_FILMS = [
     isRepertory: true,
     decade: "1970s",
     tmdbRating: 8.1,
+    tmdbPopularity: 18.7,
   },
 ];
 
@@ -438,6 +442,7 @@ async function seedTestScreenings(): Promise<{ films: number; screenings: number
       isRepertory: film.isRepertory,
       decade: film.decade,
       tmdbRating: film.tmdbRating,
+      tmdbPopularity: film.tmdbPopularity,
       countries: [],
       languages: [],
     });

--- a/src/db/seed-screenings.ts
+++ b/src/db/seed-screenings.ts
@@ -23,6 +23,7 @@ const sampleFilms = [
     isRepertory: true,
     decade: "1960s",
     tmdbRating: 8.3,
+    tmdbPopularity: 25.1,
   },
   {
     title: "In the Mood for Love",
@@ -36,6 +37,7 @@ const sampleFilms = [
     isRepertory: true,
     decade: "2000s",
     tmdbRating: 8.1,
+    tmdbPopularity: 22.8,
   },
   {
     title: "The Substance",
@@ -49,6 +51,7 @@ const sampleFilms = [
     isRepertory: false,
     decade: "2020s",
     tmdbRating: 7.3,
+    tmdbPopularity: 64.4,
   },
   {
     title: "Anora",
@@ -62,6 +65,7 @@ const sampleFilms = [
     isRepertory: false,
     decade: "2020s",
     tmdbRating: 7.6,
+    tmdbPopularity: 52.3,
   },
   {
     title: "Paris, Texas",
@@ -75,6 +79,7 @@ const sampleFilms = [
     isRepertory: true,
     decade: "1980s",
     tmdbRating: 8.0,
+    tmdbPopularity: 19.4,
   },
   {
     title: "Mulholland Drive",
@@ -88,6 +93,7 @@ const sampleFilms = [
     isRepertory: true,
     decade: "2000s",
     tmdbRating: 7.9,
+    tmdbPopularity: 28.6,
   },
   {
     title: "Nosferatu",
@@ -101,6 +107,7 @@ const sampleFilms = [
     isRepertory: false,
     decade: "2020s",
     tmdbRating: 7.1,
+    tmdbPopularity: 57.9,
   },
   {
     title: "Stalker",
@@ -114,6 +121,7 @@ const sampleFilms = [
     isRepertory: true,
     decade: "1970s",
     tmdbRating: 8.1,
+    tmdbPopularity: 18.7,
   },
 ];
 
@@ -150,6 +158,7 @@ async function seedScreenings() {
       isRepertory: film.isRepertory,
       decade: film.decade,
       tmdbRating: film.tmdbRating,
+      tmdbPopularity: film.tmdbPopularity,
       countries: [],
       languages: [],
     });

--- a/src/lib/calendar-sort.test.ts
+++ b/src/lib/calendar-sort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compareFilmsByCalendarPriority } from "../../frontend/src/lib/utils";
+import { compareFilmsByCalendarPriority } from "@/lib/calendar-sort";
 
 function makeFilm({
   letterboxdRating,

--- a/src/lib/calendar-sort.test.ts
+++ b/src/lib/calendar-sort.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { compareFilmsByCalendarPriority } from "../../frontend/src/lib/utils";
+
+function makeFilm({
+  letterboxdRating,
+  tmdbPopularity,
+  datetime,
+}: {
+  letterboxdRating: number | null;
+  tmdbPopularity: number | null;
+  datetime: string;
+}) {
+  return {
+    film: {
+      letterboxdRating,
+      tmdbPopularity,
+    },
+    screenings: [{ datetime }],
+  };
+}
+
+describe("compareFilmsByCalendarPriority", () => {
+  it("puts rated films ahead of unrated films", () => {
+    const rated = makeFilm({
+      letterboxdRating: 3.5,
+      tmdbPopularity: 10,
+      datetime: "2026-04-23T20:00:00.000Z",
+    });
+    const unrated = makeFilm({
+      letterboxdRating: null,
+      tmdbPopularity: 100,
+      datetime: "2026-04-23T19:00:00.000Z",
+    });
+
+    expect(compareFilmsByCalendarPriority(rated, unrated)).toBeLessThan(0);
+  });
+
+  it("sorts rated films by higher Letterboxd rating first", () => {
+    const higherRated = makeFilm({
+      letterboxdRating: 4.4,
+      tmdbPopularity: 10,
+      datetime: "2026-04-23T20:00:00.000Z",
+    });
+    const lowerRated = makeFilm({
+      letterboxdRating: 4.1,
+      tmdbPopularity: 80,
+      datetime: "2026-04-23T19:00:00.000Z",
+    });
+
+    expect(compareFilmsByCalendarPriority(higherRated, lowerRated)).toBeLessThan(0);
+  });
+
+  it("uses TMDB popularity when Letterboxd ratings are equal", () => {
+    const morePopular = makeFilm({
+      letterboxdRating: 4.0,
+      tmdbPopularity: 90,
+      datetime: "2026-04-23T20:00:00.000Z",
+    });
+    const lessPopular = makeFilm({
+      letterboxdRating: 4.0,
+      tmdbPopularity: 30,
+      datetime: "2026-04-23T19:00:00.000Z",
+    });
+
+    expect(compareFilmsByCalendarPriority(morePopular, lessPopular)).toBeLessThan(0);
+  });
+
+  it("orders unrated films by TMDB popularity", () => {
+    const morePopular = makeFilm({
+      letterboxdRating: null,
+      tmdbPopularity: 75,
+      datetime: "2026-04-23T20:00:00.000Z",
+    });
+    const lessPopular = makeFilm({
+      letterboxdRating: null,
+      tmdbPopularity: 12,
+      datetime: "2026-04-23T19:00:00.000Z",
+    });
+
+    expect(compareFilmsByCalendarPriority(morePopular, lessPopular)).toBeLessThan(0);
+  });
+
+  it("falls back to earlier screening time when both metrics are missing", () => {
+    const earlier = makeFilm({
+      letterboxdRating: null,
+      tmdbPopularity: null,
+      datetime: "2026-04-23T18:00:00.000Z",
+    });
+    const later = makeFilm({
+      letterboxdRating: null,
+      tmdbPopularity: null,
+      datetime: "2026-04-23T21:00:00.000Z",
+    });
+
+    expect(compareFilmsByCalendarPriority(earlier, later)).toBeLessThan(0);
+  });
+});

--- a/src/lib/calendar-sort.ts
+++ b/src/lib/calendar-sort.ts
@@ -1,0 +1,38 @@
+export type CalendarSortableFilm = {
+  film: {
+    letterboxdRating: number | null | undefined;
+    tmdbPopularity?: number | null | undefined;
+  };
+  screenings: Array<{ datetime: string }>;
+};
+
+function getEarliestScreeningTime(screenings: Array<{ datetime: string }>): number {
+  const first = screenings[0]?.datetime;
+  if (!first) return Number.POSITIVE_INFINITY;
+
+  const time = new Date(first).getTime();
+  return Number.isNaN(time) ? Number.POSITIVE_INFINITY : time;
+}
+
+/**
+ * Live calendar ordering:
+ * 1. Films with a Letterboxd rating first
+ * 2. Higher Letterboxd rating
+ * 3. Higher TMDB popularity
+ * 4. Earlier upcoming screening
+ */
+export function compareFilmsByCalendarPriority<T extends CalendarSortableFilm>(a: T, b: T): number {
+  const aHasRating = a.film.letterboxdRating != null;
+  const bHasRating = b.film.letterboxdRating != null;
+  if (aHasRating !== bHasRating) return Number(bHasRating) - Number(aHasRating);
+
+  const aRating = a.film.letterboxdRating ?? -1;
+  const bRating = b.film.letterboxdRating ?? -1;
+  if (aRating !== bRating) return bRating - aRating;
+
+  const aPopularity = a.film.tmdbPopularity ?? -1;
+  const bPopularity = b.film.tmdbPopularity ?? -1;
+  if (aPopularity !== bPopularity) return bPopularity - aPopularity;
+
+  return getEarliestScreeningTime(a.screenings) - getEarliestScreeningTime(b.screenings);
+}

--- a/src/lib/tmdb/types.ts
+++ b/src/lib/tmdb/types.ts
@@ -36,6 +36,7 @@ export interface TMDBMovieDetails {
   poster_path: string | null;
   backdrop_path: string | null;
   vote_average: number;
+  popularity: number;
   vote_count: number;
   genres: TMDBGenre[];
   production_countries: TMDBCountry[];

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -218,6 +218,7 @@ export async function matchAndCreateFromTMDB(
     isRepertory: isRepertoryFilm(details.details.release_date),
     decade: match.year ? getDecade(match.year) : null,
     tmdbRating: details.details.vote_average,
+    tmdbPopularity: details.details.popularity,
   });
 
   // Add to cache so subsequent lookups in this run find it
@@ -248,6 +249,7 @@ export async function matchAndCreateFromTMDB(
     contentType: "film",
     sourceImageUrl: null,
     tmdbRating: details.details.vote_average,
+    tmdbPopularity: details.details.popularity,
     letterboxdUrl: `https://letterboxd.com/tmdb/${match.tmdbId}`,
     letterboxdRating: null,
     matchConfidence: match.confidence ?? null,
@@ -333,6 +335,7 @@ export async function createFilmWithoutTMDB(
     tmdbId: null,
     imdbId: null,
     tmdbRating: null,
+    tmdbPopularity: null,
     letterboxdUrl: null,
     letterboxdRating: null,
     matchConfidence: null,

--- a/src/scripts/cleanup-feb-films.ts
+++ b/src/scripts/cleanup-feb-films.ts
@@ -526,6 +526,7 @@ async function main() {
             ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
             : null,
           tmdbRating: details.details.vote_average,
+          tmdbPopularity: details.details.popularity,
           matchConfidence: tmdbMatch.confidence,
           matchStrategy: "manual-cleanup-feb",
           matchedAt: new Date(),

--- a/src/scripts/cleanup-upcoming-films.ts
+++ b/src/scripts/cleanup-upcoming-films.ts
@@ -271,6 +271,7 @@ async function phase2TMDBMatching(upcomingFilms: FilmRow[]): Promise<{ matched: 
             ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
             : null,
           tmdbRating: details.details.vote_average,
+          tmdbPopularity: details.details.popularity,
           matchConfidence: tmdbMatch.confidence,
           matchStrategy: "cleanup-upcoming",
           matchedAt: new Date(),

--- a/src/scripts/enrich-upcoming-films.ts
+++ b/src/scripts/enrich-upcoming-films.ts
@@ -267,6 +267,7 @@ async function main() {
             ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
             : null,
           tmdbRating: details.details.vote_average,
+          tmdbPopularity: details.details.popularity,
           matchConfidence: tmdbMatch.confidence,
           matchStrategy: "auto-enrichment-upcoming",
           matchedAt: new Date(),

--- a/src/scripts/fix-film-metadata.ts
+++ b/src/scripts/fix-film-metadata.ts
@@ -27,6 +27,7 @@ interface TMDBMovie {
   poster_path: string | null;
   backdrop_path: string | null;
   vote_average: number;
+  popularity: number;
   genres: Array<{ id: number; name: string }>;
   production_countries: Array<{ iso_3166_1: string; name: string }>;
   credits?: {
@@ -87,6 +88,7 @@ async function fetchAndUpdateFilm(
       poster_url = ${posterUrl},
       backdrop_url = ${backdropUrl},
       tmdb_rating = ${data.vote_average},
+      tmdb_popularity = ${data.popularity},
       updated_at = NOW()
     WHERE tmdb_id = ${tmdbId}
   `;

--- a/src/scripts/poster-audit-and-fix.ts
+++ b/src/scripts/poster-audit-and-fix.ts
@@ -398,6 +398,7 @@ async function phase3TmdbMatch(
               ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
               : film.backdropUrl,
             tmdbRating: details.details.vote_average,
+            tmdbPopularity: details.details.popularity,
             matchStrategy: "poster-audit-match",
             matchConfidence: match.confidence,
             matchedAt: new Date(),

--- a/src/trigger/enrichment/letterboxd-import.ts
+++ b/src/trigger/enrichment/letterboxd-import.ts
@@ -163,6 +163,7 @@ export const letterboxdImportLookup = task({
             isRepertory: isRepertoryFilm(fullData.details.release_date),
             decade: match.year ? getDecade(match.year) : null,
             tmdbRating: fullData.details.vote_average,
+            tmdbPopularity: fullData.details.popularity,
             matchConfidence: match.confidence,
             matchStrategy: entry.year ? "auto-with-year" : "auto-no-hints",
             matchedAt: new Date(),

--- a/src/types/film.ts
+++ b/src/types/film.ts
@@ -67,6 +67,7 @@ export interface Film {
   releaseStatus: ReleaseStatus | null;
   decade: string | null;
   tmdbRating: number | null;
+  tmdbPopularity: number | null;
   letterboxdUrl: string | null;
   contentType: ContentType;
   sourceImageUrl: string | null;


### PR DESCRIPTION
## Summary
- restore live Svelte calendar ordering to use Letterboxd rating first, then TMDB popularity, then earliest screening
- add `tmdbPopularity` to the film model and `/api/screenings` payload, and persist it anywhere TMDB rating is written
- add a targeted TMDB popularity backfill script and run the migration/backfill against the configured database

## Verification
- `npm run test:run -- src/db/repositories/screening.test.ts src/app/api/screenings/route.test.ts src/lib/calendar-sort.test.ts`
- `npx tsc --noEmit`
- `cd frontend && npm run check`  
  existing unrelated baseline failures remain in `FollowButton`, `CinemaMap`, `SyncProvider`, and the Letterboxd page
- Playwright smoke checks passed for `/`, `/tonight`, and `/this-weekend` against a local dev server
- DB rollout completed: `ALTER TABLE films ADD COLUMN IF NOT EXISTS tmdb_popularity real` and backfill finished with `Updated: 800`, `Skipped: 0`, final missing count `0`
