### PR TITLE
fix(homepage): default listings to today when no date selected

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-04-25: Homepage listings default to today (matches masthead)
-**PR**: TBD | **Files**: `frontend/src/routes/+page.svelte`
+**PR**: #445 | **Files**: `frontend/src/routes/+page.svelte`
 - The desktop hybrid grid was rendering the full 30-day screenings payload under each poster whenever no date filter was set, even though the day masthead already framed the page as "today". Listings now default to today's London date when neither `dateFrom` nor `dateTo` is selected.
 - Replaced the `s.datetime.split('T')[0]` UTC-date extraction with `toLondonDateStr(s.datetime)` so late-night BST screenings sit on the correct civil day for comparison with the London-time filter values and the day-grouped mobile sections.
 - Multi-day presets (Weekend, 7 days) and explicit Pick-date selections are unaffected because they set both `dateFrom` and `dateTo` and bypass the new default.

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-25: Homepage listings default to today (matches masthead)
+**PR**: TBD | **Files**: `frontend/src/routes/+page.svelte`
+- The desktop hybrid grid was rendering the full 30-day screenings payload under each poster whenever no date filter was set, even though the day masthead already framed the page as "today". Listings now default to today's London date when neither `dateFrom` nor `dateTo` is selected.
+- Replaced the `s.datetime.split('T')[0]` UTC-date extraction with `toLondonDateStr(s.datetime)` so late-night BST screenings sit on the correct civil day for comparison with the London-time filter values and the day-grouped mobile sections.
+- Multi-day presets (Weekend, 7 days) and explicit Pick-date selections are unaffected because they set both `dateFrom` and `dateTo` and bypass the new default.
+
+---
+
 ## 2026-04-22: Restore calendar ordering by Letterboxd rating then TMDB popularity
 **PR**: #444 | **Files**: `src/db/schema/films.ts`, `src/db/repositories/screening.ts`, `frontend/src/lib/utils.ts`, `src/lib/calendar-sort.ts`, `src/db/backfill-tmdb-popularity.ts`
 - Add nullable `tmdbPopularity` to the film model and `/api/screenings` payload so the live Svelte calendar pages have a real popularity fallback after Letterboxd rating

--- a/changelogs/2026-04-25-fix-homepage-date-filter-default.md
+++ b/changelogs/2026-04-25-fix-homepage-date-filter-default.md
@@ -1,0 +1,24 @@
+# Homepage listings default to today (matches masthead)
+
+**PR**: TBD
+**Date**: 2026-04-25
+
+## Changes
+- `frontend/src/routes/+page.svelte` — `filmMap` derivation now treats `filters.dateFrom`/`filters.dateTo` of `null` as "today" (London civil date) so the listings rendered under each poster on the homepage match the date implicit in the day masthead. The existing logic short-circuited the date filter entirely when no range was set, leaking the full 30-day payload from `/+page.server.ts` into the grid.
+- Date comparison now uses `toLondonDateStr(s.datetime)` instead of `s.datetime.split('T')[0]`. The previous form took the **UTC** date portion of the ISO string, which disagrees with the London-time `dateFrom`/`dateTo` strings produced by `setDatePreset` and `selectDate`. For BST overnight screenings (e.g. 00:30 London = 23:30 UTC the previous day) this caused off-by-one date filtering — a screening that London considers "tomorrow" was excluded when "tomorrow" was selected.
+
+## Why
+The day masthead derives `activeDate = filters.dateFrom ?? today` and renders a single-day headline ("Saturday, the twenty-fifth"). Users on the desktop hybrid grid saw that single-day headline above a film card whose three "next showings" actually spanned multiple future days, because the underlying derived state silently skipped the date filter when nothing was selected. This mismatch is the bug the user reported: "the listings underneath each poster show ones that are not on this date but just all the listings."
+
+## Verification
+- Local Playwright run on `http://localhost:5173/` (1440×900): all 190 desktop screening times rendered carry a London-time `datetime` of 2026-04-25 (today) before any interaction. After clicking the next-day strip button, all 116 visible times shift to 2026-04-26.
+- Mobile (390×844): the mobile day-section list now contains a single section with today's date; previously it included sections for every day in the next 30.
+- The "Pick date opens calendar popover" homepage test failed before this change too — confirmed pre-existing flakiness, not a regression.
+
+## Impact
+- **Users**: the homepage now shows the same day on the masthead, the day strip, the desktop grid, and the mobile day list — they all agree.
+- **No API change**: `/+page.server.ts` still loads the 30-day window, so navigating future days via the strip remains instant (no extra fetch).
+- **No store change**: `filters.dateFrom`/`dateTo` stay nullable; "Today" still resolves to `null`. Multi-day presets (`weekend`, `7days`) and explicit Pick-date ranges are unaffected.
+
+## Files
+- `frontend/src/routes/+page.svelte`

--- a/changelogs/2026-04-25-fix-homepage-date-filter-default.md
+++ b/changelogs/2026-04-25-fix-homepage-date-filter-default.md
@@ -1,6 +1,6 @@
 # Homepage listings default to today (matches masthead)
 
-**PR**: TBD
+**PR**: #445
 **Date**: 2026-04-25
 
 ## Changes

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -44,6 +44,14 @@
 			screenings: (typeof data.screenings)[0][];
 		}>();
 		const now = Date.now();
+		// Default to today (London) when no explicit range is set so listings
+		// match the masthead, which already shows today as the active date.
+		// Invariant: both setters always assign dateFrom and dateTo together
+		// (filters.svelte.ts setDatePreset, DayMasthead.svelte selectDate). If
+		// that ever changes, swap effectiveTo's default for a far-future bound.
+		const today = toLondonDateStr(new Date());
+		const effectiveFrom = filters.dateFrom ?? today;
+		const effectiveTo = filters.dateTo ?? today;
 
 		for (const s of data.screenings) {
 			if (!s.film) continue;
@@ -59,11 +67,12 @@
 			}
 			if (filters.cinemaIds.length > 0 && !filters.cinemaIds.includes(s.cinema?.id ?? '')) continue;
 
-			if (filters.dateFrom || filters.dateTo) {
-				const dateStr = s.datetime.split('T')[0];
-				if (filters.dateFrom && dateStr < filters.dateFrom) continue;
-				if (filters.dateTo && dateStr > filters.dateTo) continue;
-			}
+			// Compare London civil dates: late-night BST screenings have a UTC
+			// date that rolls back a day; toLondonDateStr keeps them on the
+			// right calendar day, matching the masthead and date filter.
+			const dateStr = toLondonDateStr(s.datetime);
+			if (dateStr < effectiveFrom) continue;
+			if (dateStr > effectiveTo) continue;
 
 			if (filters.formats.length > 0 && (!s.format || !filters.formats.includes(s.format))) continue;
 


### PR DESCRIPTION
## Summary
- The desktop hybrid grid was rendering up to three screenings per film card spanning the full 30-day payload from `+page.server.ts`, even though the day masthead always shows a single-day headline (defaulting to today). When no date filter was selected the `filmMap` derivation skipped the date predicate entirely, so the headline disagreed with the listings beneath every poster.
- `frontend/src/routes/+page.svelte` now treats `filters.dateFrom`/`filters.dateTo` of `null` as today's London civil date inside `filmMap`, and switches the per-screening compare from `s.datetime.split('T')[0]` (UTC date portion) to `toLondonDateStr(s.datetime)` so late-night BST screenings sit on the correct calendar day.
- Multi-day presets (`Weekend`, `7 days`) and explicit Pick-date selections are unaffected — both setters always assign `dateFrom` and `dateTo` together, so the new default only fires when nothing is set.

## Test plan
- [x] Local Playwright check at 1440×900: all desktop screening times on `/` carry a `datetime` matching today (London); clicking a future-day strip button narrows them to that single date.
- [x] Mobile (390×844): the day-grouped list collapses to a single section for today; previously it included sections for every day in the next 30.
- [x] `npx svelte-check --threshold error` — no new errors (11 pre-existing in unrelated files).
- [x] `Homepage` Playwright describe block: 14 passed; the one "Pick date popover" failure reproduces on `main` without this change (pre-existing flake).
- [ ] Verify on Vercel preview that the day strip and "Pick date" calendar still drive the listings as expected after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)