### PR TITLE
fix(frontend): mismatched posters when filter is persisted in localStorage

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-04-25: Fix poster/title mismatch on hydration when filter is persisted
+**PR**: TBD | **Files**: `frontend/src/lib/stores/filters.svelte.ts`, `frontend/test-all.spec.ts`
+- Cards on the homepage were rendering the SSR'd "All" view's poster image alongside the persisted "New" view's title — Harakiri's poster under "It's Never Over, Jeff Buckley", Stop Making Sense's poster under "One Battle After Another", etc.
+- Root cause: `filters.svelte.ts` initialized `programmingTypes` (and friends) from `localStorage` synchronously at module load. The server initialised the same state with `[]`, so SSR and the initial CSR `$derived` produced different top-N films. Svelte 5's keyed `{#each}` block updated text content for the new film set but left `<img src>` attributes bound to the SSR markup, leaving every card visually misaligned.
+- Fix: defer the persisted-state load until after Svelte's hydration commit (two `requestAnimationFrame`s), so SSR and initial CSR always match. The persisted filter is then applied via the same reactive path as a user click — which already worked correctly.
+- Added a regression Playwright test that loads the page with `programmingTypes: ['new_release']` in `localStorage` and asserts the resulting title→poster pairs equal the pairs produced by clicking the New tab.
+
+---
+
 ## 2026-04-22: Restore calendar ordering by Letterboxd rating then TMDB popularity
 **PR**: #444 | **Files**: `src/db/schema/films.ts`, `src/db/repositories/screening.ts`, `frontend/src/lib/utils.ts`, `src/lib/calendar-sort.ts`, `src/db/backfill-tmdb-popularity.ts`
 - Add nullable `tmdbPopularity` to the film model and `/api/screenings` payload so the live Svelte calendar pages have a real popularity fallback after Letterboxd rating

--- a/changelogs/2026-04-25-fix-poster-title-mismatch.md
+++ b/changelogs/2026-04-25-fix-poster-title-mismatch.md
@@ -1,0 +1,101 @@
+# Fix poster/title mismatch on hydration when filter is persisted
+
+**PR**: TBD
+**Date**: 2026-04-25
+
+## Symptom
+
+Users with the **New** (or any other) filter persisted in `localStorage` from
+a previous visit saw mismatched film posters on the desktop homepage grid.
+For example:
+
+| Slot | Title shown                                        | Poster image actually rendered |
+|------|----------------------------------------------------|--------------------------------|
+| 0    | It's Never Over, Jeff Buckley                      | Harakiri                       |
+| 1    | One Battle After Another                           | Stop Making Sense              |
+| 2    | Wolfwalkers                                        | 12 Angry Men                   |
+| 3    | Hamnet                                             | Come and See                   |
+| 4    | Cine-Real presents: North by Northwest             | Seven Samurai                  |
+
+The titles, byline, runtime and screenings list were correct for the named
+films. Only the `<img src>` was wrong — and consistently the SSR-rendered
+"All" view's top films appeared in place of the "New" view's posters.
+
+## Root cause
+
+`frontend/src/lib/stores/filters.svelte.ts` initialised the persisted filter
+fields (`cinemaIds`, `formats`, `programmingTypes`, `genres`, `decades`)
+synchronously at module load:
+
+```ts
+const persisted = loadPersisted(); // {} on server, real data on client
+let programmingTypes = $state(persisted.programmingTypes ?? []);
+```
+
+This produced a SSR/CSR hydration mismatch:
+
+1. The server rendered with `programmingTypes = []` → Akira / Fight Club / etc. at the top of `hybridFilms`.
+2. The client hydrated with `programmingTypes = ['new_release']` → Project Hail Mary / The Drama / etc.
+3. Svelte 5's keyed `{#each films as { film, ... } (film.id)}` block correctly updated text content (titles, bylines) but failed to update `<img src>` / `<img srcset>` attributes when the keys at every position changed during hydration.
+
+The text content updated reactively, the image attributes did not — so every
+card displayed a poster from a different film than the one named.
+
+## Fix
+
+Defer the persisted-state load until after Svelte's hydration commit so the
+initial client render matches the server render. Once that's true, the
+keyed-`{#each}` block never has to reconcile a wholesale key change during
+hydration; the persisted filter is applied via the same reactive path as a
+user clicking the tab, which already worked correctly.
+
+Implemented with a double `requestAnimationFrame` callback:
+
+```ts
+if (browser) {
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            const persisted = loadPersisted();
+            if (persisted.cinemaIds?.length) cinemaIds = persisted.cinemaIds;
+            // …
+            hydrated = true;
+        });
+    });
+}
+```
+
+`queueMicrotask` was tried first but fires too close to hydration and
+re-triggers the same Svelte bug. Two RAFs guarantee we run after the first
+paint, when reactivity has fully settled.
+
+The persistence `$effect` is gated on the `hydrated` flag so we don't write
+the SSR defaults back to `localStorage` before the persisted values have
+been re-applied.
+
+## Verification
+
+- Manually reproduced the bug by setting `localStorage['pictures-filters'] = {programmingTypes: ['new_release']}` on prod (`pictures.london`) and reloading — observed Harakiri's poster under the Jeff Buckley title.
+- Manually verified the fix on the dev server with the same `localStorage` setup — title/poster pairs now match.
+- Added a Playwright regression test (`test-all.spec.ts`) that:
+  1. Loads the page, clicks the New tab, captures title→poster pairs.
+  2. Reloads the page with `programmingTypes: ['new_release']` persisted in `localStorage`.
+  3. Polls the rendered cards until they equal the captured pairs (`expect.poll`).
+
+## Impact
+
+- All visitors with any non-default persisted filter (cinemaIds, formats,
+  programmingTypes, genres, decades) — the bug affected every persisted
+  filter field, but `programmingTypes` was by far the most visible because
+  toggling it changes the entire top of the calendar.
+- Brief (≤1 frame) "All" view flicker on first paint when a persisted
+  filter is active. The user-visible content corruption is gone in
+  exchange.
+
+## Follow-up
+
+The deeper Svelte 5 keyed-`{#each}` hydration bug — that `<img src>` /
+`<img srcset>` attributes don't update when every key in an each-block
+changes during hydration — remains. We've worked around it by ensuring
+keys never change during hydration, but the underlying engine bug should
+be reported upstream and a more architectural fix (e.g. cookie-backed
+filter state read in `+page.server.ts`) considered if it recurs.

--- a/frontend/src/lib/stores/filters.svelte.ts
+++ b/frontend/src/lib/stores/filters.svelte.ts
@@ -21,27 +21,47 @@ function loadPersisted(): Partial<PersistedFilters> {
 	}
 }
 
-const persisted = loadPersisted();
-
-// Filter state — Svelte 5 runes module
+// Filter state starts with SSR-safe defaults on both server and client.
+// Persisted state is applied after hydration via a microtask — applying it
+// synchronously here creates an SSR/CSR mismatch where Svelte 5's keyed
+// {#each} block leaves stale <img src> attributes on cards whose keys
+// changed during hydration (mismatched posters / titles).
 let filmSearch = $state('');
-let cinemaIds = $state<string[]>(persisted.cinemaIds ?? []);
+let cinemaIds = $state<string[]>([]);
 let dateFrom = $state<string | null>(null);
 let dateTo = $state<string | null>(null);
 let timeFrom = $state<number | null>(null);
 let timeTo = $state<number | null>(null);
-let formats = $state<string[]>(persisted.formats ?? []);
-let programmingTypes = $state<FilterProgrammingType[]>(persisted.programmingTypes ?? []);
-let genres = $state<string[]>(persisted.genres ?? []);
-let decades = $state<string[]>(persisted.decades ?? []);
+let formats = $state<string[]>([]);
+let programmingTypes = $state<FilterProgrammingType[]>([]);
+let genres = $state<string[]>([]);
+let decades = $state<string[]>([]);
 let hideSeen = $state(false);
 let hideNotInterested = $state(true);
 let showSoldOut = $state(false);
 
-// Persist selected fields to localStorage
+let hydrated = false;
+
 if (browser) {
+	// Two RAFs guarantee we run after Svelte's hydration commit and the
+	// first paint. queueMicrotask fires too close to hydration and trips a
+	// keyed-{#each} bug where <img src> attributes don't pick up the new
+	// reactive value when the each-block keys change.
+	requestAnimationFrame(() => {
+		requestAnimationFrame(() => {
+			const persisted = loadPersisted();
+			if (persisted.cinemaIds?.length) cinemaIds = persisted.cinemaIds;
+			if (persisted.formats?.length) formats = persisted.formats;
+			if (persisted.programmingTypes?.length) programmingTypes = persisted.programmingTypes;
+			if (persisted.genres?.length) genres = persisted.genres;
+			if (persisted.decades?.length) decades = persisted.decades;
+			hydrated = true;
+		});
+	});
+
 	$effect.root(() => {
 		$effect(() => {
+			// Track all persisted fields so the effect re-runs when any change.
 			const data: PersistedFilters = {
 				cinemaIds,
 				formats,
@@ -49,6 +69,9 @@ if (browser) {
 				genres,
 				decades
 			};
+			// Skip until persisted state has been applied; otherwise the first
+			// run would clobber localStorage with the SSR defaults.
+			if (!hydrated) return;
 			localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 		});
 	});

--- a/frontend/test-all.spec.ts
+++ b/frontend/test-all.spec.ts
@@ -96,6 +96,60 @@ test.describe('Pictures London — SvelteKit Frontend', () => {
 			expect(repCount).toBeLessThanOrEqual(allCount);
 		});
 
+		test('persisted New filter renders matching posters and titles', async ({ page, context }) => {
+			// Regression for fix/poster-title-mismatch: persisted filter loaded
+			// at module init produced a SSR/CSR hydration mismatch where titles
+			// updated to the new film set but <img src> attributes stayed bound
+			// to the SSR'd "All" view's films. This test loads the page with a
+			// New filter persisted in localStorage and confirms each card's
+			// poster URL matches the title set produced by clicking the tab.
+			await page.setViewportSize({ width: 1440, height: 900 });
+
+			const readPairs = () =>
+				page.evaluate(() =>
+					Array.from(document.querySelectorAll('article.film-card')).slice(0, 5).map((c) => ({
+						title: c.querySelector('h3.film-title')?.textContent?.trim() ?? '',
+						imgSrc: (c.querySelector('img') as HTMLImageElement | null)?.src ?? ''
+					}))
+				);
+
+			// Capture title→poster pairs from clicking the New tab on a fresh page.
+			await page.goto(BASE);
+			await page.waitForSelector('.film-card', { timeout: 10000 });
+			await page.locator('.desktop-toolbar').getByRole('tab', { name: 'New', exact: true }).click();
+			await expect(
+				page.locator('.desktop-toolbar [role="tab"][aria-selected="true"]')
+			).toHaveText('New');
+			await page.waitForTimeout(800);
+			const expected = await readPairs();
+			expect(expected.length).toBe(5);
+			// Sanity: titles are unique per card (catches obvious render glitches).
+			expect(new Set(expected.map((p) => p.title)).size).toBe(expected.length);
+
+			// Persist the New filter, reload, and verify the same pairings appear.
+			await context.addInitScript(() => {
+				try {
+					localStorage.setItem(
+						'pictures-filters',
+						JSON.stringify({
+							cinemaIds: [],
+							formats: [],
+							programmingTypes: ['new_release'],
+							genres: [],
+							decades: []
+						})
+					);
+				} catch { /* ignore */ }
+			});
+			await page.goto(BASE);
+			await page.waitForSelector('.film-card', { timeout: 10000 });
+			await expect(
+				page.locator('.desktop-toolbar [role="tab"][aria-selected="true"]')
+			).toHaveText('New');
+			// Poll for the deferred persisted-state apply to settle.
+			await expect.poll(readPairs, { timeout: 5000 }).toEqual(expected);
+		});
+
 		test('cinema area chip narrows results', async ({ page }) => {
 			await page.setViewportSize({ width: 1440, height: 900 });
 			await page.goto(BASE);


### PR DESCRIPTION
## Summary
- Cards on the homepage were rendering the SSR'd *All* view's poster image alongside the persisted *New* view's title — Harakiri's poster under *It's Never Over, Jeff Buckley*, Stop Making Sense's poster under *One Battle After Another*, etc.
- Root cause: `filters.svelte.ts` initialised `programmingTypes` (and friends) from `localStorage` synchronously at module load, producing an SSR/CSR hydration mismatch. The server saw `[]`; the client saw `['new_release']`. Svelte 5's keyed `{#each ... (film.id)}` block updated text content during hydration but left `<img src>` bound to the SSR markup.
- Fix: defer the persisted-state load until after Svelte's hydration commit (two `requestAnimationFrame`s). With matching SSR/CSR initial state, the persisted filter is then applied via the same reactive path as a user click, which already worked correctly. The persistence `$effect` is gated on a `hydrated` flag so the SSR defaults aren't written back to `localStorage`.
- See `changelogs/2026-04-25-fix-poster-title-mismatch.md` for full diagnosis and context.

## Test plan
- [x] Manual reproduction on prod (`pictures.london`) by seeding `localStorage['pictures-filters'] = {programmingTypes: ['new_release']}` and reloading — confirmed mismatched posters before fix.
- [x] Manual verification on the dev server with the same seeded `localStorage` — title/poster pairs now match.
- [x] Manual verification of the no-`localStorage` first-time-visitor path — All view renders correctly, `localStorage` is not pre-populated.
- [x] Manual verification of tab transitions (All → Repertory → New → All) — all transitions render correct title/poster pairs.
- [x] New Playwright regression test (`test-all.spec.ts:99`) using `expect.poll` to assert the persisted-filter reload renders identical pairs to the click-to-New flow. Passes on the first try with `--retries=0`.
- [x] `svelte-check` — only pre-existing errors in unrelated files (`festivals/[slug]/+page.ts`, `letterboxd/+page.svelte`, `CinemaMap.svelte`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)