### PR TITLE
test(homepage): lock in date-filter default with Playwright assertion

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-04-25: Lock-in test for homepage date-filter default
+**PR**: TBD | **Files**: `frontend/test-all.spec.ts`
+- Adds the regression test the #445 review flagged: on initial homepage load, every screening time visible in the desktop hybrid grid resolves to today's London date; clicking the next-day strip button narrows them to a single non-today date.
+- One assertion catches both halves of the original bug — a leaked future-day screening or a UTC-vs-London string mismatch would surface as a `datetime` whose London date isn't today.
+
+---
+
 ## 2026-04-25: Fix poster/title mismatch on hydration when filter is persisted
 **PR**: #446 | **Files**: `frontend/src/lib/stores/filters.svelte.ts`, `frontend/test-all.spec.ts`
 - Cards on the homepage were rendering the SSR'd "All" view's poster image alongside the persisted "New" view's title — Harakiri's poster under "It's Never Over, Jeff Buckley", Stop Making Sense's poster under "One Battle After Another", etc.

--- a/changelogs/2026-04-25-test-homepage-date-filter-lockin.md
+++ b/changelogs/2026-04-25-test-homepage-date-filter-lockin.md
@@ -1,0 +1,22 @@
+# Lock-in test for homepage date-filter default
+
+**PR**: TBD
+**Date**: 2026-04-25
+
+## Changes
+- `frontend/test-all.spec.ts` — adds `Homepage > "listings under each poster default to today and follow the day strip"`. On initial load, collects every `<time datetime>` in the desktop hybrid grid, converts each to London civil date, and asserts every value equals today. Then clicks the next-day strip button and asserts the visible set narrows to a single non-today date.
+
+## Why
+Reviewer feedback on #445 (the homepage date-filter default fix) flagged that the verification ("190 → 116 screening times") lived only in the changelog, not in a checked-in test. The next refactor of the `filmMap` derivation could silently re-introduce either of the two original bugs:
+1. The `||` short-circuit returning, leaking the full 30-day payload into the desktop grid.
+2. The UTC-string-slice path re-emerging, causing late-night BST screenings to land on the wrong calendar day.
+
+This single test case bites on both: a leaked future-day screening or a UTC/London mismatch produces a `datetime` whose London-date != today, failing the assertion.
+
+## Impact
+- **No production code change.** Tests-only.
+- The test runs against real production data via the existing dev-server proxy — no fixtures needed because today's London date is computed from the same `Intl.DateTimeFormat` semantics the page itself uses.
+- Verified against the local dev server: passes in 2.5 s.
+
+## Files
+- `frontend/test-all.spec.ts`

--- a/frontend/test-all.spec.ts
+++ b/frontend/test-all.spec.ts
@@ -53,6 +53,55 @@ test.describe('Pictures London — SvelteKit Frontend', () => {
 			await expect(today).toBeVisible();
 		});
 
+		test('listings under each poster default to today and follow the day strip', async ({ page }) => {
+			// Locks in PR #445: filmMap previously skipped its date predicate
+			// when no range was set, leaking the full 30-day payload into every
+			// poster. It also compared `s.datetime.split('T')[0]` (UTC date)
+			// against London-time filter values, so late-night BST screenings
+			// landed on the wrong calendar day. This single assertion catches
+			// both halves: a leaked future-day or a UTC-vs-London mismatch
+			// produces a `datetime` that resolves to a London date != today.
+			const londonDate = (iso: string) =>
+				new Date(iso).toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+			const today = londonDate(new Date().toISOString());
+
+			await page.goto(BASE);
+			await page.waitForSelector('.film-card .screening time', { timeout: 10000 });
+
+			const collectDates = async () => {
+				const times = page.locator('.film-card .screening time');
+				const n = await times.count();
+				const out: string[] = [];
+				for (let i = 0; i < n; i++) {
+					const dt = await times.nth(i).getAttribute('datetime');
+					if (dt) out.push(dt);
+				}
+				return out;
+			};
+
+			const initial = await collectDates();
+			expect(initial.length, 'expected at least one screening on the homepage').toBeGreaterThan(0);
+			const offToday = initial.filter((d) => londonDate(d) !== today);
+			expect(
+				offToday,
+				`expected every visible screening to be on ${today} (London); ${offToday.length} were on other days: ${offToday.slice(0, 3).join(', ')}`
+			).toEqual([]);
+
+			// Click the next-day strip button — listings should narrow to that day.
+			const stripButtons = page.locator('.day-strip .strip-btn:not(.strip-arrow)');
+			await stripButtons.nth(1).click(); // index 0 = Today, 1 = +1 day
+			await page.waitForTimeout(300);
+			const after = await collectDates();
+			if (after.length > 0) {
+				const uniqueDays = new Set(after.map(londonDate));
+				expect(
+					uniqueDays.size,
+					`expected screenings to narrow to a single day after strip click, got ${[...uniqueDays].join(', ')}`
+				).toBe(1);
+				expect([...uniqueDays][0]).not.toBe(today);
+			}
+		});
+
 		test('Pick date button opens calendar popover', async ({ page }) => {
 			await page.goto(BASE);
 			await page.getByRole('button', { name: /Pick date/ }).first().click();


### PR DESCRIPTION
## Summary
- Follow-up to #445. Adds the single Playwright assertion the review flagged as the highest-value test-coverage gap.
- On initial load, every `<time datetime>` rendered inside `.film-card .screening` resolves to today's London civil date. After clicking the next-day strip button, the visible set narrows to a single non-today date.
- One assertion bites on both halves of the original bug: a leaked future-day screening or a UTC-vs-London string mismatch would produce a `datetime` whose London-date isn't today.

## Test plan
- [x] Runs against the live dev server (`http://localhost:5173/`) on `chromium`: passes in 2.5 s.
- [ ] Verify CI E2E job is green before merge.

## Notes
- No production code change. Tests-only.
- Uses real production data via the existing dev-server proxy — no fixtures needed because today's London date is computed from the same `Intl.DateTimeFormat` semantics the page itself uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)