### PR TITLE
fix(frontend): defensive hardening on date handling

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,14 @@
+## 2026-04-25: Defensive hardening on frontend date handling
+**PR**: TBD | **Files**: `frontend/src/lib/utils.ts`, `frontend/src/routes/+page.svelte`, `frontend/src/routes/film/[id]/+page.svelte`
+- Soften the `filmMap` invariant comment on the homepage — `set dateFrom`/`set dateTo` are public store accessors and a future caller could break the both-set-together convention; comment now flags the convention plus what would happen if it lapses.
+- Surface that lapse instead of swallowing it: `console.warn` in the homepage `filmMap` derivation when exactly one of `filters.dateFrom`/`filters.dateTo` is null, so a future one-sided setter doesn't silently collapse the range to today.
+- Warn on malformed input to `toLondonDateStr`: `new Date('garbage').toLocaleDateString` returns the literal `"Invalid Date"`, which lexicographically beats every YYYY-MM-DD and silently drops the row from filmMap range filters and dayGroups bucketing. Now logs a console warning so the upstream data-quality issue surfaces.
+- Replace `tomorrowD.toISOString().split('T')[0]` (UTC date portion) with `toLondonDateStr(tomorrowD)` in the film detail page's "TOMORROW" badge so all three date strings (today / nextDate / tomorrow) speak the same London-civil-date language.
+
+---
+
 ## 2026-04-25: Lock-in test for homepage date-filter default
-**PR**: TBD | **Files**: `frontend/test-all.spec.ts`
+**PR**: #447 | **Files**: `frontend/test-all.spec.ts`
 - Adds the regression test the #445 review flagged: on initial homepage load, every screening time visible in the desktop hybrid grid resolves to today's London date; clicking the next-day strip button narrows them to a single non-today date.
 - One assertion catches both halves of the original bug — a leaked future-day screening or a UTC-vs-London string mismatch would surface as a `datetime` whose London date isn't today.
 

--- a/changelogs/2026-04-25-fix-frontend-date-handling-defensive.md
+++ b/changelogs/2026-04-25-fix-frontend-date-handling-defensive.md
@@ -1,0 +1,38 @@
+# Defensive hardening on frontend date handling
+
+**PR**: TBD
+**Date**: 2026-04-25
+
+## Changes
+
+### `frontend/src/lib/utils.ts` — `toLondonDateStr` warns on invalid input
+`new Date('garbage').toLocaleDateString('en-CA', { timeZone: 'Europe/London' })` returns the literal string `"Invalid Date"`. Lexicographically, `"I" (0x49) > "9" (0x39) > "0"`, so `"Invalid Date" > "2026-04-25"` for *every* current calendar date — it always sorts after a real date. In the homepage `filmMap` range filter, that means a malformed datetime trips the `dateStr > effectiveTo` branch and is silently dropped from the calendar. Same risk for `dayGroups` bucketing.
+
+The function now `console.warn`s when `Number.isNaN(d.getTime())`, preserving the existing exclusion behaviour while surfacing the upstream data corruption to the developer console (and to PostHog session-recording playback in production). No behavioural change for valid input.
+
+### `frontend/src/routes/+page.svelte` — soften the date-range invariant comment
+The previous comment claimed "both setters always assign `dateFrom` and `dateTo` together." That holds across all 6 current call sites (`setDatePreset`, `DayMasthead.selectDate`, `MobileDatePicker`, `MobileFilterSheet`, `ActiveFilterChips` clear, `DateTimePicker.selectDate`), but the public `set dateFrom`/`set dateTo` accessors on the `filters` store allow a future caller to break the convention. The new comment names the convention plus the failure mode if it lapses.
+
+### `frontend/src/routes/+page.svelte` — surface a one-sided date range
+Adds a dev-side `console.warn` in `filmMap` when exactly one of `filters.dateFrom`/`filters.dateTo` is null, so a future setter that resets one but not the other doesn't silently collapse the range to today. The warning only fires when the invariant breaks, which today is unreachable; it's an alarm, not a runtime cost.
+
+### `frontend/src/routes/film/[id]/+page.svelte` — same date language for the "TOMORROW" badge
+The `nextScreeningLabel` derivation compared a London-civil `nextDate` against `tomorrowD.toISOString().split('T')[0]` (UTC date portion of a noon-anchored timestamp). The two strings happen to match because UTC noon and London noon are always on the same calendar day, but mixing UTC slices with London civils is the same code-smell that masked the original #445 bug. Replaced with `toLondonDateStr(tomorrowD)` so all three operands speak the same date language.
+
+## Why
+Follow-up to PR #445 review. Three of the four reviewer-flagged items were defensive (silent-failure-hunter + comment-analyzer wording + the second-opinion code-reviewer's note about a related UTC slice). They're each individually small enough that bundling them is the proportionate response.
+
+## Verification
+- `npx svelte-check --threshold error` — no new errors (11 pre-existing in unrelated files).
+- `Homepage` Playwright describe block: 16 passed, 2 pre-existing flakes (Pick date popover + persisted New filter); the lock-in test from #447 still green.
+- `toLondonDateStr` change is observation-only — existing `"Invalid Date"` return preserved, so no caller's behaviour shifts.
+- The film detail "TOMORROW" badge swap is a semantic identity for noon-anchored Dates: `toLondonDateStr(tomorrowD)` and `tomorrowD.toISOString().split('T')[0]` produce the same YYYY-MM-DD because UTC noon is never on a different calendar day than London noon (London is always within ±1h of UTC, well clear of the day boundary).
+
+## Files
+- `frontend/src/lib/utils.ts`
+- `frontend/src/routes/+page.svelte`
+- `frontend/src/routes/film/[id]/+page.svelte`
+
+## Deferred to follow-up PRs
+- **Extract `filmMap` body to a pure function + wire Vitest** (pr-test-analyzer suggestion). Larger refactor; deserves its own PR with test scaffolding.
+- **Shared "today (London)" `$state` ticking at midnight** to replace per-derivation `new Date()` in masthead / `filmMap` / `dayGroups` (code-reviewer round 1). Cross-cutting; warrants a small RFC-style PR.

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -25,8 +25,21 @@ export function formatDate(date: Date | string): string {
 	}).toUpperCase();
 }
 
+const invalidDateWarned = new Set<string>();
 export function toLondonDateStr(date: Date | string): string {
 	const d = typeof date === 'string' ? new Date(date) : date;
+	// `toLocaleDateString` on Invalid Date returns the literal "Invalid Date",
+	// which silently sorts after every YYYY-MM-DD and excludes the row from
+	// range-filter compares without surfacing the upstream data corruption.
+	// Log each unique invalid input once so a single bad row doesn't spam the
+	// console (this helper is hot — called inside derived map/filter loops).
+	if (Number.isNaN(d.getTime())) {
+		const key = String(date);
+		if (!invalidDateWarned.has(key)) {
+			invalidDateWarned.add(key);
+			console.warn('toLondonDateStr received invalid date:', date);
+		}
+	}
 	return d.toLocaleDateString('en-CA', { timeZone: 'Europe/London' }); // YYYY-MM-DD
 }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -37,6 +37,10 @@
 
 	let mobileFilterOpen = $state(false);
 
+	// Dedup key for the one-sided date-range invariant warning so the dev
+	// console isn't spammed when filmMap re-derives on every reactive tick.
+	let oneSidedDateRangeWarnKey = '';
+
 	// Group screenings by film + apply filters.
 	const filmMap = $derived.by(() => {
 		const map = new Map<string, {
@@ -46,10 +50,24 @@
 		const now = Date.now();
 		// Default to today (London) when no explicit range is set so listings
 		// match the masthead, which already shows today as the active date.
-		// Invariant: both setters always assign dateFrom and dateTo together
-		// (filters.svelte.ts setDatePreset, DayMasthead.svelte selectDate). If
-		// that ever changes, swap effectiveTo's default for a far-future bound.
+		// Every current caller of the date-filter setters (setDatePreset,
+		// DayMasthead.selectDate) assigns dateFrom and dateTo together, but
+		// `set dateFrom` / `set dateTo` on `filters` are public — if a future
+		// caller sets only one, this defaults the other to today. The dev-only
+		// warning below surfaces that drift instead of silently collapsing the
+		// range to a single day.
 		const today = toLondonDateStr(new Date());
+		if (
+			import.meta.env.DEV &&
+			(filters.dateFrom === null) !== (filters.dateTo === null) &&
+			oneSidedDateRangeWarnKey !== `${filters.dateFrom}|${filters.dateTo}`
+		) {
+			oneSidedDateRangeWarnKey = `${filters.dateFrom}|${filters.dateTo}`;
+			console.warn('homepage: one-sided date range — invariant broken', {
+				dateFrom: filters.dateFrom,
+				dateTo: filters.dateTo
+			});
+		}
 		const effectiveFrom = filters.dateFrom ?? today;
 		const effectiveTo = filters.dateTo ?? today;
 

--- a/frontend/src/routes/film/[id]/+page.svelte
+++ b/frontend/src/routes/film/[id]/+page.svelte
@@ -49,9 +49,14 @@
 		const today = toLondonDateStr(new Date());
 		const nextDate = toLondonDateStr(nextScreening.datetime);
 		if (nextDate === today) return 'today';
+		// Resolve "tomorrow" through the same London-civil-date helper used for
+		// `today` and `nextDate` so all three operands speak the same date
+		// language. Behaviour-equivalent here (UTC noon and London noon are
+		// always the same calendar day), but the previous shape mixed UTC
+		// slices with London civils — the same code-smell that masked #445.
 		const tomorrowD = new Date(today + 'T12:00:00Z');
 		tomorrowD.setUTCDate(tomorrowD.getUTCDate() + 1);
-		if (nextDate === tomorrowD.toISOString().split('T')[0]) return 'tomorrow';
+		if (nextDate === toLondonDateStr(tomorrowD)) return 'tomorrow';
 		return new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' })
 			.format(new Date(nextScreening.datetime))
 			.toLowerCase();


### PR DESCRIPTION
## Summary
Bundled follow-up to #445's review. Three small defensive items, all on date handling.

- **`toLondonDateStr` warns on Invalid Date input.** `new Date('garbage').toLocaleDateString` returns the literal `"Invalid Date"`, which lexicographically beats every YYYY-MM-DD and silently drops the row from `filmMap` range filters and `dayGroups` bucketing. Now logs once per unique invalid input (deduped via module-scope `Set`) so the upstream data corruption surfaces.
- **Homepage `filmMap` warns on a one-sided date range.** Every current caller of the date-filter setters assigns `dateFrom` and `dateTo` together — but `set dateFrom`/`set dateTo` are public on the store. A dev-only `console.warn` (gated on `import.meta.env.DEV`, deduped by `${dateFrom}|${dateTo}`) fires when only one is null, so a future regression surfaces instead of silently collapsing the range to today. The invariant comment above also got softened to flag what would happen if the convention lapses.
- **Film detail "TOMORROW" badge speaks the same date language as the rest.** Replaced `tomorrowD.toISOString().split('T')[0]` with `toLondonDateStr(tomorrowD)`. Behaviour-equivalent for noon-anchored Dates (UTC noon and London noon are always the same calendar day), but stops mixing UTC slices with London civils — the same code-smell that masked the original #445 bug.

## Test plan
- [x] `npx svelte-check --threshold error` — no new errors (11 pre-existing in unrelated files).
- [x] `Homepage` Playwright describe block: 16 passed, 2 pre-existing flakes (Pick-date popover + persisted-New-filter); the lock-in test from #447 still green.
- [ ] Verify CI E2E job is green before merge.

## Deferred
- Extracting `filmMap` to a pure function + wiring Vitest for the frontend (pr-test-analyzer suggestion). Larger refactor, separate PR.
- Shared "today (London)" `\$state` ticking at midnight to replace per-derivation `new Date()` calls in masthead / `filmMap` / `dayGroups`. Cross-cutting, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)