### PR TITLE
feat(deps): migrate to Inngest SDK v4

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-04-25: Make Homepage Playwright suite resilient to sparse-data hours
-**PR**: TBD | **Files**: `frontend/test-all.spec.ts`
+**PR**: #452 | **Files**: `frontend/test-all.spec.ts`
 - Three Homepage tests were failing late evening because today's listings have thinned out by then (most films have already started). They now use Playwright's `test.skip()` when the data can't actually exhibit what's being asserted, preserving the original assertion intent: filters must narrow when there's data to narrow.
 - `cinema area chip narrows results` (line 209): post-click skip when filtered count is 0 (no Soho/West End films right now) or equals the all-count (every visible film already is in Soho/West End). Both legitimately occur at sparse-data hours and aren't a chip-wiring bug.
 - `format chip (35mm) reduces displayed films` (line 221): skip when no 35mm films are currently visible — the chip can't narrow what isn't there. Detected via `.film-card` text containing the rendered "35MM" format pill.
@@ -9,11 +9,21 @@
 ---
 
 ## 2026-04-25: Address retroactive review of calendar-filter extraction
-**PR**: TBD | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`, `changelogs/2026-04-25-refactor-extract-filmmap-helper.md`
+**PR**: #451 | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`, `changelogs/2026-04-25-refactor-extract-filmmap-helper.md`
 - Slim `CalendarScreening` interface to only the fields `buildFilmMap` actually reads — drop unused `bookingUrl`, `runtime`, `posterUrl`, `letterboxdRating`, `tmdbPopularity`, `cinema.shortName`. The output still carries the caller's full screening shape via the `<S>` generic on `FilmGroup`, so the homepage's richer payload flows through untouched.
 - Move the dev-only one-sided-range invariant warning (`(dateFrom == null) !== (dateTo == null)`) from `+page.svelte` into `buildFilmMap`. The invariant is about the helper's input, not component state — module-scope dedup key inside the helper is the right home for it, and removes the leakage of the helper's contract into the caller. `+page.svelte`'s `filmMap` derivation is now a single `buildFilmMap(...)` call.
 - Hoist `s.film` to a local `const film` inside the loop after the null guard so the type narrows by control flow (no more `as NonNullable<S['film']>` cast at the `map.set` callsite — well, almost; one cast remains where TS doesn't propagate generic-indexed-access narrowing through). Cache `new Date(s.datetime)` once per iteration so the now-check and time-of-day filter share the parse. Add radix `10` to `parseInt`.
 - Backfill `## Impact` section in the original extraction changelog (`changelogs/2026-04-25-refactor-extract-filmmap-helper.md`).
+
+---
+
+## 2026-04-25: Migrate to Inngest SDK v4
+**PR**: #450 | **Files**: `package.json`, `package-lock.json`, `src/inngest/functions.ts`
+- Bumped `inngest` from `^3.54.0` to `^4.2.4`. Inngest v4 is the long-term path; v3 will eventually stop receiving security backports (today's Vercel-gate incident showed the cost of being on a stale minor).
+- Migrated all 6 `createFunction` call sites in `src/inngest/functions.ts` to v4's signature: triggers move from the second positional argument into the `triggers` field of the first (options) argument (and must be wrapped in an array — caught in code review).
+- Skipped the optional `eventType()` / `staticSchema()` migration — our exported `Events` / `ScraperEvent` types are decorative (we never wired them into the `Inngest` client via the v3 generic or `schemas` option), so there's no v3 schema pattern to translate.
+- v4's "default mode is cloud" change is invisible to us: the production deploy already sets `INNGEST_SIGNING_KEY`, which is what v4 now requires by default.
+- Verification: `npx tsc --noEmit` clean, `npm run test:run` 913/913 pass; Vercel preview `GET /api/inngest` confirms `function_count: 6, mode: "cloud"`.
 
 ---
 

--- a/changelogs/2026-04-25-feat-inngest-v4-migration.md
+++ b/changelogs/2026-04-25-feat-inngest-v4-migration.md
@@ -27,18 +27,20 @@ inngest.createFunction(
 **After (v4):**
 ```typescript
 inngest.createFunction(
-  { id: "run-cinema-scraper", retries: 2, triggers: { event: "scraper/run" } },
+  { id: "run-cinema-scraper", retries: 2, triggers: [{ event: "scraper/run" }] },
   async ({ event, step }) => { ... }
 );
 ```
 
 All six functions migrated:
-- `runCinemaScraper` — `triggers: { event: "scraper/run" }`
-- `scheduledScrapeAll` — `triggers: { cron: "0 6 * * *" }`
-- `handleFunctionFailure` — `triggers: { event: "inngest/function.failed" }`
-- `scheduledBFIPDFImport` — `triggers: { cron: "0 6 * * 0" }`
-- `scheduledBFIChanges` — `triggers: { cron: "0 10 * * *" }`
-- `scheduledLetterboxdEnrichment` — `triggers: { cron: "0 8 * * *" }`
+- `runCinemaScraper` — `triggers: [{ event: "scraper/run" }]`
+- `scheduledScrapeAll` — `triggers: [{ cron: "0 6 * * *" }]`
+- `handleFunctionFailure` — `triggers: [{ event: "inngest/function.failed" }]`
+- `scheduledBFIPDFImport` — `triggers: [{ cron: "0 6 * * 0" }]`
+- `scheduledBFIChanges` — `triggers: [{ cron: "0 10 * * *" }]`
+- `scheduledLetterboxdEnrichment` — `triggers: [{ cron: "0 8 * * *" }]`
+
+> **Important:** `triggers` MUST be an array, even for a single trigger. v4's TypeScript signature is `triggers?: TTriggers extends InngestFunction.Trigger<string>[]` (`node_modules/inngest/components/InngestFunction.d.ts:100-101`) and the wire-format schema is `z.array(...)` (`node_modules/inngest/types.d.ts:1181`). The official migration guide's single-object example was misleading — TypeScript accepts the singular form because the generic default falls back to a permissive shape, but Inngest cloud will silently fail to register the trigger on the wire. First pass of this PR used the singular form; caught in code review before merge.
 
 ### 2. Things we did NOT migrate (and why)
 

--- a/changelogs/2026-04-25-feat-inngest-v4-migration.md
+++ b/changelogs/2026-04-25-feat-inngest-v4-migration.md
@@ -1,0 +1,67 @@
+# Migrate to Inngest SDK v4
+
+**PR**: TBD
+**Date**: 2026-04-25
+
+## Changes
+- `package.json`: `"inngest": "^3.54.0"` → `"inngest": "^4.2.4"`
+- `package-lock.json`: refreshed; resolves to `inngest@4.2.4`
+- `src/inngest/functions.ts`: migrated all 6 `createFunction` calls to v4's trigger-in-options-object signature.
+
+## Why now
+Today's Vercel-vulnerability-gate incident (forcing a same-day v3.52 → v3.54 bump) made the cost of staying on the v3 line concrete: v4 is GA (released 2026-03-17), and the v3 line will keep accumulating CVE-driven hotfix pressure until we move. The migration surface in this codebase is genuinely small, so we do it now while the context is fresh rather than waiting for the next gate to force the move under outage pressure.
+
+## Migration mechanics
+
+### 1. Triggers move into the options object (6 sites)
+
+**Before (v3):**
+```typescript
+inngest.createFunction(
+  { id: "run-cinema-scraper", retries: 2 },
+  { event: "scraper/run" },
+  async ({ event, step }) => { ... }
+);
+```
+
+**After (v4):**
+```typescript
+inngest.createFunction(
+  { id: "run-cinema-scraper", retries: 2, triggers: { event: "scraper/run" } },
+  async ({ event, step }) => { ... }
+);
+```
+
+All six functions migrated:
+- `runCinemaScraper` — `triggers: { event: "scraper/run" }`
+- `scheduledScrapeAll` — `triggers: { cron: "0 6 * * *" }`
+- `handleFunctionFailure` — `triggers: { event: "inngest/function.failed" }`
+- `scheduledBFIPDFImport` — `triggers: { cron: "0 6 * * 0" }`
+- `scheduledBFIChanges` — `triggers: { cron: "0 10 * * *" }`
+- `scheduledLetterboxdEnrichment` — `triggers: { cron: "0 8 * * *" }`
+
+### 2. Things we did NOT migrate (and why)
+
+- **`EventSchemas` → `eventType()`**: the v4 migration guide describes this as the recommended pattern for centralised event schemas, but our code never used `EventSchemas` to begin with — `src/inngest/client.ts` exports decorative `ScraperEvent` / `FestivalProgrammeDetectedEvent` / `Events` types that aren't connected to the `Inngest` instance via a generic or `schemas` option. So there's no v3 schema pattern to translate.
+- **`step.invoke()` string-arg removal**: we don't use `step.invoke()` anywhere.
+- **Manual `globalThis.fetch` binding**: we never bound it; v4's lazy-fetch resolution is purely beneficial.
+- **`isDev` / `INNGEST_DEV` flag**: production already passes `INNGEST_SIGNING_KEY`, which is what v4's new cloud default requires.
+
+## Verification
+- `npx tsc --noEmit` — clean.
+- `npm run test:run` — 913/913 pass.
+- Local `next dev` smoke skipped because port 3000 was occupied by an existing dev session at the time. Vercel preview deploy provides the runtime check (a v4 incompatibility would surface at module-load on cold start, immediately and visibly).
+- After merge, watch the first scheduled cron (`0 6 * * *` UTC for `scheduledScrapeAll`) and the next ad-hoc `scraper/run` event to confirm functions register and execute under the v4 protocol.
+
+## Rollback plan
+If the preview deploy or the first post-merge cron exposes a regression, revert is straightforward:
+```
+npm install inngest@^3.54.0
+git revert <merge-commit>
+```
+The v3 → v4 changes are entirely localised to the trigger-arg shape; reverting to v3 is mechanically symmetrical to the migration.
+
+## References
+- [TypeScript SDK Migration Guide: v3 to v4](https://www.inngest.com/docs/reference/typescript/v4/migrations/v3-to-v4)
+- [TypeScript SDK v4 GA changelog](https://www.inngest.com/changelog/2026-03-17-typescript-sdk-v4-ga)
+- [Tracking issue: inngest v3 → v4 migration](https://github.com/inngest/inngest-js/issues/1304)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.45.1",
-        "inngest": "^3.54.0",
+        "inngest": "^4.2.4",
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.562.0",
         "next": "16.1.0",
@@ -12995,15 +12995,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -16713,6 +16704,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17030,9 +17022,9 @@
       "license": "ISC"
     },
     "node_modules/inngest": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/inngest/-/inngest-3.54.0.tgz",
-      "integrity": "sha512-EBMgyRZt9rWUmc9GUdxznbO1CmyXKZi2CZPNxNTyZJyjZMXFhPiftq/lTKjhYXD9/WlqaVFVB2K7o8vDAkGs6w==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/inngest/-/inngest-4.2.4.tgz",
+      "integrity": "sha512-MBFcRhhQ+dcGHLYCbIcMYxiAZCxzfAx0+3b/euYQKc7MK3rOnNHaNHuF2e0WsT13oWJiGzjuC3T4Nocggmh5WQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.3",
@@ -17050,14 +17042,12 @@
         "@types/debug": "^4.1.12",
         "@types/ms": "~2.1.0",
         "canonicalize": "^1.0.8",
-        "chalk": "^4.1.2",
         "cross-fetch": "^4.0.0",
         "debug": "^4.3.4",
         "hash.js": "^1.1.7",
         "json-stringify-safe": "^5.0.1",
         "ms": "^2.1.3",
         "serialize-error-cjs": "^0.1.3",
-        "strip-ansi": "^5.2.0",
         "temporal-polyfill": "^0.2.5",
         "ulid": "^2.3.0",
         "zod": "^3.25.0"
@@ -17075,6 +17065,7 @@
         "hono": ">=4.2.7",
         "koa": ">=2.14.2",
         "next": ">=12.0.0",
+        "react": ">=18.0.0",
         "typescript": ">=5.8.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
@@ -17106,40 +17097,12 @@
         "next": {
           "optional": true
         },
+        "react": {
+          "optional": true
+        },
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/inngest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/inngest/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/inngest/node_modules/zod": {
@@ -22195,18 +22158,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
@@ -22304,6 +22255,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.1",
-    "inngest": "^3.54.0",
+    "inngest": "^4.2.4",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.562.0",
     "next": "16.1.0",

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -489,8 +489,8 @@ export const runCinemaScraper = inngest.createFunction(
   {
     id: "run-cinema-scraper",
     retries: 2,
+    triggers: { event: "scraper/run" },
   },
-  { event: "scraper/run" },
   async ({ event, step }) => {
     const { cinemaId, scraperId, triggeredBy } = event.data;
     const startTime = Date.now();
@@ -620,8 +620,8 @@ export const scheduledScrapeAll = inngest.createFunction(
   {
     id: "scheduled-scrape-all",
     retries: 0, // Don't retry the scheduler itself - individual scrapers have their own retries
+    triggers: { cron: "0 6 * * *" }, // 6:00 AM UTC daily
   },
-  { cron: "0 6 * * *" }, // 6:00 AM UTC daily
   async ({ step }) => {
     console.log(`[Inngest] Starting scheduled scrape for ${CHEERIO_CINEMAS.length} cinemas`);
 
@@ -656,8 +656,8 @@ export const handleFunctionFailure = inngest.createFunction(
   {
     id: "handle-function-failure",
     retries: 0, // Don't retry failure handlers
+    triggers: { event: "inngest/function.failed" },
   },
-  { event: "inngest/function.failed" },
   async ({ event, step }) => {
     const { function_id, run_id, error } = event.data;
     const originalEvent = event.data.event;
@@ -787,8 +787,8 @@ export const scheduledBFIPDFImport = inngest.createFunction(
   {
     id: "scheduled-bfi-pdf-import",
     retries: 2,
+    triggers: { cron: "0 6 * * 0" }, // 6:00 AM UTC every Sunday
   },
-  { cron: "0 6 * * 0" }, // 6:00 AM UTC every Sunday
   async ({ step }) => {
     console.log("[Inngest] Starting scheduled BFI PDF import...");
 
@@ -824,8 +824,8 @@ export const scheduledBFIChanges = inngest.createFunction(
   {
     id: "scheduled-bfi-changes",
     retries: 2,
+    triggers: { cron: "0 10 * * *" }, // 10:00 AM UTC daily
   },
-  { cron: "0 10 * * *" }, // 10:00 AM UTC daily
   async ({ step }) => {
     console.log("[Inngest] Starting scheduled BFI programme changes import...");
 
@@ -861,8 +861,8 @@ export const scheduledLetterboxdEnrichment = inngest.createFunction(
   {
     id: "scheduled-letterboxd-enrichment",
     retries: 1,
+    triggers: { cron: "0 8 * * *" }, // 8:00 AM UTC daily (2 hours after scrapers)
   },
-  { cron: "0 8 * * *" }, // 8:00 AM UTC daily (2 hours after scrapers)
   async ({ step }) => {
     console.log("[Inngest] Starting scheduled Letterboxd enrichment...");
 

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -489,7 +489,7 @@ export const runCinemaScraper = inngest.createFunction(
   {
     id: "run-cinema-scraper",
     retries: 2,
-    triggers: { event: "scraper/run" },
+    triggers: [{ event: "scraper/run" }],
   },
   async ({ event, step }) => {
     const { cinemaId, scraperId, triggeredBy } = event.data;
@@ -620,7 +620,7 @@ export const scheduledScrapeAll = inngest.createFunction(
   {
     id: "scheduled-scrape-all",
     retries: 0, // Don't retry the scheduler itself - individual scrapers have their own retries
-    triggers: { cron: "0 6 * * *" }, // 6:00 AM UTC daily
+    triggers: [{ cron: "0 6 * * *" }], // 6:00 AM UTC daily
   },
   async ({ step }) => {
     console.log(`[Inngest] Starting scheduled scrape for ${CHEERIO_CINEMAS.length} cinemas`);
@@ -656,7 +656,7 @@ export const handleFunctionFailure = inngest.createFunction(
   {
     id: "handle-function-failure",
     retries: 0, // Don't retry failure handlers
-    triggers: { event: "inngest/function.failed" },
+    triggers: [{ event: "inngest/function.failed" }],
   },
   async ({ event, step }) => {
     const { function_id, run_id, error } = event.data;
@@ -787,7 +787,7 @@ export const scheduledBFIPDFImport = inngest.createFunction(
   {
     id: "scheduled-bfi-pdf-import",
     retries: 2,
-    triggers: { cron: "0 6 * * 0" }, // 6:00 AM UTC every Sunday
+    triggers: [{ cron: "0 6 * * 0" }], // 6:00 AM UTC every Sunday
   },
   async ({ step }) => {
     console.log("[Inngest] Starting scheduled BFI PDF import...");
@@ -824,7 +824,7 @@ export const scheduledBFIChanges = inngest.createFunction(
   {
     id: "scheduled-bfi-changes",
     retries: 2,
-    triggers: { cron: "0 10 * * *" }, // 10:00 AM UTC daily
+    triggers: [{ cron: "0 10 * * *" }], // 10:00 AM UTC daily
   },
   async ({ step }) => {
     console.log("[Inngest] Starting scheduled BFI programme changes import...");
@@ -861,7 +861,7 @@ export const scheduledLetterboxdEnrichment = inngest.createFunction(
   {
     id: "scheduled-letterboxd-enrichment",
     retries: 1,
-    triggers: { cron: "0 8 * * *" }, // 8:00 AM UTC daily (2 hours after scrapers)
+    triggers: [{ cron: "0 8 * * *" }], // 8:00 AM UTC daily (2 hours after scrapers)
   },
   async ({ step }) => {
     console.log("[Inngest] Starting scheduled Letterboxd enrichment...");


### PR DESCRIPTION
## Summary
- Bumps `inngest` from `^3.54.0` to `^4.2.4`. v4 has been GA since 2026-03-17; today's Vercel vulnerability-gate incident showed the cost of staying on the v3 line and made the case for moving while context is fresh.
- The only source change is in `src/inngest/functions.ts`: v4 moves the trigger from `createFunction`'s second positional arg into the first (options) arg as a `triggers: { event | cron }` field. All 6 call sites migrated mechanically — no behaviour change.
- Detailed changelog with full mechanics + rollback plan: `changelogs/2026-04-25-feat-inngest-v4-migration.md`.

## What we did NOT migrate (and why)
- `EventSchemas` → `eventType()`: we never used `EventSchemas` — exported `Events` / `ScraperEvent` types in `src/inngest/client.ts` are decorative, never wired into `new Inngest<Events>` or `schemas:`.
- `step.invoke()` raw-string arg removal: not used.
- Manual `globalThis.fetch` binding: never bound.
- `isDev` / `INNGEST_DEV`: production already sets `INNGEST_SIGNING_KEY`, which is what v4's new "default mode is cloud" requires.

## Lockfile
v4 drops `chalk`/`ansi-styles`/`strip-ansi`/`ansi-regex` transitives (smaller install). Adds an optional `react` peer for v4's UI components — we don't use them. No app-level dep cascade.

## Test plan
- [x] `npx tsc --noEmit` clean (had flagged exactly 6 \"Expected 2 arguments, but got 3\" errors before the migration, one per `createFunction`)
- [x] `npm run test:run` — 913/913 pass
- [x] Code-reviewer agent confirmed: no other v3-only APIs remain; `inngest.send()` calls in `src/app/api/admin/scrape/{route,all/route}.ts` are v4-compatible; `inngest/function.failed` payload (`function_id` / `run_id` / `error` / `event`) is unchanged in v4
- [ ] Local `next dev` smoke skipped (port 3000 occupied by existing dev session); Vercel preview deploy is the runtime check
- [ ] Post-merge: watch the next ad-hoc `scraper/run` event and the first scheduled cron (`0 6 * * *` UTC) to confirm registration + execution under the v4 protocol

## Rollback
Mechanically symmetrical to the migration if the preview deploy or first post-merge cron exposes a regression: `npm install inngest@^3.54.0` + `git revert <merge-commit>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)