### PR TITLE
fix(frontend): address retroactive review of calendar-filter extraction

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,14 @@
+## 2026-04-25: Address retroactive review of calendar-filter extraction
+**PR**: TBD | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`, `changelogs/2026-04-25-refactor-extract-filmmap-helper.md`
+- Slim `CalendarScreening` interface to only the fields `buildFilmMap` actually reads — drop unused `bookingUrl`, `runtime`, `posterUrl`, `letterboxdRating`, `tmdbPopularity`, `cinema.shortName`. The output still carries the caller's full screening shape via the `<S>` generic on `FilmGroup`, so the homepage's richer payload flows through untouched.
+- Move the dev-only one-sided-range invariant warning (`(dateFrom == null) !== (dateTo == null)`) from `+page.svelte` into `buildFilmMap`. The invariant is about the helper's input, not component state — module-scope dedup key inside the helper is the right home for it, and removes the leakage of the helper's contract into the caller. `+page.svelte`'s `filmMap` derivation is now a single `buildFilmMap(...)` call.
+- Hoist `s.film` to a local `const film` inside the loop after the null guard so the type narrows by control flow (no more `as NonNullable<S['film']>` cast at the `map.set` callsite — well, almost; one cast remains where TS doesn't propagate generic-indexed-access narrowing through). Cache `new Date(s.datetime)` once per iteration so the now-check and time-of-day filter share the parse. Add radix `10` to `parseInt`.
+- Backfill `## Impact` section in the original extraction changelog (`changelogs/2026-04-25-refactor-extract-filmmap-helper.md`).
+
+---
+
 ## 2026-04-25: Extract homepage filmMap to a pure helper
-**PR**: TBD | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`
+**PR**: direct-to-main `c5733f93` (gate-violation; reviewed retroactively in follow-up PR) | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`
 - Pulled the homepage `filmMap` derivation body out of `+page.svelte` into a pure function `buildFilmMap(screenings, filters, { today, now })` in a new `frontend/src/lib/calendar-filter.ts`. Same behaviour, but now isolated from Svelte runes and reactive scope so it can be tested as a plain TS function.
 - The homepage component is now a thin reactive wrapper that snapshots store state, runs the helper, and returns the result. The dev-side one-sided-range warning stays in the component (it reads reactive state directly).
 - Vitest wiring deferred — the extraction is the foundation; landing test infra can ship as its own PR once the dependency baseline is settled.

--- a/changelogs/2026-04-25-fix-calendar-filter-followup.md
+++ b/changelogs/2026-04-25-fix-calendar-filter-followup.md
@@ -1,0 +1,37 @@
+# Address retroactive review of calendar-filter extraction
+
+**PR**: TBD
+**Date**: 2026-04-25
+
+## Why
+The original extraction (commit `c5733f93`) landed direct on `main` due to a local-HEAD slip during a `gh pr create` failure recovery, bypassing the PR-review gate the project mandates. A retroactive Code Reviewer agent run on the diff surfaced two should-fix items, three nits, and a missing changelog `## Impact` section. This PR closes the gate-violation by addressing all of them.
+
+## Changes
+
+### `frontend/src/lib/calendar-filter.ts`
+- **`CalendarScreening` interface slim.** Removed fields the helper never reads: `bookingUrl`, `film.runtime`, `film.posterUrl`, `film.letterboxdRating`, `film.tmdbPopularity`, `cinema.shortName`. Reviewer flagged this as payload-shape leakage — the constraint should only require what the function uses; the output type already preserves the caller's full screening shape via `<S>` on `FilmGroup`.
+- **One-sided-range invariant warning moved into the helper.** The invariant is "if a future caller of `filters.dateFrom`/`filters.dateTo` setters assigns one without the other, we silently default the missing end to today" — that's a property of `buildFilmMap`'s input, not of the calling component. A module-scope `lastOneSidedRangeWarnKey` dedup variable lives next to the helper, gated on `import.meta.env.DEV`. `+page.svelte`'s component-scope `oneSidedDateRangeWarnKey` is gone.
+- **Loop body micro-cleanups.** Hoist `s.film` to a local `const film` after the null guard so subsequent reads use the narrowed local. Cache `new Date(s.datetime)` once per iteration so the now-check and the time-of-day filter share the parse. Pass radix `10` to `parseInt`.
+
+### `frontend/src/routes/+page.svelte`
+- Removed the now-redundant one-sided-range warning block and the `oneSidedDateRangeWarnKey` declaration. The `filmMap` derivation is now a single `buildFilmMap(...)` call.
+
+### `changelogs/2026-04-25-refactor-extract-filmmap-helper.md`
+- Added the `## Impact` section the original changelog was missing per the project template in `CLAUDE.md`.
+
+## Impact
+- **No user-facing change.** Lock-in test from #447 still passes against the refactored helper, confirming behaviour-preservation.
+- **Tighter helper contract.** Future test fixtures can pass leaner objects — only the fields actually used by the function are required.
+- **Invariant lives next to the code that depends on it.** Moving the warning into `calendar-filter.ts` means a second consumer of `buildFilmMap` (e.g. a future Tonight or Reachable view) gets the same drift detection for free.
+
+## Verification
+- `npx svelte-check --threshold error` — no new errors (11 pre-existing in unrelated files).
+- `Homepage > listings under each poster default to today and follow the day strip` Playwright lock-in: passes in 3.1 s. Confirms behaviour-preservation through both the original extraction and this follow-up.
+
+## Files
+- `frontend/src/lib/calendar-filter.ts`
+- `frontend/src/routes/+page.svelte`
+- `changelogs/2026-04-25-refactor-extract-filmmap-helper.md`
+
+## Out of scope
+- Wiring Vitest. Still deferred per the user's earlier revert.

--- a/changelogs/2026-04-25-refactor-extract-filmmap-helper.md
+++ b/changelogs/2026-04-25-refactor-extract-filmmap-helper.md
@@ -21,10 +21,15 @@ The behavioural contract is documented in the file and matches what the homepage
 - Screenings are bucketed by `film.id` in insertion order; the caller is responsible for any ordering.
 
 ### `frontend/src/routes/+page.svelte`
-Replaced the ~85-line `filmMap` derivation body with a 16-line snapshot construction + call to `buildFilmMap`. The dev-side one-sided-range warning stays in the component because it reads `filters.dateFrom`/`filters.dateTo` directly to track the warn dedup key. The component is now a thin reactive wrapper.
+Replaced the ~85-line `filmMap` derivation body with a snapshot construction + call to `buildFilmMap`. The component is now a thin reactive wrapper.
 
 ## Why
 Pre-test-analyzer's call-out on the #445 review: the inlined derivation was untestable as written, and the BST midnight boundary (where the original bug lived) is hard to hit through Playwright. Extracting the pure function gives a clear unit-test surface — even before a test runner lands on the frontend, the function shape itself is the win, because it's now possible to pass arbitrary fixture data through the same code that runs in production.
+
+## Impact
+- **No user-facing change.** The Playwright lock-in test from #447 still passes against the refactored code, confirming behaviour-preservation.
+- **Future test surface unblocked.** `buildFilmMap` is callable from any test runner without rendering the homepage; passing `today` and `now` explicitly makes the function deterministic and avoids hidden clock reads that would diverge between SSR and CSR.
+- **No SSR/hydration impact.** Same inputs in production produce the same `Map` they did when the logic was inlined.
 
 ## Verification
 - `npx svelte-check --threshold error` — no new errors (11 pre-existing in unrelated files).

--- a/frontend/src/lib/calendar-filter.ts
+++ b/frontend/src/lib/calendar-filter.ts
@@ -1,30 +1,26 @@
 import type { FilterProgrammingType } from '$lib/constants/filters';
 import { toLondonDateStr } from '$lib/utils';
 
-// Minimal structural type the filter cares about; intentionally narrower
-// than the full `+page.server.ts` payload so callers can pass either the
-// home payload or a film-detail payload as long as it has these fields.
+// Minimal structural type — only the fields `buildFilmMap` actually reads.
+// Callers can pass any wider type that satisfies this constraint; the output
+// preserves the caller's full screening shape via the `<S>` generic on
+// `FilmGroup`, so the homepage's richer payload (poster, runtime, ratings,
+// etc.) flows through untouched.
 export interface CalendarScreening {
 	id: string;
 	datetime: string;
 	format: string | null;
-	bookingUrl: string;
 	film: {
 		id: string;
 		title: string;
 		year: number | null;
 		director: string | null;
 		genres: string[];
-		runtime: number | null;
-		posterUrl: string | null;
 		isRepertory: boolean;
-		letterboxdRating: number | null;
-		tmdbPopularity: number | null;
 	} | null;
 	cinema: {
 		id: string;
 		name: string;
-		shortName: string | null;
 	} | null;
 }
 
@@ -56,6 +52,12 @@ export interface FilmGroup<S extends CalendarScreening = CalendarScreening> {
 	screenings: S[];
 }
 
+// Module-scope dedup for the one-sided-range invariant warning. Lives here
+// (rather than in the calling component) because the invariant is about the
+// helper's own input — a future caller breaking the convention should be
+// surfaced regardless of which Svelte component happened to invoke us.
+let lastOneSidedRangeWarnKey = '';
+
 /**
  * Group upcoming screenings by film, applying the active filters.
  *
@@ -78,15 +80,38 @@ export function buildFilmMap<S extends CalendarScreening>(
 	const effectiveTo = filters.dateTo ?? today;
 	const searchQuery = filters.filmSearch ? filters.filmSearch.toLowerCase() : '';
 
+	// Every current caller (setDatePreset in `filters.svelte.ts`,
+	// `DayMasthead.selectDate`) assigns dateFrom and dateTo together, but
+	// `set dateFrom` / `set dateTo` on the store are public — if a future
+	// caller sets only one, we silently default the other to today. The
+	// dev-only warning below surfaces that drift instead of swallowing it.
+	if (
+		import.meta.env.DEV &&
+		(filters.dateFrom === null) !== (filters.dateTo === null)
+	) {
+		const key = `${filters.dateFrom}|${filters.dateTo}`;
+		if (lastOneSidedRangeWarnKey !== key) {
+			lastOneSidedRangeWarnKey = key;
+			console.warn('buildFilmMap: one-sided date range — invariant broken', {
+				dateFrom: filters.dateFrom,
+				dateTo: filters.dateTo
+			});
+		}
+	}
+
 	for (const s of screenings) {
-		if (!s.film) continue;
-		if (new Date(s.datetime).getTime() <= now) continue;
+		const film = s.film;
+		if (!film) continue;
+
+		const dt = new Date(s.datetime);
+		const dtMs = dt.getTime();
+		if (dtMs <= now) continue;
 
 		if (searchQuery) {
 			const matches =
-				s.film.title.toLowerCase().includes(searchQuery) ||
+				film.title.toLowerCase().includes(searchQuery) ||
 				(s.cinema?.name?.toLowerCase().includes(searchQuery) ?? false) ||
-				(s.film.director?.toLowerCase().includes(searchQuery) ?? false);
+				(film.director?.toLowerCase().includes(searchQuery) ?? false);
 			if (!matches) continue;
 		}
 		if (filters.cinemaIds.length > 0 && !filters.cinemaIds.includes(s.cinema?.id ?? '')) continue;
@@ -99,17 +124,18 @@ export function buildFilmMap<S extends CalendarScreening>(
 
 		if (filters.timeFrom !== null && filters.timeTo !== null) {
 			const hour = parseInt(
-				new Date(s.datetime).toLocaleString('en-GB', {
+				dt.toLocaleString('en-GB', {
 					hour: 'numeric',
 					hour12: false,
 					timeZone: 'Europe/London'
-				})
+				}),
+				10
 			);
 			if (hour < filters.timeFrom || hour > filters.timeTo) continue;
 		}
 
 		if (filters.programmingTypes.length > 0) {
-			const isRepertory = s.film.isRepertory;
+			const isRepertory = film.isRepertory;
 			const matchesAny = filters.programmingTypes.some((type) =>
 				type === 'repertory' ? isRepertory : !isRepertory
 			);
@@ -119,29 +145,29 @@ export function buildFilmMap<S extends CalendarScreening>(
 		if (filters.genres.length > 0) {
 			// Chip keys are lowercase canonical genre names; `film.genres`
 			// is already lowercased by the backend pipeline.
-			const filmGenres = (s.film.genres ?? []).map((g) => g.toLowerCase());
+			const filmGenres = (film.genres ?? []).map((g) => g.toLowerCase());
 			if (!filters.genres.some((g) => filmGenres.includes(g))) continue;
 		}
 
 		if (filters.decades.length > 0) {
-			if (!s.film.year) continue;
+			if (!film.year) continue;
 			// Label convention: '2020s' / '2010s' / '2000s' for 2000+ eras,
 			// '90s' / '80s' / '70s' for 1970s–1990s, 'Pre-1970' for anything
 			// earlier. Matches the chip labels in both filter surfaces.
 			let decade: string;
-			if (s.film.year < 1970) {
+			if (film.year < 1970) {
 				decade = 'Pre-1970';
-			} else if (s.film.year >= 2000) {
-				decade = `${Math.floor(s.film.year / 10) * 10}s`;
+			} else if (film.year >= 2000) {
+				decade = `${Math.floor(film.year / 10) * 10}s`;
 			} else {
-				decade = `${Math.floor((s.film.year % 100) / 10) * 10}s`;
+				decade = `${Math.floor((film.year % 100) / 10) * 10}s`;
 			}
 			if (!filters.decades.includes(decade)) continue;
 		}
 
-		const existing = map.get(s.film.id);
+		const existing = map.get(film.id);
 		if (existing) existing.screenings.push(s);
-		else map.set(s.film.id, { film: s.film as NonNullable<S['film']>, screenings: [s] });
+		else map.set(film.id, { film: film as NonNullable<S['film']>, screenings: [s] });
 	}
 	return map;
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -39,35 +39,11 @@
 
 	let mobileFilterOpen = $state(false);
 
-	// Dedup key for the one-sided date-range invariant warning so the dev
-	// console isn't spammed when filmMap re-derives on every reactive tick.
-	let oneSidedDateRangeWarnKey = '';
-
 	// Group screenings by film + apply filters via the pure helper in
-	// `$lib/calendar-filter`. Keeping the snapshot-shape extraction intact
-	// here preserves the surface area for the lock-in test and keeps the
-	// derivation reactive to the same set of state reads as before.
-	const filmMap = $derived.by(() => {
-		// Default to today (London) when no explicit range is set so listings
-		// match the masthead, which already shows today as the active date.
-		// Every current caller of the date-filter setters (setDatePreset,
-		// DayMasthead.selectDate) assigns dateFrom and dateTo together, but
-		// `set dateFrom` / `set dateTo` on `filters` are public — if a future
-		// caller sets only one, this defaults the other to today. The dev-only
-		// warning below surfaces that drift instead of silently collapsing the
-		// range to a single day.
-		if (
-			import.meta.env.DEV &&
-			(filters.dateFrom === null) !== (filters.dateTo === null) &&
-			oneSidedDateRangeWarnKey !== `${filters.dateFrom}|${filters.dateTo}`
-		) {
-			oneSidedDateRangeWarnKey = `${filters.dateFrom}|${filters.dateTo}`;
-			console.warn('homepage: one-sided date range — invariant broken', {
-				dateFrom: filters.dateFrom,
-				dateTo: filters.dateTo
-			});
-		}
-		return buildFilmMap(
+	// `$lib/calendar-filter`. The helper owns the one-sided-range invariant
+	// warning internally — see calendar-filter.ts.
+	const filmMap = $derived.by(() =>
+		buildFilmMap(
 			data.screenings,
 			{
 				filmSearch: filters.filmSearch,
@@ -82,8 +58,8 @@
 				decades: filters.decades
 			},
 			{ today: todayStore.value, now: Date.now() }
-		);
-	});
+		)
+	);
 
 	const dayGroups = $derived.by(() => {
 		const all = [...filmMap.values()].flatMap((f) => f.screenings.map((s) => ({ ...s, film: f.film })));


### PR DESCRIPTION
## Summary
Closes the PR-review gate that was bypassed when commit \`c5733f93\` (the homepage \`filmMap\` extraction) landed direct to \`main\` due to a local-HEAD slip. The Code Reviewer agent's retroactive pass surfaced 2 should-fix + 3 nits + a changelog gap; this PR addresses all of them.

- **Slim \`CalendarScreening\` interface** to only the fields \`buildFilmMap\` actually reads. The output type still carries the caller's full screening shape via the \`<S>\` generic, so the homepage's richer payload flows through untouched.
- **Move the one-sided-range invariant warning** from \`+page.svelte\` into \`buildFilmMap\` itself, with a module-scope dedup gated on \`import.meta.env.DEV\`. The invariant is a property of the helper's input, not of the calling component — and a second consumer of the helper now gets the drift detection for free.
- **Loop body micro-cleanups**: hoist \`s.film\` to a local after the null guard, cache \`new Date(s.datetime)\` once per iteration, add radix to \`parseInt\`.
- **Backfill \`## Impact\` section** in the original extraction changelog (was the one doc-rule deviation flagged).

## Test plan
- [x] \`npx svelte-check --threshold error\` — no new errors.
- [x] Lock-in test from #447 (\`Homepage > listings under each poster default to today and follow the day strip\`): passes in 3.1s. Behaviour-preserving.
- [ ] Verify CI green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)