### PR TITLE
chore(lint): ignore generated build dirs in ESLint config

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,14 @@
+## 2026-04-26: Add generated-dir ignores to ESLint config
+**PR**: TBD | **Files**: `eslint.config.mjs`
+- `globalIgnores()` now covers `.trigger/**`, `.vercel/**`, `frontend/.svelte-kit/**`, `frontend/.vercel/**`. The existing `.next/**` already covered Next's typegen output.
+- Reproduced the bug: with a populated `frontend/.svelte-kit/` (created by frontend's `prepare` script), `npm run lint` reports **81 errors / 170 warnings** of phantom rule violations against generated code. After the fix: **0 errors / 41 warnings**, identical to a clean checkout.
+- Caught during PR #455 verification — chasing 251 fake errors burned ~1 hr. This is the root-cause fix so the next dep-update author doesn't repeat the goose chase.
+- Phase 2 item 13 from `tasks/todo.md`.
+
+---
+
 ## 2026-04-26: Drop unused @anthropic-ai/* deps
-**PR**: TBD | **Files**: `package.json`, `package-lock.json`
+**PR**: #456 | **Files**: `package.json`, `package-lock.json`
 - Removed `@anthropic-ai/sdk` and `@anthropic-ai/claude-agent-sdk` from `dependencies` / `devDependencies`. The 2026-02-28 Gemini migration replaced their runtime usage but left both packages listed — `grep -rE "from ['\"]@anthropic-ai" --include="*.ts"` returns zero results.
 - `npm uninstall` removed 330 transitive lockfile entries (~5 MB of install footprint, faster cold installs in CI).
 - Verification: `npm run lint` 0 errors / 41 warnings, `npx tsc --noEmit` clean, `npm run test:run` 913/913 pass.

--- a/changelogs/2026-04-26-eslint-ignore-generated-dirs.md
+++ b/changelogs/2026-04-26-eslint-ignore-generated-dirs.md
@@ -1,0 +1,42 @@
+# Add generated-dir ignores to ESLint config
+
+**PR**: TBD
+**Date**: 2026-04-26
+**Branch**: `chore/eslint-ignore-generated-dirs`
+
+## Changes
+
+Added four patterns to `globalIgnores()` in `eslint.config.mjs`:
+
+- `.trigger/**` — Trigger.dev's `.trigger/tmp/build-*/` build artifacts
+- `.vercel/**` — root Vercel build output (when present locally)
+- `frontend/.svelte-kit/**` — SvelteKit's `prepare` / `sync` output (`ambient.d.ts`, `non-ambient.d.ts`, `types/`, `output/`)
+- `frontend/.vercel/**` — frontend Vercel build output
+
+`.next/**` already covered Next's typegen — no change needed there.
+
+## Why
+
+During PR #455 verification I burned ~1 hour chasing **251 phantom lint errors** that turned out to be entirely from generated code in dirs ESLint wasn't told to ignore:
+
+- 122 `@typescript-eslint/no-this-alias` errors — all in `frontend/.vercel/output/functions/.../catchall.func/.svelte-kit/output/server/...`
+- 22 `react-hooks/rules-of-hooks` errors — all in SvelteKit's compiled SSR output
+- 81 errors after partial cleanup — `frontend/.svelte-kit/types/...`, `frontend/.svelte-kit/non-ambient.d.ts`
+
+A clean checkout passed lint cleanly because none of those generated dirs existed yet. The fix is mechanical: add the patterns and the false positives disappear.
+
+## Verification
+
+In a fresh worktree at `origin/main`, after running `cd frontend && npm install` (which populates `.svelte-kit/`):
+
+| | Before fix | After fix |
+|---|---|---|
+| `npm run lint` | 251 problems (81 errors, 170 warnings) | 41 problems (0 errors, 41 warnings) |
+
+The "after" state matches a clean checkout exactly — meaning `eslint.config.mjs` now produces deterministic results regardless of which generated artifacts happen to be on disk.
+
+## Impact
+
+- The next dep-update author won't waste time on this red herring.
+- CI behavior unchanged (CI starts from a clean checkout, so it never had the artifacts anyway). Local dev is the only winner.
+- Phase 2 item 13 from `tasks/todo.md`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,12 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Local one-off analysis scripts
     ".tmp-*.js",
+    // Generated build artifacts that previously triggered phantom lint errors
+    // when present locally. Matched root-relative because eslint runs from /.
+    ".trigger/**",
+    ".vercel/**",
+    "frontend/.svelte-kit/**",
+    "frontend/.vercel/**",
   ]),
   // Rule overrides - temporarily downgrade problematic rules to warnings
   // TODO: Fix these issues incrementally and remove these overrides


### PR DESCRIPTION
## Summary
- Adds `.trigger/**`, `.vercel/**`, `frontend/.svelte-kit/**`, `frontend/.vercel/**` to `globalIgnores()` in `eslint.config.mjs`.
- Phase 2 item 13 from `tasks/todo.md` — recommended to land between items 1 and 3 so subsequent major-bump PRs have honest lint signals.

## Why
While verifying #455, I chased 251 phantom lint errors for ~1 hour before realizing they were all in generated build artifacts that ESLint wasn't told to ignore. A clean checkout (CI's environment) passes lint fine; local dev gets noise from `frontend/.svelte-kit/`, `.trigger/tmp/`, etc.

## Verification
Reproduced the bug in a fresh worktree at `origin/main`:

| State | `npm run lint` |
|---|---|
| With `frontend/.svelte-kit/` populated, before fix | 251 problems (**81 errors**, 170 warnings) |
| With `frontend/.svelte-kit/` populated, after fix | 41 problems (**0 errors**, 41 warnings) |

After-fix output matches a clean checkout exactly.

## Impact
- CI behavior unchanged — CI starts clean.
- Local dev no longer produces phantom errors after frontend `npm install` runs `svelte-kit sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)