### PR TITLE
chore: declare Node engine in package.json

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,14 @@
+## 2026-04-26: Declare Node engine in package.json
+**PR**: TBD | **Files**: `package.json`
+- Added `"engines": {"node": "^20.20.0 || >=22.22.0"}` to root `package.json`. Matches the strictest dep requirement (`@posthog/ai` 7.16.10, `posthog-node` 5.30.4).
+- No CI workflow change — `.github/workflows/*.yml` already use Node 24, well above the floor. `.nvmrc` stays at `22` (resolves to current 22 LTS, satisfies the engine).
+- Effect: local devs on older Node now get an explicit `EBADENGINE` warning at install time pointing at the requirement. Vercel will continue to use a compatible runtime (its current default exceeds the floor).
+- Phase 2 item 2 from `tasks/todo.md`.
+
+---
+
 ## 2026-04-26: Add generated-dir ignores to ESLint config
-**PR**: TBD | **Files**: `eslint.config.mjs`
+**PR**: #457 | **Files**: `eslint.config.mjs`
 - `globalIgnores()` now covers `.trigger/**`, `.vercel/**`, `frontend/.svelte-kit/**`, `frontend/.vercel/**`. The existing `.next/**` already covered Next's typegen output.
 - Reproduced the bug: with a populated `frontend/.svelte-kit/` (created by frontend's `prepare` script), `npm run lint` reports **81 errors / 170 warnings** of phantom rule violations against generated code. After the fix: **0 errors / 41 warnings**, identical to a clean checkout.
 - Caught during PR #455 verification — chasing 251 fake errors burned ~1 hr. This is the root-cause fix so the next dep-update author doesn't repeat the goose chase.

--- a/changelogs/2026-04-26-package-engines-node.md
+++ b/changelogs/2026-04-26-package-engines-node.md
@@ -1,0 +1,46 @@
+# Declare Node engine in package.json
+
+**PR**: TBD
+**Date**: 2026-04-26
+**Branch**: `chore/node-bump-20-20`
+
+## Changes
+
+Added to root `package.json`:
+
+```json
+"engines": {
+  "node": "^20.20.0 || >=22.22.0"
+}
+```
+
+No other files touched.
+
+## Why
+
+Phase 1 (#455) bumped `@posthog/ai` to 7.16.10 and `posthog-node` to 5.30.4. Both packages declare a Node engine of `^20.20.0 || >=22.22.0`. The repo had no `engines` field, so:
+
+- Local devs on Node < 20.20 (or 22.x < 22.22) saw EBADENGINE warnings at install time **without** an actionable signal to upgrade.
+- The project's intended runtime requirement was implicit, scattered across deps.
+
+Adding the field surfaces the requirement explicitly. Anyone running `npm install` on a non-conforming Node version now gets a clear warning citing the project's own `engines` declaration.
+
+## What was NOT changed and why
+
+- `.nvmrc` stays at `22`. Local nvm/fnm resolves this to current 22 LTS (well above 22.22), which already satisfies the engine.
+- `.github/workflows/*.yml` stay at Node 24 (or `${{ env.NODE_VERSION }} = '24'`). CI deliberately tests on a newer Node than production runtime — that catches forward-compat issues. No reason to drop to 22.
+- `frontend/package.json` left without `engines`. The frontend has no deps with stricter Node requirements; over-declaring would just cause noise.
+
+## Verification
+
+- `npm install` re-installs cleanly against the new engines field
+- `npm run lint` → 0 errors, 41 warnings
+- `npx tsc --noEmit` → clean
+- `npm run test:run` → 913/913 pass
+
+## Impact
+
+- Existing CI: unchanged (already on Node 24).
+- Existing Vercel deploy: unchanged (Vercel's default Node satisfies the engine).
+- Local dev on Node < 20.20: now gets a louder warning. Upgrade path: switch to Node 22 LTS via `nvm use` (the project's `.nvmrc` already points there).
+- Phase 2 item 2 from `tasks/todo.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,9 @@
         "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^4.0.16"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "pictures",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "^20.20.0 || >=22.22.0"
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix"


### PR DESCRIPTION
## Summary
- Adds \`"engines": {"node": "^20.20.0 || >=22.22.0"}\` to root \`package.json\`. Matches the strictest dep requirement (\`@posthog/ai\` 7.16.10, \`posthog-node\` 5.30.4 — both bumped in #455).
- Phase 2 item 2 from \`tasks/todo.md\`.

## What does NOT change
- CI workflows already use Node 24 — well above the floor, deliberately ahead of LTS to catch forward-compat issues. No change.
- \`.nvmrc\` stays at \`22\` (resolves to current 22 LTS via nvm, satisfies the engine).
- Vercel runtime: unchanged (its default exceeds the floor).

## Why
Without an explicit \`engines\` field, devs running \`npm install\` on Node < 20.20 see EBADENGINE warnings cited from individual transitive packages instead of from the project itself. This makes the requirement explicit and actionable: upgrade to the version your own project demands.

## Verification
- [x] \`npm run lint\` → 0 errors, 41 warnings
- [x] \`npx tsc --noEmit\` → clean
- [x] \`npm run test:run\` → 913/913 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)