### PR TITLE
chore(deps): bump lucide-react to v1

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,14 @@
-## 2026-04-26: Bump @vercel/analytics + @vercel/speed-insights to v2
+## 2026-04-26: Bump lucide-react to v1
 **PR**: TBD | **Files**: `package.json`, `package-lock.json`
+- `lucide-react` 0.562.0 → 1.11.0 (the v1.0 stabilization release).
+- Audited all 78 unique icon imports across `src/**/*.{ts,tsx}` — every name still exists in v1.11.0. `npx tsc --noEmit` resolves all imports cleanly.
+- No source code changes required.
+- Phase 2 item 4 from `tasks/todo.md`.
+
+---
+
+## 2026-04-26: Bump @vercel/analytics + @vercel/speed-insights to v2
+**PR**: #459 | **Files**: `package.json`, `package-lock.json`
 - `@vercel/analytics` 1.6.1 → 2.0.1, `@vercel/speed-insights` 1.3.1 → 2.0.0. Both used only in `src/app/layout.tsx` via the `/next` subpath.
 - v2's `/next` subpath still exports the same `Analytics` and `SpeedInsights` named components — drop-in replacement, zero source code changes needed.
 - Phase 2 item 3 from `tasks/todo.md` (lowest-risk major).

--- a/changelogs/2026-04-26-lucide-react-v1.md
+++ b/changelogs/2026-04-26-lucide-react-v1.md
@@ -1,0 +1,51 @@
+# Bump lucide-react to v1
+
+**PR**: TBD
+**Date**: 2026-04-26
+**Branch**: `chore/lucide-react-v1`
+
+## Changes
+
+- `lucide-react` 0.562.0 → 1.11.0 (the v1.0 stabilization release)
+- No source code changes
+
+## Why
+
+Phase 2 item 4 from `tasks/todo.md`. The 1.0 stabilization release locks the icon API after years on the 0.x train.
+
+## Audit
+
+Pulled every unique icon name across the codebase via Python:
+
+```python
+re.finditer(r'import\s*\{([^}]+)\}\s*from\s*["\']lucide-react["\']', src, re.DOTALL)
+```
+
+Found 78 unique icons used across ~30 files. All 78 still resolve in v1.11.0 — `npx tsc --noEmit` reports no missing-export errors.
+
+The full list (for future reference if names ever do change):
+
+```
+Activity, AlertCircle, AlertTriangle, ArrowLeft, BarChart3, Bell, Bike, Bot,
+Building2, Calendar, CalendarClock, CalendarPlus, Check, CheckCircle,
+CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Clapperboard,
+ClipboardCheck, Clock, Clock3, Cloud, Cookie, Database, ExternalLink, Eye,
+EyeOff, FileText, Film, Filter, Footprints, Globe, Heart, History, Image,
+ImageIcon, Info, LayoutDashboard, Leaf, Link2, List, ListFilter, Loader2,
+MapPin, Megaphone, Menu, Monitor, Moon, MousePointer, Navigation, Pencil, Play,
+Plus, RefreshCw, RotateCcw, Search, Settings, Share2, ShieldAlert, ShoppingCart,
+Siren, SlidersHorizontal, Sparkles, Star, Sun, Tag, Ticket, Train, Trash2,
+TrendingUp, User, Users, Video, X, XCircle, Zap
+```
+
+## Verification
+
+- `npm run lint` → 0 errors, 41 warnings
+- `npx tsc --noEmit` → clean (proves every imported icon resolves)
+- `npm run test:run` → 913/913 pass
+
+## Impact
+
+- No runtime visual change expected. Icons render the same.
+- Bundle size may shift slightly with v1's tree-shaking improvements but the project already imports named icons (which tree-shake cleanly in 0.x and 1.x).
+- Phase 2 item 4 of 12 complete.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "drizzle-orm": "^0.45.1",
         "inngest": "^4.2.4",
         "lottie-react": "^2.4.1",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.11.0",
         "next": "^16.2.4",
         "postgres": "^3.4.7",
         "posthog-js": "^1.362.0",
@@ -18238,9 +18238,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "drizzle-orm": "^0.45.1",
     "inngest": "^4.2.4",
     "lottie-react": "^2.4.1",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.11.0",
     "next": "^16.2.4",
     "postgres": "^3.4.7",
     "posthog-js": "^1.362.0",


### PR DESCRIPTION
## Summary
- \`lucide-react\` 0.562.0 → 1.11.0 (the v1.0 stabilization release after years on the 0.x train)
- Phase 2 item 4 from \`tasks/todo.md\`

## Audit
Extracted all 78 unique icon imports across the codebase. Every name still resolves in v1.11.0 — \`tsc --noEmit\` is clean.

## Verification
- [x] \`npm run lint\` → 0 errors, 41 warnings
- [x] \`npx tsc --noEmit\` → clean (proves every imported icon resolves)
- [x] \`npm run test:run\` → 913/913 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)