### PR TITLE
chore(deps): bump tailwind-merge to v3 (frontend)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,14 @@
+## 2026-04-26: Bump tailwind-merge to v3 (frontend)
+**PR**: TBD | **Files**: `frontend/package.json`, `frontend/package-lock.json`
+- `tailwind-merge` 2.6.1 → 3.5.0. Single usage at `frontend/src/lib/utils.ts:5` — the `cn()` wrapper around `twMerge(clsx(inputs))`.
+- The `twMerge()` function signature is unchanged in v3; v3's breaking changes are around custom config shapes which we don't use.
+- Verification: `npm run check` 13 errors / 2 warnings (matches origin/main exactly — all pre-existing). Dev server boots clean and `/`, `/cinemas`, `/map` all return HTTP 200.
+- Phase 2 item 5 from `tasks/todo.md`.
+
+---
+
 ## 2026-04-26: Bump lucide-react to v1
-**PR**: TBD | **Files**: `package.json`, `package-lock.json`
+**PR**: #460 | **Files**: `package.json`, `package-lock.json`
 - `lucide-react` 0.562.0 → 1.11.0 (the v1.0 stabilization release).
 - Audited all 78 unique icon imports across `src/**/*.{ts,tsx}` — every name still exists in v1.11.0. `npx tsc --noEmit` resolves all imports cleanly.
 - No source code changes required.

--- a/changelogs/2026-04-26-tailwind-merge-v3.md
+++ b/changelogs/2026-04-26-tailwind-merge-v3.md
@@ -1,0 +1,43 @@
+# Bump tailwind-merge to v3 (frontend)
+
+**PR**: TBD
+**Date**: 2026-04-26
+**Branch**: `chore/tailwind-merge-v3`
+
+## Changes
+
+- `tailwind-merge` 2.6.1 → 3.5.0 in `frontend/package.json`
+- No source code changes
+
+## Why
+
+Phase 2 item 5 from `tasks/todo.md`. Frontend-only change — backend doesn't use this package.
+
+## Audit
+
+Single usage in the entire frontend, at `frontend/src/lib/utils.ts:5`:
+
+```ts
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+This is the canonical `cn()` helper pattern. v3's breaking changes are around custom-config shapes (extending the class-group merge map), which we don't use — vanilla `twMerge(string)` is unchanged across v2 and v3.
+
+## Verification
+
+- `npm run check` (svelte-check) → 13 errors, 2 warnings (matches origin/main exactly — all pre-existing, none related to tailwind-merge)
+- `npm run dev` boots cleanly. Smoke tested 3 routes:
+  - `/` → HTTP 200
+  - `/cinemas` → HTTP 200
+  - `/map` → HTTP 200
+
+## Impact
+
+- No runtime behavior change. The `cn()` helper produces the same merged class string.
+- No bundle-size regression expected.
+- Phase 2 item 5 of 12 complete.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
 				"posthog-js": "^1.0.0",
 				"svelte-clerk": "^1.1.1",
 				"svelte-maplibre": "^1.3.0",
-				"tailwind-merge": "^2.0.0"
+				"tailwind-merge": "^3.5.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.58.2",
@@ -3440,9 +3440,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tailwind-merge": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-			"integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+			"integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,6 @@
 		"posthog-js": "^1.0.0",
 		"svelte-clerk": "^1.1.1",
 		"svelte-maplibre": "^1.3.0",
-		"tailwind-merge": "^2.0.0"
+		"tailwind-merge": "^3.5.0"
 	}
 }


### PR DESCRIPTION
## Summary
- \`tailwind-merge\` 2.6.1 → 3.5.0 in \`frontend/package.json\`
- Single usage at \`frontend/src/lib/utils.ts:5\` — the \`cn()\` wrapper around \`twMerge(clsx(inputs))\`. \`twMerge\` signature unchanged in v3.
- Phase 2 item 5 from \`tasks/todo.md\`

## Verification
- [x] \`npm run check\` → 13 errors / 2 warnings (matches origin/main exactly — pre-existing)
- [x] Dev server boots, \`/\`, \`/cinemas\`, \`/map\` all return HTTP 200
- [x] Backend unaffected (frontend-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)