### PR TITLE
chore(deps): bump uuid to v14, drop redundant @types/uuid

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,13 @@
+## 2026-04-26: Bump uuid to v14 + drop redundant @types/uuid
+**PR**: TBD | **Files**: `package.json`, `package-lock.json`
+- `uuid` 13.0.0 → 14.0.0. Six call sites all use `import { v4 as uuidv4 } from "uuid"` — signature unchanged.
+- Removed `@types/uuid@^10.0.0` from `devDependencies`. uuid v14 ships its own type declarations (`./dist/index.d.ts`), making the separate `@types/*` package redundant.
+- Phase 2 item 6 from `tasks/todo.md`.
+
+---
+
 ## 2026-04-26: Bump tailwind-merge to v3 (frontend)
-**PR**: TBD | **Files**: `frontend/package.json`, `frontend/package-lock.json`
+**PR**: #461 | **Files**: `frontend/package.json`, `frontend/package-lock.json`
 - `tailwind-merge` 2.6.1 → 3.5.0. Single usage at `frontend/src/lib/utils.ts:5` — the `cn()` wrapper around `twMerge(clsx(inputs))`.
 - The `twMerge()` function signature is unchanged in v3; v3's breaking changes are around custom config shapes which we don't use.
 - Verification: `npm run check` 13 errors / 2 warnings (matches origin/main exactly — all pre-existing). Dev server boots clean and `/`, `/cinemas`, `/map` all return HTTP 200.

--- a/changelogs/2026-04-26-uuid-v14.md
+++ b/changelogs/2026-04-26-uuid-v14.md
@@ -1,0 +1,54 @@
+# Bump uuid to v14 + drop redundant @types/uuid
+
+**PR**: TBD
+**Date**: 2026-04-26
+**Branch**: `chore/uuid-v14`
+
+## Changes
+
+- `uuid` 13.0.0 → 14.0.0
+- Removed `@types/uuid@^10.0.0` from `devDependencies` (uuid v14 ships its own types)
+
+## Why
+
+Phase 2 item 6 from `tasks/todo.md`.
+
+## Audit
+
+Six call sites, all using the same import pattern:
+
+```ts
+import { v4 as uuidv4 } from "uuid";
+```
+
+Files:
+- `src/lib/scraper-health/index.ts`
+- `src/db/seed-screenings.ts`
+- `src/db/seed-cli.ts` (also imports `v4` directly)
+- `src/scrapers/pipeline.ts`
+- `src/scrapers/utils/film-matching.ts`
+- `src/scrapers/seasons/pipeline.ts`
+
+The `v4` named export still exists in v14 — `npx tsc --noEmit` resolves all six imports cleanly.
+
+## @types/uuid removal
+
+uuid v14's `package.json` declares:
+
+```json
+"types": "./dist/index.d.ts"
+```
+
+That makes the separate `@types/uuid` package redundant — having both can cause TypeScript to pick the wrong types. Removed `@types/uuid` from `devDependencies`. `tsc --noEmit` confirms no type-resolution regressions.
+
+## Verification
+
+- `npm run lint` → 0 errors, 41 warnings
+- `npx tsc --noEmit` → clean
+- `npm run test:run` → 913/913 pass
+
+## Impact
+
+- No runtime behavior change. UUID v4 strings still generate the same way.
+- Smaller `devDependencies` footprint.
+- Phase 2 item 6 of 12 complete.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "tailwind-merge": "^3.4.0",
         "unpdf": "^1.4.0",
         "use-debounce": "^10.0.6",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "zod": "^4.2.1",
         "zustand": "^5.0.9"
       },
@@ -55,7 +55,6 @@
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "@types/uuid": "^10.0.0",
         "@vitest/coverage-v8": "^4.0.16",
         "apify-client": "^2.22.0",
         "babel-plugin-react-compiler": "1.0.0",
@@ -2496,6 +2495,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph/node_modules/uuid": {
@@ -11755,13 +11767,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -22877,9 +22882,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "tailwind-merge": "^3.4.0",
     "unpdf": "^1.4.0",
     "use-debounce": "^10.0.6",
-    "uuid": "^13.0.0",
+    "uuid": "^14.0.0",
     "zod": "^4.2.1",
     "zustand": "^5.0.9"
   },
@@ -149,7 +149,6 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "^4.0.16",
     "apify-client": "^2.22.0",
     "babel-plugin-react-compiler": "1.0.0",


### PR DESCRIPTION
## Summary
- \`uuid\` 13.0.0 → 14.0.0
- Removed \`@types/uuid@^10.0.0\` (uuid v14 ships its own type declarations)
- Phase 2 item 6 from \`tasks/todo.md\`

## Audit
Six call sites all use \`import { v4 as uuidv4 } from "uuid"\`. \`v4\` export unchanged in v14, all imports resolve cleanly.

## Verification
- [x] \`npm run lint\` → 0 errors, 41 warnings
- [x] \`npx tsc --noEmit\` → clean
- [x] \`npm run test:run\` → 913/913 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)