### PR TITLE
chore(deps): bump TypeScript to v6 in both halves

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,14 @@
+## 2026-04-26: Bump TypeScript to v6 (both halves)
+**PR**: TBD | **Files**: `package.json`, `package-lock.json`, `frontend/package.json`, `frontend/package-lock.json`, `types/globals.d.ts`
+- `typescript` 5.9.3 → 6.0.3 in both root and `frontend/`. Single PR per the plan, keeping versions in lock-step.
+- New file `types/globals.d.ts` with `/// <reference types="google.maps" />`. TS v6 tightened auto-loading of transitive `@types/*` packages — `@types/google.maps` (used by `src/components/map/cinema-map.tsx` for the `google.maps.X` namespace) comes in via `@vis.gl/react-google-maps` and was no longer auto-resolved. The single-line global reference makes the dependency explicit.
+- Verification: backend lint 0/41, tsc clean, 913/913 tests pass. Frontend svelte-check 13 errors / 2 warnings (matches origin/main exactly — all pre-existing). Dev server boots, `/`, `/cinemas`, `/map` all HTTP 200.
+- Phase 2 item 9 from `tasks/todo.md`.
+
+---
+
 ## 2026-04-26: Bump jsdom to v29
-**PR**: TBD | **Files**: `package.json`, `package-lock.json`
+**PR**: #463 | **Files**: `package.json`, `package-lock.json`
 - `jsdom` 27.4.0 → 29.0.2. Test environment only — used by Vitest for `@testing-library/react` rendering.
 - No source code changes. All 913 tests pass without modification across the v27 → v29 jump.
 - Phase 2 item 7 from `tasks/todo.md`.

--- a/changelogs/2026-04-26-typescript-v6.md
+++ b/changelogs/2026-04-26-typescript-v6.md
@@ -1,0 +1,56 @@
+# Bump TypeScript to v6 (both halves)
+
+**PR**: TBD
+**Date**: 2026-04-26
+**Branch**: `chore/typescript-v6`
+
+## Changes
+
+- `typescript` 5.9.3 → 6.0.3 in **both** `package.json` and `frontend/package.json`. Single PR per the plan, keeping the two halves in lock-step so a regression is bisectable.
+- New file `types/globals.d.ts` with a single line:
+  ```ts
+  /// <reference types="google.maps" />
+  ```
+
+## Why
+
+Phase 2 item 9 from `tasks/todo.md`. v5 → v6 was queued as a "stricter type checks may surface latent issues" risk; in practice the codebase passed tsc + svelte-check with one fix.
+
+## The `google.maps` fix
+
+TS v5.9 auto-loaded `@types/google.maps` via the transitive resolution from `@vis.gl/react-google-maps` (which depends on it). TS v6 is stricter — only directly-declared `@types/*` packages are auto-included. `src/components/map/cinema-map.tsx` references the `google.maps.*` namespace ~14 times, all of which started failing with:
+
+```
+TS2503: Cannot find namespace 'google'.
+TS2304: Cannot find name 'google'.
+```
+
+Tried adding `@types/google.maps` as a direct devDep — didn't help (TS v6 still wouldn't auto-load it). The clean fix is a triple-slash directive in a project-level types file:
+
+```ts
+// types/globals.d.ts
+/// <reference types="google.maps" />
+```
+
+This is matched by the existing `tsconfig.json` `"include": ["**/*.ts", ...]` glob, so TS picks it up automatically. The reference is project-wide, not file-local, so any future Google Maps usage gets the same types.
+
+## Verification
+
+### Backend
+- `npm run lint` → 0 errors, 41 warnings
+- `npx tsc --noEmit` → clean
+- `npm run test:run` → 913/913 pass
+
+### Frontend
+- `npm run check` (svelte-check) → 13 errors, 2 warnings (matches origin/main exactly — all pre-existing, none introduced by TS v6)
+- `npm run dev` boots cleanly. Smoke tested:
+  - `/` → HTTP 200
+  - `/cinemas` → HTTP 200
+  - `/map` → HTTP 200 (the route most likely to break given the cinema-map fix)
+
+## Impact
+
+- No runtime behavior change.
+- Slightly stricter type checks across both halves.
+- The `types/globals.d.ts` file is the canonical home for any future global type references the codebase needs.
+- Phase 2 item 9 of 12 complete. **Note item 8 (eslint v10) is blocked on upstream `eslint-plugin-react` not yet supporting eslint v10 — see `tasks/todo.md`.**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
 				"svelte": "^5.54.0",
 				"svelte-check": "^4.4.2",
 				"tailwindcss": "^4.0.0",
-				"typescript": "^5.9.3",
+				"typescript": "^6.0.3",
 				"vite": "^7.3.1"
 			}
 		},
@@ -3530,9 +3530,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
 		"svelte": "^5.54.0",
 		"svelte-check": "^4.4.2",
 		"tailwindcss": "^4.0.0",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^7.3.1"
 	},
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/cheerio": "^0.22.35",
+        "@types/google.maps": "^3.64.0",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -73,7 +74,7 @@
         "tailwindcss": "^4",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.21.0",
-        "typescript": "^5",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.16"
       },
       "engines": {
@@ -2258,6 +2259,19 @@
       "dependencies": {
         "@types/node": "^22.10.5",
         "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@inngest/ai/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@jpwilliams/waitgroup": {
@@ -22665,9 +22679,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/cheerio": "^0.22.35",
+    "@types/google.maps": "^3.64.0",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -167,7 +168,7 @@
     "tailwindcss": "^4",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.21.0",
-    "typescript": "^5",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.16"
   }
 }

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="google.maps" />


### PR DESCRIPTION
## Summary
- \`typescript\` 5.9.3 → 6.0.3 in both root and \`frontend/\`. Single PR keeping the two halves in lock-step.
- New \`types/globals.d.ts\` with \`/// <reference types="google.maps" />\` to satisfy TS v6's stricter auto-load behavior.
- Phase 2 item 9 from \`tasks/todo.md\`.

## The google.maps fix
TS v5 auto-loaded \`@types/google.maps\` because \`@vis.gl/react-google-maps\` depends on it. TS v6 only auto-loads directly-declared \`@types/*\`, so \`src/components/map/cinema-map.tsx\`'s ~14 \`google.maps.*\` references started failing. The triple-slash directive in a project-level globals file is the cleanest fix — TS picks it up via the existing tsconfig include glob.

## Verification
### Backend
- [x] \`npm run lint\` → 0 errors, 41 warnings
- [x] \`npx tsc --noEmit\` → clean
- [x] \`npm run test:run\` → 913/913 pass

### Frontend
- [x] \`npm run check\` → 13 errors, 2 warnings (matches origin/main — all pre-existing)
- [x] Dev server boots, \`/\`, \`/cinemas\`, \`/map\` all HTTP 200

## Note
Item 8 (eslint v9 → v10) is **blocked on upstream**: \`eslint-plugin-react@7.37.5\` (latest) does not declare peer compatibility with eslint v10. Documented in \`tasks/todo.md\` so it can be revisited when the plugin ships v10 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)