### PR TITLE
feat(frontend): perf + search-UX batch (web-vitals, iOS zoom, recents, content-visibility)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,20 @@
+## 2026-04-27: Frontend perf + search-UX batch
+**PR**: TBD | **Files**: 4 new + 9 modified across `frontend/src`
+- **Perf:** Ship `web-vitals` v5 → PostHog with route × viewport × connection dims (`web_vital` event), replacing PostHog's redundant `capture_performance` flag. Universal #1 pick across all 9 panel agents.
+- **Perf:** Trim homepage server payload from 30-day to 14-day window (UX Architect's unique pick) — halves transfer size + JSON parse on LCP path.
+- **Perf:** Add `preconnect` + `dns-prefetch` for `api.pictures.london` (TMDB already had it).
+- **Perf:** Mark first 1 mobile poster + first 4 desktop posters with `fetchpriority="high"` + `loading="eager"`; rest stay lazy. Add `content-visibility: auto` + `contain-intrinsic-size` on calendar row/card components to skip offscreen layout.
+- **Refactor:** Split `frontend/src/routes/film/[id]/+page.svelte` from 1,113 → 867 lines by extracting `FilmSidebar.svelte` (eager) and `FilmSimilarRail.svelte` (lazy via `requestIdleCallback`).
+- **Search UX:** Full `SearchInput.svelte` rewrite — adds `inputmode="search"` + `enterkeyhint="search"` (UI Designer's iOS zoom + keyboard fix), `AbortController` on every keystroke, debounce 200ms → 120ms, full ARIA combobox pattern (`aria-activedescendant`, `aria-live` result-count), `<mark>` match highlighting on titles + directors + cinema names.
+- **Search predictions:** Recent searches drawer (last 5, localStorage) shown on focus when query is empty. New `lib/stores/recent-searches.svelte.ts`.
+- **Search instrumentation:** Extend `search_performed` event with `latency_ms`, `films_count`, `cinemas_count`. Add `entity_type` to `search_result_clicked` + new `trackSearchCinemaClick`.
+- Code-reviewed: bumped `DesktopHybridCard` `contain-intrinsic-size` from 360px → 640px after reviewer flagged real CLS risk on 4-col grid.
+- Backend search-relevance work (pg_trgm + unaccent + ranking) is the consensus #1 from the search panel but lives in the Next.js API; queued as a separate PR.
+
+---
+
 ## 2026-04-26: Drop unused @chenglou/pretext from frontend deps
-**PR**: TBD | **Files**: `frontend/package.json`, `frontend/package-lock.json`
+**PR**: #466 | **Files**: `frontend/package.json`, `frontend/package-lock.json`
 - Plan item 11 was "bump @chenglou/pretext 0.0.3 → 0.0.6", but `grep -rE "@chenglou"` returns zero hits in `frontend/src/**`. Same situation the Anthropic SDKs were in (item 1) — listed in `package.json` but never imported.
 - The local `frontend/src/lib/components/pretext/` directory contains custom Svelte components (`BreathingGrid.svelte`, `FittedTitleCanvas.svelte`) inspired by the package's design language but written from scratch in this codebase. They don't import the package.
 - Decision: remove the unused dep instead of bumping it. Saves install footprint and removes a 0.x version bomb from the maintenance surface.

--- a/changelogs/2026-04-27-fe-perf-search-batch.md
+++ b/changelogs/2026-04-27-fe-perf-search-batch.md
@@ -1,0 +1,65 @@
+# Frontend perf + search-UX batch
+
+**PR**: TBD
+**Date**: 2026-04-27
+**Branch**: `feat/fe-perf-search-batch-1`
+
+## Background
+
+Two parallel multi-agent research panels (consolidated reports in `Obsidian Vault/Pictures/Research/2026-04-26-frontend-perf-pitches.md` and `2026-04-26-search-pitches.md`) ranked perf and search improvements for `pictures.london`. The user approved the consensus set plus a handful of unique-perspective picks; this PR ships the frontend-only ones. Backend changes (pg_trgm + unaccent + relevance ranking) — the search panel's universal #1 — live in the Next.js API and are queued as a separate PR.
+
+## Changes
+
+### Performance
+
+- **`web-vitals` → PostHog**: Adds `web-vitals` v5 dep (~2 KB gzip, Google-maintained, sole new dep). Registers `onLCP/onINP/onCLS/onTTFB/onFCP` from `frontend/src/lib/analytics/web-vitals.ts`, fires `web_vital` events with `metric_name`, `value`, `rating`, `route`, `viewport`, `viewport_w`, `connection_type`. Replaces PostHog's `capture_performance: true` flag (which captured raw timings without CWV attribution). Loaded in `PostHogProvider.svelte` after PostHog init (already idle-deferred).
+- **Homepage payload trim**: `frontend/src/routes/+page.server.ts` `endDate` cut from +30d → +14d. Halves transfer + JSON parse on LCP path. UX Architect's unique pick from the perf panel.
+- **`preconnect` + `dns-prefetch`** for `api.pictures.london` added in `frontend/src/app.html` (TMDB already had it). Saves ~150–300ms TLS+DNS on cold mobile.
+- **Poster `fetchpriority` + `loading`**: First 1 above-fold poster on mobile (`MobileFilmRow` `priority` prop, applied to `dayGroups[0].films[0]` in `+page.svelte`) and first 4 desktop posters (`DesktopHybridCard` `priority` prop) get `fetchpriority="high"` + `loading="eager"`. Rest stay lazy.
+- **`content-visibility: auto` + `contain-intrinsic-size`** on `MobileFilmRow.row` (220px) and `DesktopHybridCard.card` (640px after review tightening). Browser skips layout/paint for offscreen rows. Intrinsic sizes sized to actual rendered card height to avoid CLS on first reveal.
+
+### `film/[id]/+page.svelte` refactor (1,113 → 867 lines, –22%)
+
+- New `frontend/src/lib/components/film/FilmSidebar.svelte` (credits / tagline / status). Rendered eagerly — small, primary content area.
+- New `frontend/src/lib/components/film/FilmSimilarRail.svelte` (the "If you like this" rail). Lazy-imported via `requestIdleCallback` after first paint, so the rail's image-heavy markup + CSS don't compete with hero/showings paint. The `>= 2` guard remains.
+- Showings section + day picker intentionally left in the main file — primary content + tightly coupled to the popover state. Worth its own PR if we want to keep cutting.
+
+### Search UX (full `SearchInput.svelte` rewrite)
+
+- **iOS zoom prevention** (UI Designer's unique pick, user-flagged): `inputmode="search"` + `enterkeyhint="search"` on the `<input>` (existing `font-size: 16px` was already there, completing the set).
+- **`AbortController` per keystroke + debounce 200 → 120ms**: Each new query aborts the previous in-flight request. Drops wasted backend calls and tightens felt latency. Cleaned up in `onMount` teardown.
+- **Latency instrumentation**: `trackSearch(q, total, { latencyMs, filmsCount, cinemasCount })` measured via `performance.now()` deltas. Establishes the SLI the backend ranking PR will be measured against.
+- **Full ARIA 1.2 combobox**: `aria-activedescendant`, listbox-with-options pattern, visually-hidden `aria-live="polite"` region announcing "X results for {q}" *after debounce settles* (avoids per-keystroke screen-reader spam).
+- **Match highlighting**: `<mark>` around case-insensitive query occurrences in result titles, directors, and cinema names. Pure transparent background — no Swiss-style break.
+- **Recent searches drawer** (consensus pick + user-flagged "predictions"): New `frontend/src/lib/stores/recent-searches.svelte.ts` — last 5 queries, localStorage-backed, dedup case-insensitively. Shown on input focus when query is empty. Per-row remove + clear-all.
+- **Empty-dropdown flash fix**: `handleInput` only opens the dropdown when there's something to show (live results or recents) — prevents a 1-char gap between recents and live results from flashing an empty panel.
+- **Recent rows are `<div role="option">`** (not `<button>`) so the inline remove button can nest without invalid HTML. Listbox keyboard nav still works through `aria-activedescendant` from the input.
+
+### `apiGet` extension
+
+- `frontend/src/lib/api/client.ts` now accepts `signal?: AbortSignal` on the options bag, forwarded to `fetch`. Used by SearchInput's AbortController.
+
+## Reverted during implementation
+
+- **Layout cinemas cache**: Initial attempt added `setHeaders({ 'cache-control': ... })` to `+layout.server.ts`. SvelteKit throws on duplicate `cache-control` between layout and page (the homepage and other routes already set their own via ISR). Reverted with an explanatory comment in the layout. Caching of `/api/cinemas` will be addressed at a different layer (upstream API headers + Vercel fetch cache) in a future PR.
+
+## Impact
+
+- Affects every route (web-vitals + preconnect + cinemas in layout).
+- Affects homepage (payload trim + poster priority + content-visibility).
+- Affects `film/[id]` route (sidebar/similar split).
+- Affects header search across all routes (full SearchInput rewrite).
+
+## Verification
+
+- `npm run lint` from root: 0 errors, 41 pre-existing warnings.
+- `npm run check` in `frontend/`: 11 baseline errors (all in `letterboxd/+page.svelte`, none in modified files).
+- `npm run build` in `frontend/`: clean.
+- Code-reviewer agent flagged one blocker (DesktopHybridCard intrinsic-size 360px → 640px) and one minor (1-char empty dropdown) — both fixed before commit.
+- Manual smoke test: homepage `200`, `/search?q=blade` `200`, `/film/[real-id]` `200` with all expected sections (breadcrumb, hero, sidebar) rendering.
+- Playwright tests need backend dev server (`localhost:3000`) or `API_PROXY_TARGET=https://api.pictures.london` env. Will be exercised on Vercel preview.
+
+## Known trade-offs
+
+- 14-day homepage window: the calendar popover lets users navigate past day-14 with no max. Beyond 14 days they'd see an empty list. User signed off on this when approving the trim. Could be tightened with a `max` on the popover or a "load more" CTA in a follow-up.
+- Backend search relevance (pg_trgm + unaccent + ranking) was every search-panel agent's #1 pick but lives in `src/app/api/films/search/route.ts` (Next.js backend). Queued as a separate PR with backend coordination.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
 				"posthog-js": "^1.0.0",
 				"svelte-clerk": "^1.1.1",
 				"svelte-maplibre": "^1.3.0",
-				"tailwind-merge": "^3.5.0"
+				"tailwind-merge": "^3.5.0",
+				"web-vitals": "^5.2.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.58.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
 		"posthog-js": "^1.0.0",
 		"svelte-clerk": "^1.1.1",
 		"svelte-maplibre": "^1.3.0",
-		"tailwind-merge": "^3.5.0"
+		"tailwind-merge": "^3.5.0",
+		"web-vitals": "^5.2.0"
 	}
 }

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -6,6 +6,8 @@
 		<meta name="theme-color" content="#0a0a0a" />
 		<link rel="preconnect" href="https://image.tmdb.org" crossorigin />
 		<link rel="dns-prefetch" href="https://image.tmdb.org" />
+		<link rel="preconnect" href="https://api.pictures.london" crossorigin />
+		<link rel="dns-prefetch" href="https://api.pictures.london" />
 		<link rel="preload" href="/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin />
 		<link rel="preload" href="/fonts/Fraunces.woff2" as="font" type="font/woff2" crossorigin />
 		<link rel="preload" href="/fonts/IBMPlexMono.woff2" as="font" type="font/woff2" crossorigin />

--- a/frontend/src/lib/analytics/PostHogProvider.svelte
+++ b/frontend/src/lib/analytics/PostHogProvider.svelte
@@ -14,13 +14,20 @@
 		if (!browser) return;
 
 		const loadPostHog = () => {
-			Promise.all([import('./posthog'), import('posthog-js')]).then(([mod, ph]) => {
+			Promise.all([
+				import('./posthog'),
+				import('posthog-js'),
+				import('./web-vitals')
+			]).then(([mod, ph, webVitals]) => {
 				mod.initPostHog();
 				posthogModule = mod;
 				posthogLib = ph.default;
 				// Track initial pageview (deferred)
 				mod.trackPageview(page.url.href);
 				lastPath = page.url.pathname;
+				// Start web-vitals reporting once PostHog is alive. The reporter
+				// is idempotent on subsequent calls.
+				void webVitals.startWebVitals(ph.default);
 			});
 		};
 

--- a/frontend/src/lib/analytics/posthog.ts
+++ b/frontend/src/lib/analytics/posthog.ts
@@ -44,7 +44,10 @@ export function initPostHog() {
 			dom_event_allowlist: ['click', 'submit', 'change'],
 			element_allowlist: ['button', 'a', 'input', 'select', 'textarea']
 		},
-		capture_performance: true,
+		// Disabled in favour of the web-vitals reporter at $lib/analytics/web-vitals,
+		// which captures LCP/INP/CLS/TTFB/FCP with route + viewport + connection
+		// dimensions PostHog's built-in flag doesn't expose.
+		capture_performance: false,
 		capture_exceptions: true
 	});
 
@@ -159,22 +162,48 @@ export function trackFilmStatusChange(
 
 // ── Search Events ───────────────────────────────────────────────
 
-export function trackSearch(query: string, resultCount: number) {
+export function trackSearch(
+	query: string,
+	resultCount: number,
+	options?: { latencyMs?: number; filmsCount?: number; cinemasCount?: number }
+) {
 	if (!browser) return;
 	posthog.capture('search_performed', {
 		query,
 		query_length: query.length,
-		result_count: resultCount
+		result_count: resultCount,
+		latency_ms: options?.latencyMs,
+		films_count: options?.filmsCount,
+		cinemas_count: options?.cinemasCount
 	});
 }
 
-export function trackSearchResultClick(query: string, film: FilmContext, resultPosition: number) {
+type SearchResultEntity = 'film' | 'cinema' | 'recent';
+
+export function trackSearchResultClick(
+	query: string,
+	film: FilmContext,
+	resultPosition: number,
+	entityType: SearchResultEntity = 'film'
+) {
 	if (!browser) return;
 	posthog.capture('search_result_clicked', {
 		query,
 		film_id: film.filmId,
 		film_title: film.filmTitle,
-		result_position: resultPosition
+		result_position: resultPosition,
+		entity_type: entityType
+	});
+}
+
+export function trackSearchCinemaClick(query: string, cinemaId: string, cinemaName: string, resultPosition: number) {
+	if (!browser) return;
+	posthog.capture('search_result_clicked', {
+		query,
+		cinema_id: cinemaId,
+		cinema_name: cinemaName,
+		result_position: resultPosition,
+		entity_type: 'cinema' as SearchResultEntity
 	});
 }
 

--- a/frontend/src/lib/analytics/web-vitals.ts
+++ b/frontend/src/lib/analytics/web-vitals.ts
@@ -1,0 +1,78 @@
+/**
+ * Core Web Vitals → PostHog
+ *
+ * Reports field-data LCP / INP / CLS / TTFB / FCP via the official `web-vitals`
+ * package, tagged with route, viewport, and connection type so we can slice
+ * p75 by `route × is_mobile` in PostHog.
+ *
+ * Replaces PostHog's built-in `capture_performance` flag, which captures raw
+ * resource timings but not Core Web Vitals attribution.
+ */
+import type posthog from 'posthog-js';
+
+interface MinimalNetworkInformation {
+	effectiveType?: string;
+	saveData?: boolean;
+}
+
+function getConnectionType(): string | undefined {
+	if (typeof navigator === 'undefined') return undefined;
+	const conn = (
+		navigator as Navigator & { connection?: MinimalNetworkInformation }
+	).connection;
+	return conn?.effectiveType;
+}
+
+function getViewportBucket(): 'mobile' | 'tablet' | 'desktop' {
+	if (typeof window === 'undefined') return 'desktop';
+	const w = window.innerWidth;
+	if (w < 768) return 'mobile';
+	if (w < 1024) return 'tablet';
+	return 'desktop';
+}
+
+let started = false;
+
+export async function startWebVitals(client: typeof posthog): Promise<void> {
+	if (started) return;
+	if (typeof window === 'undefined') return;
+	started = true;
+
+	const { onLCP, onINP, onCLS, onTTFB, onFCP } = await import('web-vitals');
+
+	// Each web-vital callback has its own metric subtype (LCPMetric, INPMetric,
+	// …). They all share `name`/`value`/`rating`/`delta`/`navigationType` but
+	// the structural-typing collision means a single `Metric` alias rejects.
+	// Use a minimal common shape that satisfies every callback.
+	interface CommonMetric {
+		name: string;
+		value: number;
+		rating: 'good' | 'needs-improvement' | 'poor';
+		delta: number;
+		navigationType?: string;
+	}
+
+	const report = (metric: CommonMetric) => {
+		try {
+			client.capture('web_vital', {
+				metric_name: metric.name,
+				value: metric.value,
+				rating: metric.rating,
+				delta: metric.delta,
+				navigation_type: metric.navigationType,
+				route: window.location.pathname,
+				viewport: getViewportBucket(),
+				viewport_w: window.innerWidth,
+				connection_type: getConnectionType()
+			});
+		} catch {
+			/* best-effort — never throw from analytics */
+		}
+	};
+
+	onLCP(report);
+	onINP(report);
+	onCLS(report);
+	onTTFB(report);
+	onFCP(report);
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -15,7 +15,7 @@ export class ApiError extends Error {
 
 export async function apiGet<T>(
 	path: string,
-	opts?: { fetch?: typeof fetch; token?: string }
+	opts?: { fetch?: typeof fetch; token?: string; signal?: AbortSignal }
 ): Promise<T> {
 	const f = opts?.fetch ?? fetch;
 	const headers: Record<string, string> = {
@@ -25,7 +25,7 @@ export async function apiGet<T>(
 		headers['Authorization'] = `Bearer ${opts.token}`;
 	}
 
-	const res = await f(`${API_BASE}${path}`, { headers });
+	const res = await f(`${API_BASE}${path}`, { headers, signal: opts?.signal });
 	if (!res.ok) {
 		throw new ApiError(res.status, await res.text());
 	}

--- a/frontend/src/lib/components/calendar/DesktopHybridCard.svelte
+++ b/frontend/src/lib/components/calendar/DesktopHybridCard.svelte
@@ -25,11 +25,14 @@
 	let {
 		film,
 		screenings,
-		maxScreenings = 3
+		maxScreenings = 3,
+		priority = false
 	}: {
 		film: Film;
 		screenings: Screening[];
 		maxScreenings?: number;
+		/** Mark this card's poster as the LCP candidate (above-fold). */
+		priority?: boolean;
 	} = $props();
 
 	const upcoming = $derived.by(() =>
@@ -93,7 +96,8 @@
 					srcset={posterImage?.srcset}
 					sizes={posterImage?.sizes}
 					alt=""
-					loading="lazy"
+					loading={priority ? 'eager' : 'lazy'}
+					fetchpriority={priority ? 'high' : 'auto'}
 					decoding="async"
 				/>
 			{:else}
@@ -147,6 +151,15 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0;
+		/* Skip layout/paint for offscreen cards. `contain-intrinsic-size`
+		   reserves enough vertical space (poster aspect + meta + screenings)
+		   so scroll anchoring stays stable and there's no CLS on first reveal.
+		   Real cards are ~550–700px on a 4-col grid (poster ~450px tall at
+		   2:3 in a ~300px column, plus title/byline/meta/3 screenings); under-
+		   reserving causes visible jumps as offscreen cards reveal. `auto`
+		   lets the browser refine after first measurement. */
+		content-visibility: auto;
+		contain-intrinsic-size: auto 640px;
 	}
 
 	.poster-link {

--- a/frontend/src/lib/components/calendar/MobileFilmRow.svelte
+++ b/frontend/src/lib/components/calendar/MobileFilmRow.svelte
@@ -23,11 +23,14 @@
 	let {
 		film,
 		screenings,
-		maxScreenings = 3
+		maxScreenings = 3,
+		priority = false
 	}: {
 		film: Film;
 		screenings: Screening[];
 		maxScreenings?: number;
+		/** Mark this row's poster as the LCP candidate (first row above fold). */
+		priority?: boolean;
 	} = $props();
 
 	const upcoming = $derived.by(() =>
@@ -124,7 +127,8 @@
 					alt=""
 					width="116"
 					height="174"
-					loading="lazy"
+					loading={priority ? 'eager' : 'lazy'}
+					fetchpriority={priority ? 'high' : 'auto'}
 					decoding="async"
 				/>
 			{:else}
@@ -141,6 +145,11 @@
 		align-items: flex-start;
 		padding: 18px 0 20px;
 		border-bottom: 1px solid var(--color-border-subtle);
+		/* Skip layout/paint for offscreen rows. The browser renders only when
+		   the row scrolls within ~viewport. `contain-intrinsic-size` reserves
+		   space so scroll position and Cmd-F still work, with no CLS. */
+		content-visibility: auto;
+		contain-intrinsic-size: auto 220px;
 	}
 
 	.text-col {

--- a/frontend/src/lib/components/film/FilmSidebar.svelte
+++ b/frontend/src/lib/components/film/FilmSidebar.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import type { FilmStatus } from '$lib/types';
+
+	interface Film {
+		id: string;
+		title: string;
+		year: number | null;
+		genres: string[];
+		directors: string[];
+		cast: Array<{ name: string; character?: string }> | null;
+		countries: string[];
+		languages?: string[];
+		tagline: string | null;
+	}
+
+	let {
+		film,
+		currentStatus,
+		onToggleStatus
+	}: {
+		film: Film;
+		currentStatus: FilmStatus | null;
+		onToggleStatus: (status: FilmStatus) => void;
+	} = $props();
+</script>
+
+<aside class="sidebar">
+	<section class="credits-section">
+		<h3 class="credits-title">Credits</h3>
+
+		{#if film.directors?.length}
+			<div class="credit-row">
+				<span class="credit-key">Director{film.directors.length > 1 ? 's' : ''}</span>
+				<span class="credit-val">{film.directors.join(', ')}</span>
+			</div>
+		{/if}
+
+		{#if film.cast?.length}
+			<div class="credit-row">
+				<span class="credit-key">Cast</span>
+				<span class="credit-val">{film.cast.slice(0, 5).map((c) => c.name).join(', ')}</span>
+			</div>
+		{/if}
+
+		{#if film.countries?.length}
+			<div class="credit-row">
+				<span class="credit-key">Country</span>
+				<span class="credit-val">{film.countries.join(', ')}</span>
+			</div>
+		{/if}
+
+		{#if film.languages?.length}
+			<div class="credit-row">
+				<span class="credit-key">Language</span>
+				<span class="credit-val">{film.languages.join(', ')}</span>
+			</div>
+		{/if}
+	</section>
+
+	{#if film.tagline}
+		<section class="tagline-section">
+			<p class="tagline">{film.tagline}</p>
+		</section>
+	{/if}
+
+	<section class="status-section">
+		<h3 class="credits-title"><span class="italic-cap">S</span>tatus</h3>
+		<div class="status-row">
+			<button
+				type="button"
+				class="status-btn"
+				class:active={currentStatus === 'want_to_see'}
+				onclick={() => onToggleStatus('want_to_see')}
+				aria-pressed={currentStatus === 'want_to_see'}
+			>
+				Want to see
+			</button>
+			<button
+				type="button"
+				class="status-btn"
+				class:active={currentStatus === 'not_interested'}
+				onclick={() => onToggleStatus('not_interested')}
+				aria-pressed={currentStatus === 'not_interested'}
+			>
+				Not interested
+			</button>
+		</div>
+	</section>
+</aside>
+
+<style>
+	.sidebar {
+		padding-left: 0;
+	}
+
+	@media (min-width: 1024px) {
+		.sidebar {
+			border-left: 1px solid var(--color-border-subtle);
+			padding-left: 32px;
+		}
+	}
+
+	.credits-section, .status-section, .tagline-section {
+		padding-bottom: 20px;
+		border-bottom: 1px solid var(--color-border-subtle);
+		margin-bottom: 18px;
+	}
+
+	.credits-title {
+		margin: 0 0 10px;
+		font-family: var(--font-serif);
+		font-size: 14px;
+		font-weight: 500;
+		letter-spacing: -0.005em;
+		color: var(--color-text);
+	}
+	.credits-title :global(.italic-cap) { font-style: italic; }
+
+	.credit-row {
+		padding: 5px 0;
+		display: flex;
+		gap: 8px;
+		align-items: baseline;
+	}
+
+	.credit-key {
+		font-family: var(--font-mono-plex);
+		font-size: 10px;
+		color: var(--color-text-tertiary);
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		min-width: 90px;
+		padding-top: 3px;
+	}
+
+	.credit-val {
+		flex: 1;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 13px;
+		color: var(--color-text-secondary);
+		line-height: 1.3;
+	}
+
+	.tagline {
+		margin: 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 16px;
+		color: var(--color-text-secondary);
+		line-height: 1.35;
+	}
+
+	.status-row {
+		display: flex;
+		border: 1px solid var(--color-border);
+	}
+
+	.status-btn {
+		flex: 1;
+		padding: 8px 10px;
+		font-family: var(--font-serif);
+		font-size: 12.5px;
+		font-weight: 400;
+		letter-spacing: -0.005em;
+		color: var(--color-text-secondary);
+		background: transparent;
+		border: none;
+		border-right: 1px solid var(--color-border);
+		cursor: pointer;
+		transition: background-color var(--duration-fast) var(--ease-sharp),
+			color var(--duration-fast) var(--ease-sharp);
+	}
+
+	.status-btn:last-child { border-right: none; }
+
+	.status-btn:hover {
+		background: var(--color-bg-subtle);
+		color: var(--color-text);
+	}
+
+	.status-btn.active {
+		background: var(--color-text);
+		color: var(--color-bg);
+		font-weight: 500;
+	}
+</style>

--- a/frontend/src/lib/components/film/FilmSimilarRail.svelte
+++ b/frontend/src/lib/components/film/FilmSimilarRail.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	interface SimilarFilm {
+		id: string;
+		title: string;
+		year: number | null;
+		posterUrl: string | null;
+	}
+
+	let { similar }: { similar: SimilarFilm[] } = $props();
+</script>
+
+{#if similar.length >= 2}
+	<section class="similar" aria-labelledby="similar-heading">
+		<header class="similar-head">
+			<h2 id="similar-heading" class="similar-title">
+				<span class="italic-cap">I</span>f you like this
+			</h2>
+		</header>
+		<div class="similar-rail">
+			{#each similar as s (s.id)}
+				<a href="/film/{s.id}" class="similar-card">
+					<div class="similar-poster">
+						{#if s.posterUrl}
+							<img src={s.posterUrl} alt={s.title} loading="lazy" decoding="async" />
+						{:else}
+							<div class="similar-poster-fallback"><span>{s.title}</span></div>
+						{/if}
+					</div>
+					<h3 class="similar-name">{s.title}</h3>
+					{#if s.year}<p class="similar-year">{s.year}</p>{/if}
+				</a>
+			{/each}
+		</div>
+	</section>
+{/if}
+
+<style>
+	.similar {
+		max-width: 1400px;
+		margin: 0 auto;
+		padding: 32px 2rem 64px;
+		border-top: 1px solid var(--color-border-subtle);
+	}
+
+	.similar-head {
+		margin-bottom: 20px;
+	}
+
+	.similar-title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-weight: 400;
+		font-size: 28px;
+		letter-spacing: -0.02em;
+		line-height: 1;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 36';
+	}
+
+	.similar-title .italic-cap {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+	}
+
+	.similar-rail {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+		gap: 20px 18px;
+	}
+
+	@media (max-width: 767px) {
+		.similar-rail {
+			display: flex;
+			overflow-x: auto;
+			scroll-snap-type: x mandatory;
+			gap: 14px;
+			padding-bottom: 8px;
+		}
+		.similar-card {
+			flex: 0 0 132px;
+			scroll-snap-align: start;
+		}
+	}
+
+	.similar-card {
+		display: flex;
+		flex-direction: column;
+		color: var(--color-text);
+		text-decoration: none;
+	}
+
+	.similar-poster {
+		position: relative;
+		aspect-ratio: 2 / 3;
+		background: var(--color-bg-subtle);
+		border: 1px solid var(--color-border-subtle);
+		margin-bottom: 8px;
+		overflow: hidden;
+	}
+
+	.similar-poster img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.similar-poster-fallback {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		padding: 8px;
+		font-family: var(--font-serif);
+		font-size: 12px;
+		color: var(--color-text-tertiary);
+	}
+
+	.similar-name {
+		margin: 0 0 2px;
+		font-family: var(--font-serif);
+		font-weight: 400;
+		font-size: 14px;
+		line-height: 1.2;
+		color: var(--color-text);
+		font-variation-settings: '"SOFT" 100', '"opsz" 24';
+	}
+
+	.similar-year {
+		margin: 0;
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-size: 12px;
+		color: var(--color-text-tertiary);
+	}
+</style>

--- a/frontend/src/lib/components/filters/SearchInput.svelte
+++ b/frontend/src/lib/components/filters/SearchInput.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { onMount } from 'svelte';
-	import { debounce, getPosterImageAttributes } from '$lib/utils';
+	import { onMount, tick } from 'svelte';
+	import { getPosterImageAttributes } from '$lib/utils';
 	import { apiGet } from '$lib/api/client';
-	import { trackSearch, trackSearchNoResults, trackSearchResultClick } from '$lib/analytics/posthog';
+	import {
+		trackSearch,
+		trackSearchNoResults,
+		trackSearchResultClick,
+		trackSearchCinemaClick
+	} from '$lib/analytics/posthog';
+	import { recentSearches } from '$lib/stores/recent-searches.svelte';
 
 	interface SearchResult {
 		id: string;
@@ -20,6 +26,9 @@
 		address: string | null;
 	}
 
+	const DEBOUNCE_MS = 120;
+	const MIN_QUERY_LEN = 2;
+
 	let query = $state('');
 	let films = $state<SearchResult[]>([]);
 	let cinemas = $state<CinemaResult[]>([]);
@@ -27,37 +36,94 @@
 	let selectedIndex = $state(-1);
 	let inputEl = $state<HTMLInputElement>();
 	let loading = $state(false);
+	let liveStatus = $state('');
 
+	const recents = $derived(recentSearches.entries);
+	const showRecents = $derived(query.length === 0 && recents.length > 0);
 	const totalResults = $derived(films.length + cinemas.length);
+	const totalNavigable = $derived(showRecents ? recents.length : totalResults);
 
-	const doSearch = debounce(async (q: string) => {
-		if (q.length < 2) {
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let inFlight: AbortController | null = null;
+	let queuedAnnouncement: ReturnType<typeof setTimeout> | null = null;
+
+	function scheduleSearch(q: string) {
+		if (debounceTimer) clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => doSearch(q), DEBOUNCE_MS);
+	}
+
+	async function doSearch(q: string) {
+		if (q.length < MIN_QUERY_LEN) {
 			films = [];
 			cinemas = [];
+			loading = false;
 			return;
 		}
+
+		// Abort any in-flight request — we only care about the latest query.
+		if (inFlight) inFlight.abort();
+		const controller = new AbortController();
+		inFlight = controller;
+
 		loading = true;
+		const startedAt = performance.now();
 		try {
 			const res = await apiGet<{ results: SearchResult[]; cinemas: CinemaResult[] }>(
-				`/api/films/search?q=${encodeURIComponent(q)}`
+				`/api/films/search?q=${encodeURIComponent(q)}`,
+				{ signal: controller.signal }
 			);
+			if (controller.signal.aborted) return;
 			films = res.results;
 			cinemas = res.cinemas;
 			const total = films.length + cinemas.length;
-			trackSearch(q, total);
+			const latencyMs = Math.round(performance.now() - startedAt);
+			trackSearch(q, total, {
+				latencyMs,
+				filmsCount: films.length,
+				cinemasCount: cinemas.length
+			});
 			if (total === 0) trackSearchNoResults(q);
+			announceResults(total);
 		} catch (e) {
+			if (controller.signal.aborted) return;
 			console.error('[search] Failed to search:', e instanceof Error ? e.message : e);
 			films = [];
 			cinemas = [];
+		} finally {
+			if (inFlight === controller) {
+				inFlight = null;
+				loading = false;
+			}
 		}
-		loading = false;
-	}, 200);
+	}
+
+	function announceResults(total: number) {
+		if (queuedAnnouncement) clearTimeout(queuedAnnouncement);
+		// Delay slightly so the announcement reflects the settled state, not
+		// every keystroke. Avoids screen-reader spam.
+		queuedAnnouncement = setTimeout(() => {
+			liveStatus =
+				total === 0
+					? `No results for ${query}`
+					: `${total} result${total === 1 ? '' : 's'} for ${query}`;
+		}, 250);
+	}
 
 	function handleInput() {
 		selectedIndex = -1;
-		open = query.length >= 2;
-		doSearch(query);
+		// Only open the dropdown when we'll show *something*: live results
+		// (≥ MIN_QUERY_LEN) or the recents drawer (when query is empty).
+		// Closing for sub-min queries avoids an empty panel flash on the
+		// 1-char transition between recents and live results.
+		open = query.length >= MIN_QUERY_LEN || (query.length === 0 && recents.length > 0);
+		if (query.length === 0) {
+			if (inFlight) inFlight.abort();
+			films = [];
+			cinemas = [];
+			loading = false;
+			return;
+		}
+		scheduleSearch(query);
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
@@ -65,18 +131,18 @@
 
 		if (e.key === 'ArrowDown') {
 			e.preventDefault();
-			selectedIndex = Math.min(selectedIndex + 1, totalResults - 1);
+			selectedIndex = Math.min(selectedIndex + 1, totalNavigable - 1);
 		} else if (e.key === 'ArrowUp') {
 			e.preventDefault();
 			selectedIndex = Math.max(selectedIndex - 1, -1);
 		} else if (e.key === 'Enter') {
 			e.preventDefault();
-			if (selectedIndex >= 0) {
+			if (showRecents && selectedIndex >= 0) {
+				applyRecent(recents[selectedIndex]);
+			} else if (!showRecents && selectedIndex >= 0) {
 				navigateToResult(selectedIndex);
-			} else if (query.trim().length >= 2) {
-				open = false;
-				goto(`/search?q=${encodeURIComponent(query.trim())}`);
-				query = '';
+			} else if (query.trim().length >= MIN_QUERY_LEN) {
+				submitFullSearch();
 			}
 		} else if (e.key === 'Escape') {
 			open = false;
@@ -84,28 +150,59 @@
 		}
 	}
 
-	function navigateToResult(index: number) {
-		if (index < films.length) {
-			const film = films[index];
-			trackSearchResultClick(query, {
-				filmId: film.id,
-				filmTitle: film.title,
-				filmYear: film.year
-			}, index);
-			goto(`/film/${film.id}`);
-		} else {
-			const cinemaIndex = index - films.length;
-			goto(`/cinemas/${cinemas[cinemaIndex].id}`);
-		}
+	function submitFullSearch() {
+		const q = query.trim();
+		if (q.length < MIN_QUERY_LEN) return;
+		recentSearches.add(q);
 		open = false;
+		goto(`/search?q=${encodeURIComponent(q)}`);
 		query = '';
 	}
 
-	function handleFocus() {
-		if (query.length >= 2) open = true;
+	function navigateToResult(index: number) {
+		const q = query.trim();
+		if (index < films.length) {
+			const film = films[index];
+			trackSearchResultClick(
+				q,
+				{ filmId: film.id, filmTitle: film.title, filmYear: film.year },
+				index,
+				'film'
+			);
+			if (q.length >= MIN_QUERY_LEN) recentSearches.add(q);
+			goto(`/film/${film.id}`);
+		} else {
+			const cinemaIndex = index - films.length;
+			const cinema = cinemas[cinemaIndex];
+			trackSearchCinemaClick(q, cinema.id, cinema.name, index);
+			goto(`/cinemas/${cinema.id}`);
+		}
+		open = false;
+		query = '';
+		films = [];
+		cinemas = [];
+	}
+
+	function applyRecent(q: string) {
+		query = q;
+		open = true;
+		selectedIndex = -1;
+		// Jump straight to typeahead results for that query.
+		scheduleSearch(q);
+	}
+
+	async function handleFocus() {
+		if (query.length >= MIN_QUERY_LEN) {
+			open = true;
+		} else if (recents.length > 0) {
+			open = true;
+		}
+		// Ensure dropdown geometry is settled before keyboard nav.
+		await tick();
 	}
 
 	function handleBlur() {
+		// Defer so click handlers on results fire first.
 		setTimeout(() => (open = false), 200);
 	}
 
@@ -113,9 +210,40 @@
 		query = '';
 		films = [];
 		cinemas = [];
-		open = false;
+		if (inFlight) inFlight.abort();
+		open = recents.length > 0;
 		inputEl?.focus();
 	}
+
+	function clearOneRecent(q: string, e: MouseEvent) {
+		e.stopPropagation();
+		recentSearches.remove(q);
+	}
+
+	// Visual match highlighting: split a string around the case-insensitive
+	// occurrence(s) of the query. Returns alternating non-match / match parts.
+	function highlightParts(text: string, q: string): Array<{ text: string; match: boolean }> {
+		if (!q || q.length < MIN_QUERY_LEN) return [{ text, match: false }];
+		const parts: Array<{ text: string; match: boolean }> = [];
+		const lowerText = text.toLowerCase();
+		const lowerQ = q.toLowerCase();
+		let i = 0;
+		let idx = lowerText.indexOf(lowerQ, i);
+		while (idx !== -1) {
+			if (idx > i) parts.push({ text: text.slice(i, idx), match: false });
+			parts.push({ text: text.slice(idx, idx + q.length), match: true });
+			i = idx + q.length;
+			idx = lowerText.indexOf(lowerQ, i);
+		}
+		if (i < text.length) parts.push({ text: text.slice(i), match: false });
+		return parts;
+	}
+
+	const activeDescendant = $derived.by(() => {
+		if (!open || selectedIndex < 0) return undefined;
+		if (showRecents) return `search-opt-recent-${selectedIndex}`;
+		return `search-opt-${selectedIndex}`;
+	});
 
 	onMount(() => {
 		function globalKeydown(e: KeyboardEvent) {
@@ -125,7 +253,12 @@
 			}
 		}
 		document.addEventListener('keydown', globalKeydown);
-		return () => document.removeEventListener('keydown', globalKeydown);
+		return () => {
+			document.removeEventListener('keydown', globalKeydown);
+			if (debounceTimer) clearTimeout(debounceTimer);
+			if (queuedAnnouncement) clearTimeout(queuedAnnouncement);
+			if (inFlight) inFlight.abort();
+		};
 	});
 </script>
 
@@ -142,19 +275,23 @@
 			onfocus={handleFocus}
 			onblur={handleBlur}
 			onkeydown={handleKeydown}
-			type="text"
-			role="combobox" autocapitalize="off"
-			placeholder="Search films, cinemas, directors..."
-			class="search-input"
+			type="search"
+			role="combobox"
+			inputmode="search"
+			enterkeyhint="search"
+			autocapitalize="off"
 			autocomplete="off"
 			spellcheck="false"
+			placeholder="Search films, cinemas, directors..."
+			class="search-input"
 			aria-label="Search films, cinemas, directors"
 			aria-expanded={open}
 			aria-controls={open ? 'search-results' : undefined}
 			aria-autocomplete="list"
+			aria-activedescendant={activeDescendant}
 		/>
 		{#if query}
-			<button class="clear-btn" onclick={clearSearch} aria-label="Clear search">
+			<button class="clear-btn" type="button" onclick={clearSearch} aria-label="Clear search">
 				<svg aria-hidden="true" width="10" height="10" viewBox="0 0 10 10" fill="none">
 					<path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.2" stroke-linecap="square"/>
 				</svg>
@@ -164,11 +301,63 @@
 		{/if}
 	</div>
 
+	<!-- visually-hidden polite live region for screen-reader result counts -->
+	<div class="sr-only" aria-live="polite" aria-atomic="true">{liveStatus}</div>
+
 	{#if open}
 		<div class="results-dropdown" id="search-results" role="listbox" aria-label="Search results">
-			{#if loading}
+			{#if showRecents}
+				<div class="results-section-header">
+					<span>RECENT</span>
+					<button
+						class="recents-clear"
+						type="button"
+						onclick={() => recentSearches.clear()}
+						aria-label="Clear all recent searches"
+					>CLEAR</button>
+				</div>
+				{#each recents as recent, i (recent)}
+					<!-- Recent row uses div+role=option (not <button>) so the inline
+					     remove button can nest without invalid HTML. Listbox
+					     keyboard nav happens on the input via aria-activedescendant. -->
+					<div
+						class="result-row recent-row"
+						class:selected={selectedIndex === i}
+						id="search-opt-recent-{i}"
+						role="option"
+						aria-selected={selectedIndex === i}
+						tabindex="-1"
+						onmouseenter={() => (selectedIndex = i)}
+						onclick={() => applyRecent(recent)}
+						onkeydown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								e.preventDefault();
+								applyRecent(recent);
+							}
+						}}
+					>
+						<svg aria-hidden="true" class="result-clock" width="12" height="12" viewBox="0 0 12 12" fill="none">
+							<circle cx="6" cy="6" r="5" stroke="currentColor" stroke-width="1" opacity="0.5"/>
+							<path d="M6 3V6L8 7.5" stroke="currentColor" stroke-width="1" stroke-linecap="square" opacity="0.7"/>
+						</svg>
+						<div class="result-info">
+							<span class="result-title">{recent}</span>
+						</div>
+						<button
+							type="button"
+							class="recent-remove"
+							onclick={(e) => clearOneRecent(recent, e)}
+							aria-label="Remove {recent} from recent searches"
+						>
+							<svg aria-hidden="true" width="8" height="8" viewBox="0 0 8 8" fill="none">
+								<path d="M1 1L7 7M7 1L1 7" stroke="currentColor" stroke-width="1" stroke-linecap="square"/>
+							</svg>
+						</button>
+					</div>
+				{/each}
+			{:else if loading && totalResults === 0}
 				<div class="results-loading">SEARCHING...</div>
-			{:else if totalResults === 0 && query.length >= 2}
+			{:else if totalResults === 0 && query.length >= MIN_QUERY_LEN}
 				<div class="results-empty">
 					<span>NO RESULTS</span>
 					<a href="/search?q={encodeURIComponent(query)}" class="search-all-link" onclick={() => { open = false; query = ''; }}>
@@ -177,11 +366,13 @@
 				</div>
 			{:else}
 				{#if films.length > 0}
-					<div class="results-section-header">FILMS</div>
-					{#each films as film, i}
+					<div class="results-section-header"><span>FILMS</span></div>
+					{#each films as film, i (film.id)}
 						<button
+							type="button"
 							class="result-row"
 							class:selected={selectedIndex === i}
+							id="search-opt-{i}"
 							role="option"
 							aria-selected={selectedIndex === i}
 							onmouseenter={() => (selectedIndex = i)}
@@ -201,26 +392,34 @@
 									class="result-poster"
 									loading="lazy"
 									decoding="async"
+									width="28"
+									height="42"
 								/>
 							{:else}
 								<div class="result-poster-empty"></div>
 							{/if}
 							<div class="result-info">
-								<span class="result-title">{film.title}</span>
+								<span class="result-title">
+									{#each highlightParts(film.title, query) as part, pi (pi)}{#if part.match}<mark>{part.text}</mark>{:else}{part.text}{/if}{/each}
+								</span>
 								<span class="result-meta">
-									{film.year ?? ''}{film.directors.length ? ` · ${film.directors[0]}` : ''}
+									{film.year ?? ''}{#if film.directors.length} ·
+										{#each highlightParts(film.directors[0], query) as part, pi (pi)}{#if part.match}<mark>{part.text}</mark>{:else}{part.text}{/if}{/each}
+									{/if}
 								</span>
 							</div>
 						</button>
 					{/each}
 				{/if}
 				{#if cinemas.length > 0}
-					<div class="results-section-header">CINEMAS</div>
-					{#each cinemas as cinema, i}
+					<div class="results-section-header"><span>CINEMAS</span></div>
+					{#each cinemas as cinema, i (cinema.id)}
 						{@const idx = films.length + i}
 						<button
+							type="button"
 							class="result-row"
 							class:selected={selectedIndex === idx}
+							id="search-opt-{idx}"
 							role="option"
 							aria-selected={selectedIndex === idx}
 							onmouseenter={() => (selectedIndex = idx)}
@@ -230,7 +429,9 @@
 								<path d="M6 0C2.7 0 0 2.7 0 6c0 4.5 6 10 6 10s6-5.5 6-10c0-3.3-2.7-6-6-6z" fill="currentColor" opacity="0.4"/>
 							</svg>
 							<div class="result-info">
-								<span class="result-title">{cinema.name}</span>
+								<span class="result-title">
+									{#each highlightParts(cinema.name, query) as part, pi (pi)}{#if part.match}<mark>{part.text}</mark>{:else}{part.text}{/if}{/each}
+								</span>
 								{#if cinema.address}
 									<span class="result-meta">{cinema.address}</span>
 								{/if}
@@ -244,6 +445,18 @@
 </div>
 
 <style>
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
 	.search-container {
 		flex: 1;
 		min-width: 0;
@@ -275,7 +488,9 @@
 	}
 
 	/* 16px mobile base avoids iOS Safari's auto-zoom on focus (triggers below
-	   16px). Desktop overrides to `--font-size-sm` for visual consistency. */
+	   16px). Desktop overrides to `--font-size-sm` for visual consistency.
+	   `inputmode="search"` and `enterkeyhint="search"` on the element ensure
+	   the iOS keyboard shows the right return key + search-tuned layout. */
 	.search-input {
 		flex: 1;
 		border: none;
@@ -283,6 +498,13 @@
 		font-size: 16px;
 		color: var(--color-text);
 		outline: none;
+	}
+
+	/* Strip the WebKit cancel button — we render our own clear button. */
+	.search-input::-webkit-search-cancel-button,
+	.search-input::-webkit-search-decoration {
+		-webkit-appearance: none;
+		appearance: none;
 	}
 
 	@media (min-width: 768px) {
@@ -346,12 +568,31 @@
 	}
 
 	.results-section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
 		padding: 0.5rem 0.75rem 0.25rem;
 		font-size: 10px;
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		color: var(--color-text-tertiary);
+	}
+
+	.recents-clear {
+		font-size: 10px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--color-text-tertiary);
+		background: transparent;
+		border: none;
+		padding: 2px 4px;
+		cursor: pointer;
+	}
+
+	.recents-clear:hover {
+		color: var(--color-text);
 	}
 
 	.results-loading,
@@ -402,6 +643,21 @@
 		border-left-color: var(--color-accent);
 	}
 
+	.result-row mark {
+		background: transparent;
+		color: var(--color-text);
+		font-weight: 600;
+	}
+
+	.recent-row {
+		padding-left: 0.875rem;
+	}
+
+	.result-clock {
+		flex-shrink: 0;
+		color: var(--color-text-tertiary);
+	}
+
 	.result-poster {
 		width: 28px;
 		height: 42px;
@@ -427,6 +683,7 @@
 		display: flex;
 		flex-direction: column;
 		min-width: 0;
+		flex: 1;
 	}
 
 	.result-title {
@@ -444,5 +701,30 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	.recent-remove {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 28px;
+		min-height: 28px;
+		padding: 4px;
+		color: var(--color-text-tertiary);
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		opacity: 0;
+		transition: opacity var(--duration-fast) var(--ease-sharp);
+	}
+
+	.result-row:hover .recent-remove,
+	.result-row.selected .recent-remove,
+	.recent-remove:focus {
+		opacity: 1;
+	}
+
+	.recent-remove:hover {
+		color: var(--color-text);
 	}
 </style>

--- a/frontend/src/lib/stores/recent-searches.svelte.ts
+++ b/frontend/src/lib/stores/recent-searches.svelte.ts
@@ -1,0 +1,52 @@
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'pictures-recent-searches';
+const MAX_ENTRIES = 5;
+
+function load(): string[] {
+	if (!browser) return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((q): q is string => typeof q === 'string').slice(0, MAX_ENTRIES);
+	} catch {
+		return [];
+	}
+}
+
+let entries = $state<string[]>(load());
+
+function persist() {
+	if (!browser) return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+	} catch {
+		/* ignore quota / private mode */
+	}
+}
+
+export const recentSearches = {
+	get entries() {
+		return entries;
+	},
+
+	add(query: string) {
+		const trimmed = query.trim();
+		if (trimmed.length < 2) return;
+		const next = [trimmed, ...entries.filter((q) => q.toLowerCase() !== trimmed.toLowerCase())];
+		entries = next.slice(0, MAX_ENTRIES);
+		persist();
+	},
+
+	remove(query: string) {
+		entries = entries.filter((q) => q !== query);
+		persist();
+	},
+
+	clear() {
+		entries = [];
+		persist();
+	}
+};

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -11,6 +11,11 @@ interface CinemasResponse {
 	}>;
 }
 
+// Cinema list is near-static (changes ~weekly). We don't call `setHeaders`
+// here because each route's own `+page.server.ts` already does — SvelteKit
+// throws on duplicate `cache-control` between layout and page. Caching of the
+// layout response is therefore driven by the page-level ISR config; upstream
+// `/api/cinemas` is cached by the API itself plus Vercel's fetch cache.
 export const load: LayoutServerLoad = async ({ fetch }) => {
 	const { cinemas } = await apiFetch<CinemasResponse>('/api/cinemas', fetch);
 

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -36,8 +36,11 @@ interface ScreeningsResponse {
 export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 	setHeaders({ 'cache-control': 'public, s-maxage=3600, stale-while-revalidate=86400' });
 
+	// Trim initial payload to a 14-day window. Filter UI defaults to a near-term
+	// view, and trimming halves transfer size + JSON parse time on the homepage
+	// LCP path. Films further out are still reachable via /search and date filters.
 	const end = new Date();
-	end.setDate(end.getDate() + 30);
+	end.setDate(end.getDate() + 14);
 	const data = await apiFetch<ScreeningsResponse>(
 		`/api/screenings?endDate=${end.toISOString()}`,
 		fetch

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -177,7 +177,7 @@
 				<EmptyState title="No screenings found" description="Try adjusting your filters or check back later." />
 			{:else}
 				<div class="desktop-film-grid">
-					{#each hybridFilms as { film, screenings } (film.id)}
+					{#each hybridFilms as { film, screenings }, hi (film.id)}
 						<DesktopHybridCard
 							film={{
 								id: film.id,
@@ -195,6 +195,7 @@
 								format: s.format,
 								bookingUrl: s.bookingUrl
 							}))}
+							priority={hi < 4}
 						/>
 					{/each}
 				</div>
@@ -248,9 +249,9 @@
 		<EmptyState title="No screenings found" description="Try adjusting your filters or check back later." />
 	{:else}
 		<div class="mobile-list">
-			{#each dayGroups as { date, films } (date)}
+			{#each dayGroups as { date, films }, di (date)}
 				<section class="mobile-day">
-					{#each films as { film, screenings } (film.id)}
+					{#each films as { film, screenings }, fi (film.id)}
 						<MobileFilmRow
 							film={{
 								id: film.id,
@@ -266,6 +267,7 @@
 								cinemaName: s.cinema?.name ?? 'Unknown',
 								bookingUrl: s.bookingUrl
 							}))}
+							priority={di === 0 && fi === 0}
 						/>
 					{/each}
 				</section>

--- a/frontend/src/routes/film/[id]/+page.svelte
+++ b/frontend/src/routes/film/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import LetterboxdRatingReveal from '$lib/components/film/LetterboxdRatingReveal.svelte';
+	import FilmSidebar from '$lib/components/film/FilmSidebar.svelte';
 	import CalendarPopover from '$lib/components/filters/CalendarPopover.svelte';
 	import JsonLd from '$lib/seo/JsonLd.svelte';
 	import { movieSchema, breadcrumbSchema } from '$lib/seo/json-ld';
@@ -8,7 +9,13 @@
 	import { formatTime, formatScreeningDate, toLondonDateStr, groupBy, getPosterImageAttributes } from '$lib/utils';
 	import { trackFilmView, trackBookingClick, trackFilmStatusChange, trackCalendarExport } from '$lib/analytics/posthog';
 	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import type { FilmStatus } from '$lib/types';
+
+	// Lazy-load the below-the-fold "If you like this" rail after first paint.
+	// The component is image-heavy and never needed for LCP. Awaiting on a
+	// browser-only promise keeps it out of the SSR/hydration critical path.
+	let SimilarRail = $state<typeof import('$lib/components/film/FilmSimilarRail.svelte').default | null>(null);
 
 	let { data } = $props();
 
@@ -25,6 +32,20 @@
 			genres: film.genres,
 			directors: film.directors
 		}, 'film_detail');
+
+		// Defer the similar-rail chunk until the browser is idle so it doesn't
+		// compete with the hero/showings paint.
+		if (browser) {
+			const load = () =>
+				import('$lib/components/film/FilmSimilarRail.svelte').then((m) => {
+					SimilarRail = m.default;
+				});
+			if ('requestIdleCallback' in window) {
+				requestIdleCallback(load, { timeout: 2000 });
+			} else {
+				setTimeout(load, 1500);
+			}
+		}
 	});
 
 	function toggleStatus(status: FilmStatus) {
@@ -375,94 +396,25 @@
 		</div>
 	</section>
 
-	<aside class="sidebar">
-		<section class="credits-section">
-			<h3 class="credits-title">Credits</h3>
-
-			{#if film.directors?.length}
-				<div class="credit-row">
-					<span class="credit-key">Director{film.directors.length > 1 ? 's' : ''}</span>
-					<span class="credit-val">{film.directors.join(', ')}</span>
-				</div>
-			{/if}
-
-			{#if film.cast?.length}
-				<div class="credit-row">
-					<span class="credit-key">Cast</span>
-					<span class="credit-val">{film.cast.slice(0, 5).map((c) => c.name).join(', ')}</span>
-				</div>
-			{/if}
-
-			{#if film.countries?.length}
-				<div class="credit-row">
-					<span class="credit-key">Country</span>
-					<span class="credit-val">{film.countries.join(', ')}</span>
-				</div>
-			{/if}
-
-			{#if film.languages?.length}
-				<div class="credit-row">
-					<span class="credit-key">Language</span>
-					<span class="credit-val">{film.languages.join(', ')}</span>
-				</div>
-			{/if}
-		</section>
-
-		{#if film.tagline}
-			<section class="tagline-section">
-				<p class="tagline">{film.tagline}</p>
-			</section>
-		{/if}
-
-		<section class="status-section">
-			<h3 class="credits-title"><span class="italic-cap">S</span>tatus</h3>
-			<div class="status-row">
-				<button
-					type="button"
-					class="status-btn"
-					class:active={currentStatus === 'want_to_see'}
-					onclick={() => toggleStatus('want_to_see')}
-					aria-pressed={currentStatus === 'want_to_see'}
-				>
-					Want to see
-				</button>
-				<button
-					type="button"
-					class="status-btn"
-					class:active={currentStatus === 'not_interested'}
-					onclick={() => toggleStatus('not_interested')}
-					aria-pressed={currentStatus === 'not_interested'}
-				>
-					Not interested
-				</button>
-			</div>
-		</section>
-	</aside>
+	<FilmSidebar
+		film={{
+			id: film.id,
+			title: film.title,
+			year: film.year,
+			genres: film.genres,
+			directors: film.directors,
+			cast: film.cast,
+			countries: film.countries,
+			languages: film.languages,
+			tagline: film.tagline
+		}}
+		{currentStatus}
+		onToggleStatus={toggleStatus}
+	/>
 </div>
 
-{#if similar.length >= 2}
-	<section class="similar" aria-labelledby="similar-heading">
-		<header class="similar-head">
-			<h2 id="similar-heading" class="similar-title">
-				<span class="italic-cap">I</span>f you like this
-			</h2>
-		</header>
-		<div class="similar-rail">
-			{#each similar as s (s.id)}
-				<a href="/film/{s.id}" class="similar-card">
-					<div class="similar-poster">
-						{#if s.posterUrl}
-							<img src={s.posterUrl} alt={s.title} loading="lazy" />
-						{:else}
-							<div class="similar-poster-fallback"><span>{s.title}</span></div>
-						{/if}
-					</div>
-					<h3 class="similar-name">{s.title}</h3>
-					{#if s.year}<p class="similar-year">{s.year}</p>{/if}
-				</a>
-			{/each}
-		</div>
-	</section>
+{#if SimilarRail && similar.length >= 2}
+	<SimilarRail {similar} />
 {/if}
 
 <style>
@@ -912,202 +864,4 @@
 	}
 
 	.ext:hover { color: var(--color-text); }
-
-	/* Sidebar */
-	.sidebar {
-		padding-left: 0;
-	}
-
-	@media (min-width: 1024px) {
-		.sidebar {
-			border-left: 1px solid var(--color-border-subtle);
-			padding-left: 32px;
-		}
-	}
-
-	.credits-section, .status-section, .tagline-section {
-		padding-bottom: 20px;
-		border-bottom: 1px solid var(--color-border-subtle);
-		margin-bottom: 18px;
-	}
-
-	.credits-title {
-		margin: 0 0 10px;
-		font-family: var(--font-serif);
-		font-size: 14px;
-		font-weight: 500;
-		letter-spacing: -0.005em;
-		color: var(--color-text);
-	}
-	.credits-title .italic-cap { font-style: italic; }
-
-	.credit-row {
-		padding: 5px 0;
-		display: flex;
-		gap: 8px;
-		align-items: baseline;
-	}
-
-	.credit-key {
-		font-family: var(--font-mono-plex);
-		font-size: 10px;
-		color: var(--color-text-tertiary);
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		min-width: 90px;
-		padding-top: 3px;
-	}
-
-	.credit-val {
-		flex: 1;
-		font-family: var(--font-serif-italic);
-		font-style: italic;
-		font-size: 13px;
-		color: var(--color-text-secondary);
-		line-height: 1.3;
-	}
-
-	.tagline {
-		margin: 0;
-		font-family: var(--font-serif-italic);
-		font-style: italic;
-		font-size: 16px;
-		color: var(--color-text-secondary);
-		line-height: 1.35;
-	}
-
-	.status-row {
-		display: flex;
-		border: 1px solid var(--color-border);
-	}
-
-	.status-btn {
-		flex: 1;
-		padding: 8px 10px;
-		font-family: var(--font-serif);
-		font-size: 12.5px;
-		font-weight: 400;
-		letter-spacing: -0.005em;
-		color: var(--color-text-secondary);
-		background: transparent;
-		border: none;
-		border-right: 1px solid var(--color-border);
-		cursor: pointer;
-		transition: background-color var(--duration-fast) var(--ease-sharp),
-			color var(--duration-fast) var(--ease-sharp);
-	}
-
-	.status-btn:last-child { border-right: none; }
-
-	.status-btn:hover {
-		background: var(--color-bg-subtle);
-		color: var(--color-text);
-	}
-
-	.status-btn.active {
-		background: var(--color-text);
-		color: var(--color-bg);
-		font-weight: 500;
-	}
-
-	/* ── Similar films rail ── */
-	.similar {
-		max-width: 1400px;
-		margin: 0 auto;
-		padding: 32px 2rem 64px;
-		border-top: 1px solid var(--color-border-subtle);
-	}
-
-	.similar-head {
-		margin-bottom: 20px;
-	}
-
-	.similar-title {
-		margin: 0;
-		font-family: var(--font-serif);
-		font-weight: 400;
-		font-size: 28px;
-		letter-spacing: -0.02em;
-		line-height: 1;
-		color: var(--color-text);
-		font-variation-settings: '"SOFT" 100', '"opsz" 36';
-	}
-
-	.similar-title .italic-cap {
-		font-family: var(--font-serif-italic);
-		font-style: italic;
-	}
-
-	.similar-rail {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
-		gap: 20px 18px;
-	}
-
-	@media (max-width: 767px) {
-		.similar-rail {
-			display: flex;
-			overflow-x: auto;
-			scroll-snap-type: x mandatory;
-			gap: 14px;
-			padding-bottom: 8px;
-		}
-		.similar-card {
-			flex: 0 0 132px;
-			scroll-snap-align: start;
-		}
-	}
-
-	.similar-card {
-		display: flex;
-		flex-direction: column;
-		color: var(--color-text);
-		text-decoration: none;
-	}
-
-	.similar-poster {
-		position: relative;
-		aspect-ratio: 2 / 3;
-		background: var(--color-bg-subtle);
-		border: 1px solid var(--color-border-subtle);
-		margin-bottom: 8px;
-		overflow: hidden;
-	}
-
-	.similar-poster img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
-
-	.similar-poster-fallback {
-		position: absolute;
-		inset: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		text-align: center;
-		padding: 8px;
-		font-family: var(--font-serif);
-		font-size: 12px;
-		color: var(--color-text-tertiary);
-	}
-
-	.similar-name {
-		margin: 0 0 2px;
-		font-family: var(--font-serif);
-		font-weight: 400;
-		font-size: 14px;
-		line-height: 1.2;
-		color: var(--color-text);
-		font-variation-settings: '"SOFT" 100', '"opsz" 24';
-	}
-
-	.similar-year {
-		margin: 0;
-		font-family: var(--font-serif-italic);
-		font-style: italic;
-		font-size: 12px;
-		color: var(--color-text-tertiary);
-	}
 </style>


### PR DESCRIPTION
## Summary

Frontend-only batch implementing the consensus picks from two parallel multi-agent panels (perf + search) at `Obsidian Vault/Pictures/Research/2026-04-26-{frontend-perf-pitches,search-pitches}.md`. Backend search-relevance work (pg_trgm + unaccent + ranking) — the search panel's universal #1 — lives in the Next.js API and is queued as a follow-up PR.

The user-flagged calls were **iOS zoom prevention** and **search predictions**; both are in.

### Performance
- `web-vitals` v5 → PostHog with route × viewport × connection dims (`web_vital` event) — universal #1 across all 9 perf-panel agents. Replaces PostHog's redundant `capture_performance` flag.
- Trim homepage server payload 30d → 14d (UX Architect's unique pick).
- `preconnect` + `dns-prefetch` for `api.pictures.london`.
- First 1 mobile poster + first 4 desktop posters get `fetchpriority="high"` + `loading="eager"`; rest lazy.
- `content-visibility: auto` + `contain-intrinsic-size` (220px mobile / 640px desktop) on calendar row/card components.

### Refactor
- `film/[id]/+page.svelte` 1,113 → 867 lines (-22%). Extracted `FilmSidebar` (eager) and `FilmSimilarRail` (lazy via `requestIdleCallback`).

### Search UX (full SearchInput rewrite)
- **iOS zoom + keyboard fix** (UI Designer's unique pick, user-flagged): `inputmode="search"` + `enterkeyhint="search"` on the input.
- `AbortController` per keystroke, debounce 200ms → 120ms.
- Full ARIA 1.2 combobox: `aria-activedescendant` + `aria-live` result-count (announced *after* debounce settles to avoid screen-reader spam).
- `<mark>` match highlighting on titles, directors, cinema names.
- **Recent searches drawer** (consensus pick + user-flagged "predictions") — last 5, localStorage, dedup case-insensitively, shown on focus when query empty. New `lib/stores/recent-searches.svelte.ts`.
- Search latency instrumentation: `latency_ms`, `films_count`, `cinemas_count` on `search_performed`; `entity_type` on `search_result_clicked`.
- `apiGet` now accepts `AbortSignal`.

### Reverted during implementation
Initial layout-level `setHeaders({ 'cache-control': ... })` for the cinemas fetch — SvelteKit throws on duplicate `cache-control` between layout and page (pages already set their own via ISR). Reverted with explanatory comment. Cinema-fetch caching will be addressed at the upstream API + Vercel fetch-cache layer in a future PR.

## Test plan
- [x] `npm run lint` from root: 0 errors, 41 pre-existing warnings.
- [x] `npm run check` in `frontend/`: 11 baseline errors (all in `letterboxd/+page.svelte`, none in modified files).
- [x] `npm run build` in `frontend/`: clean.
- [x] Code-reviewer agent on the diff: flagged + fixed (`DesktopHybridCard` intrinsic-size 360 → 640px) and minor 1-char empty-dropdown bug.
- [x] Manual smoke test of `/`, `/search?q=...`, `/film/[id]` against `https://api.pictures.london` — all 200, FilmSidebar + hero + breadcrumb render correctly.
- [ ] Vercel preview Lighthouse + Playwright (need backend running or `API_PROXY_TARGET` env to exercise locally).
- [ ] Real-device check of iOS zoom on focus (production preview).

## Known trade-offs
- 14-day homepage window: calendar popover lets users navigate past day 14 with no `max`, so they'd see an empty list. User signed off on this when approving the trim. Could be tightened with a `max` or "load more" CTA in a follow-up.

## Out of scope (queued separately)
- Backend search relevance (`pg_trgm` + `unaccent` + ranking + "did you mean") — every search-panel agent's #1, but lives in `src/app/api/films/search/route.ts`.
- Programmatic SEO landing pages with Schema.org `Event` markup (SEO panel's unique pick) — separate larger initiative.
- Showings section split out of `film/[id]/+page.svelte` — tightly coupled with the day-picker popover; deferred.