### PR TITLE
fix(frontend): desktop film-grid overflow on wide viewports

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-04-27: Fix desktop film-grid overflow on wide viewports
+**PR**: TBD | **Files**: `frontend/src/routes/+page.svelte`
+- Switched all four `.desktop-film-grid` declarations from `repeat(N, 1fr)` → `repeat(N, minmax(0, 1fr))`.
+- Why: `1fr` is shorthand for `minmax(auto, 1fr)`, where `auto` honors each grid item's intrinsic min-width. The recent perf batch (#468) added `contain-intrinsic-size: auto 640px` to `DesktopHybridCard` to prevent CLS, which gave offscreen cards a 640px intrinsic width. Grid columns then locked to 640px each, blew past the 1400px shell, and pushed posters off-screen on the right at any viewport ≥ 1280px.
+- Verified at 2560×1440, 1280×900, and 1100×900 — `bodyOverflow: 0` everywhere; columns now share remaining space (e.g. 248px each on a 4-col grid at 2560px).
+
+---
+
 ## 2026-04-27: Frontend perf + search-UX batch
 **PR**: TBD | **Files**: 4 new + 9 modified across `frontend/src`
 - **Perf:** Ship `web-vitals` v5 → PostHog with route × viewport × connection dims (`web_vital` event), replacing PostHog's redundant `capture_performance` flag. Universal #1 pick across all 9 panel agents.

--- a/changelogs/2026-04-27-fix-desktop-grid-overflow.md
+++ b/changelogs/2026-04-27-fix-desktop-grid-overflow.md
@@ -1,0 +1,69 @@
+# Fix desktop film-grid overflow on wide viewports
+
+**PR**: TBD
+**Date**: 2026-04-27
+**Branch**: `fix/desktop-grid-overflow`
+
+## Symptom
+
+On desktop viewports — visible most clearly at ≥ 2560px but present from 1280px upward — the homepage film grid blew past the centered 1400px shell. Posters appeared at ~640px wide each, only ~2.5 columns were visible, the third+ posters were clipped at the right edge of the viewport, and there was a horizontal page scrollbar.
+
+Reported by visual inspection at 2560×1440 ([screenshot context: `Thursday, the thirtieth`]).
+
+## Root cause
+
+A two-feature CSS interaction introduced by #468 (the perf + search-UX batch shipped earlier on 2026-04-27):
+
+1. `frontend/src/lib/components/calendar/DesktopHybridCard.svelte:161-162` adds:
+   ```css
+   content-visibility: auto;
+   contain-intrinsic-size: auto 640px;
+   ```
+   This is a CLS-prevention measure for offscreen cards: the browser uses 640px as a placeholder size while the card is outside the viewport.
+
+2. `frontend/src/routes/+page.svelte:389` declared the grid as:
+   ```css
+   grid-template-columns: repeat(4, 1fr);
+   ```
+
+The standard CSS Grid gotcha: `1fr` is shorthand for `minmax(auto, 1fr)`. The `auto` minimum honors each grid item's intrinsic min-width. With `contain-intrinsic-size` setting that intrinsic width to 640px, every column locked to 640px — 4 columns × 640px + gaps overflowed the 1400px shell by ~1.2k pixels.
+
+Browser eval (production, 2560×1440, before fix):
+```
+shellW: 1400
+mainW: 2666           ← should be 1096
+gridCols: "640px 640px 640px 640px"   ← should be ~248px each
+bodyOverflow: 958px
+```
+
+## Fix
+
+Switched all four `grid-template-columns` declarations in `frontend/src/routes/+page.svelte` from `repeat(N, 1fr)` to `repeat(N, minmax(0, 1fr))`. The explicit `0` minimum lets columns shrink below their intrinsic content size and respect the available shell width.
+
+Affected declarations (lines 389, 395, 398, 404):
+- Default 4-col grid
+- 3-col grid in 1024–1279px range
+- 4-col grid (sidebar collapsed, 1024–1279px range)
+- 5-col grid (sidebar collapsed, ≥ 1280px)
+
+## Verification
+
+Local dev server, browser-measured grid columns and body overflow:
+
+| Viewport | Cols | Per-column | bodyOverflow |
+|---|---|---|---|
+| 2560×1440 | 4 | 248px | 0 |
+| 1280×900 | 4 | ~248px | 0 |
+| 1100×900 | 3 | 237px | 0 |
+
+Visual diff confirmed: 2560px now shows 4 full posters within the centered shell with no horizontal scroll.
+
+## Impact
+
+- Anyone on a desktop viewport ≥ 1280px viewing the homepage: posters now fit within the shell instead of overflowing the right edge.
+- No behavior change at < 1024px (mobile layout uses a separate `.mobile-list` flex column, not affected).
+- No change to the CLS-prevention `contain-intrinsic-size` on the cards themselves — the placeholder reservation still works as designed for vertical scroll anchoring.
+
+## Why this slipped through
+
+The original perf-batch PR (#468) was reviewed and code-reviewer asked to bump the intrinsic size from 360px → 640px to better match real card height. That review caught a real CLS risk but didn't surface the secondary effect on the parent grid's column resolution — which only manifests when there are many cards AND the viewport is wide enough that `contain-intrinsic-size` skips offscreen ones.

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -386,22 +386,22 @@
 
 	.desktop-film-grid {
 		display: grid;
-		grid-template-columns: repeat(4, 1fr);
+		grid-template-columns: repeat(4, minmax(0, 1fr));
 		gap: 32px 22px;
 	}
 
 	@media (min-width: 1024px) and (max-width: 1279px) {
 		.desktop-film-grid {
-			grid-template-columns: repeat(3, 1fr);
+			grid-template-columns: repeat(3, minmax(0, 1fr));
 		}
 		.sidebar-collapsed .desktop-film-grid {
-			grid-template-columns: repeat(4, 1fr);
+			grid-template-columns: repeat(4, minmax(0, 1fr));
 		}
 	}
 
 	@media (min-width: 1280px) {
 		.sidebar-collapsed .desktop-film-grid {
-			grid-template-columns: repeat(5, 1fr);
+			grid-template-columns: repeat(5, minmax(0, 1fr));
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Swap `repeat(N, 1fr)` → `repeat(N, minmax(0, 1fr))` on all four `.desktop-film-grid` rules in `frontend/src/routes/+page.svelte`.
- Fixes the regression introduced in #468: at any viewport ≥ 1280px, posters rendered ~640px wide and overflowed the 1400px shell, clipping the right-most poster off the screen.

## Root cause
`1fr` is shorthand for `minmax(auto, 1fr)`, where `auto` honors each grid item's intrinsic min-width. #468 added `content-visibility: auto` + `contain-intrinsic-size: auto 640px` to `DesktopHybridCard` to prevent CLS on offscreen cards. That 640px placeholder became the grid items' intrinsic width, locking each column to 640px and blowing past the centered shell.

Browser-measured at 2560×1440 before the fix:
```
shellW: 1400        mainW: 2666 (overflow!)
gridCols: "640px 640px 640px 640px"
bodyOverflow: 958
```

After:
```
gridCols: "247.5px 247.5px 247.5px 247.5px"
bodyOverflow: 0
```

See `changelogs/2026-04-27-fix-desktop-grid-overflow.md` for the full writeup.

## Test plan
- [x] Visually verified in production at 2560×1440 (reproduced overflow), then locally at 2560×1440, 1280×900, and 1100×900 — all clean
- [x] `npm run build` succeeds
- [x] `npm run check` — pre-existing errors only (FollowButton, CinemaMap, SyncProvider, letterboxd, LetterboxdRatingReveal); none in `+page.svelte`
- [x] Playwright suite ran: 14 passed, 6 failed with `TimeoutError waiting for .film-card`. All failures are data-dependent (today has no screenings on prod API at run time) and cannot be caused by a CSS-only change to the grid container; the layout-touching tests (sidebar collapse, day-strip, page title, footer) all pass.

## Out of scope
- `DaySection.svelte` is dead code (not imported anywhere) — left as-is.
- Other routes using `repeat(N, 1fr)` (`this-weekend`, `tonight`, `cinemas`, `festivals/[slug]`, `directors`) are currently safe because their child cards don't use `content-visibility`. Defensive `minmax(0, 1fr)` would be best practice but is outside this fix's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)