### PR TITLE
fix(frontend): remove italic first-letter treatment from titles and headings

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-05-04: Remove italic first-letter treatment from titles and headings
+**PR**: TBD | **Files**: `frontend/src/lib/components/calendar/{DayMasthead,DesktopHybridCard,MobileFilmRow}.svelte`, `frontend/src/lib/components/filters/{MobileFilterSheet,MobileDatePicker,CalendarPopover}.svelte`, `frontend/src/lib/components/film/{FilmSimilarRail,FilmSidebar}.svelte`, `frontend/src/routes/film/[id]/+page.svelte`
+- Drop the `italic-cap` / `title-italic-cap` drop-cap-lite pattern that gave the first character of titles, day mastheads, and section headings a distinct italic glyph (e.g. the italic *M* in "Monday, the fourth").
+- Strip the `<span class="italic-cap">X</span>Y` wrappers, the matching CSS rules, and the now-orphaned `titleFirst`/`titleRest` derivations across 9 components/pages.
+- Italic comma in the day masthead and italic month-strip elsewhere are left in place — only the first-letter treatment was removed.
+- Verified at desktop (1440×900) and mobile (390×844): masthead, film cards, mobile film rows, mobile Filter sheet, and mobile Date picker all render with no `italic-cap` nodes in DOM.
+
+---
+
 ## 2026-04-29: Fix CI for PR #469 — ESLint flat-config plugin scoping + Vercel webpack externals
 **PR**: #469 | **Files**: `eslint.config.mjs`, `next.config.ts`, `src/hooks/useUrlFilters.ts`
 - **ESLint**: Scope our `jsx-a11y/*`, `react-hooks/*`, `@typescript-eslint/*`, `@next/next/*` rule overrides via `files: ["**/*.{js,jsx,mjs,ts,tsx,mts,cts}"]` so they only apply where `eslint-config-next` registers those plugins. Reverts the (incorrect) explicit `jsx-a11y` re-registration from d6501bbc that triggered "Cannot redefine plugin 'jsx-a11y'" — `eslint-config-next/core-web-vitals` already registers it.

--- a/changelogs/2026-05-04-remove-italic-first-letter.md
+++ b/changelogs/2026-05-04-remove-italic-first-letter.md
@@ -1,0 +1,25 @@
+# Remove italic first-letter treatment from titles and headings
+
+**PR**: TBD
+**Date**: 2026-05-04
+
+## Changes
+- Removed the `italic-cap` / `title-italic-cap` "drop-cap-lite" pattern that styled the first character of titles, day mastheads, and section headings with `font-style: italic; font-weight: 400`.
+- Edited 9 frontend components/pages:
+  - `frontend/src/lib/components/calendar/DayMasthead.svelte` — day masthead ("Monday, the fourth"). The italic comma is preserved.
+  - `frontend/src/lib/components/calendar/DesktopHybridCard.svelte` — desktop film card titles.
+  - `frontend/src/lib/components/calendar/MobileFilmRow.svelte` — mobile film row titles.
+  - `frontend/src/lib/components/filters/MobileFilterSheet.svelte` — "Filter" sheet heading.
+  - `frontend/src/lib/components/filters/MobileDatePicker.svelte` — "Pick a date" heading + month name.
+  - `frontend/src/lib/components/filters/CalendarPopover.svelte` — desktop month name.
+  - `frontend/src/lib/components/film/FilmSimilarRail.svelte` — "If you like this".
+  - `frontend/src/lib/components/film/FilmSidebar.svelte` — "Status" sidebar heading.
+  - `frontend/src/routes/film/[id]/+page.svelte` — film title hero + "Showings" heading.
+- Removed the `titleFirst` / `titleRest` derivations that existed solely to feed the italic-cap spans.
+- Confirmed with `grep` that zero `italic-cap`, `title-italic-cap`, `titleFirst`, or `titleRest` references remain anywhere in `frontend/src/`.
+
+## Impact
+- Headings and titles render in a single, consistent weight throughout the app — no more standout italic glyph at the start of every title and heading.
+- Day masthead reads as plain "Monday, the fourth" with only the comma retaining its small italic accent (intentionally preserved).
+- Verified visually at desktop (1440×900) and mobile (390×844) viewports against the home page, mobile filter sheet, and mobile date picker. All four surfaces report `document.querySelectorAll('.italic-cap, .title-italic-cap').length === 0`.
+- No behavioural changes — purely typographic. Pre-existing svelte-check errors in unrelated files (`FollowButton`, `CinemaMap`, `SyncProvider`, `letterboxd/+page`) are unaffected.

--- a/frontend/src/lib/components/calendar/DayMasthead.svelte
+++ b/frontend/src/lib/components/calendar/DayMasthead.svelte
@@ -76,7 +76,7 @@
 
 <section class="masthead">
 	<h1 class="masthead-title" aria-label="{weekday}, the {ordinal}">
-		<span class="italic-cap">{weekday.charAt(0)}</span><span>{weekday.slice(1)}</span><span class="italic-comma">,</span> <span class="masthead-muted">the {ordinal}</span>
+		{weekday}<span class="italic-comma">,</span> <span class="masthead-muted">the {ordinal}</span>
 	</h1>
 
 	<div class="day-strip">
@@ -146,11 +146,6 @@
 		letter-spacing: -0.03em;
 		color: var(--color-text);
 		font-variation-settings: '"SOFT" 100', '"opsz" 144';
-	}
-
-	.masthead-title .italic-cap {
-		font-weight: 400;
-		font-style: italic;
 	}
 
 	.masthead-title .italic-comma {

--- a/frontend/src/lib/components/calendar/DesktopHybridCard.svelte
+++ b/frontend/src/lib/components/calendar/DesktopHybridCard.svelte
@@ -44,9 +44,6 @@
 	const visible = $derived(upcoming.slice(0, maxScreenings));
 	const overflow = $derived(Math.max(0, upcoming.length - maxScreenings));
 
-	const titleFirst = $derived(film.title.charAt(0));
-	const titleRest = $derived(film.title.slice(1));
-
 	const bylineText = $derived.by(() => {
 		const parts: string[] = [];
 		if (film.director) parts.push(film.director);
@@ -107,9 +104,7 @@
 	</a>
 
 	<a href="/film/{film.id}" class="title-link">
-		<h3 class="title film-title">
-			<span class="title-italic-cap">{titleFirst}</span><span>{titleRest}</span>
-		</h3>
+		<h3 class="title film-title">{film.title}</h3>
 	</a>
 
 	{#if bylineText}
@@ -210,10 +205,6 @@
 		line-height: 0.98;
 		color: var(--color-text);
 		font-variation-settings: '"SOFT" 100', '"opsz" 48';
-	}
-
-	.title-italic-cap {
-		font-style: italic;
 	}
 
 	.byline {

--- a/frontend/src/lib/components/calendar/MobileFilmRow.svelte
+++ b/frontend/src/lib/components/calendar/MobileFilmRow.svelte
@@ -75,17 +75,12 @@
 			cinemaName: s.cinemaName
 		}, 'calendar');
 	}
-
-	const titleFirst = $derived(film.title.charAt(0));
-	const titleRest = $derived(film.title.slice(1));
 </script>
 
 <article class="row film-card">
 	<div class="text-col">
 		<a href="/film/{film.id}" class="title-link">
-			<h3 class="title film-title">
-				<span class="title-italic-cap">{titleFirst}</span><span>{titleRest}</span>
-			</h3>
+			<h3 class="title film-title">{film.title}</h3>
 		</a>
 		{#if bylineText}
 			<p class="byline">a film by {bylineText}</p>
@@ -168,11 +163,6 @@
 		line-height: 0.92;
 		color: var(--color-text);
 		font-variation-settings: '"SOFT" 100', '"opsz" 144';
-	}
-
-	.title-italic-cap {
-		font-weight: 400;
-		font-style: italic;
 	}
 
 	.byline {

--- a/frontend/src/lib/components/film/FilmSidebar.svelte
+++ b/frontend/src/lib/components/film/FilmSidebar.svelte
@@ -64,7 +64,7 @@
 	{/if}
 
 	<section class="status-section">
-		<h3 class="credits-title"><span class="italic-cap">S</span>tatus</h3>
+		<h3 class="credits-title">Status</h3>
 		<div class="status-row">
 			<button
 				type="button"
@@ -114,8 +114,6 @@
 		letter-spacing: -0.005em;
 		color: var(--color-text);
 	}
-	.credits-title :global(.italic-cap) { font-style: italic; }
-
 	.credit-row {
 		padding: 5px 0;
 		display: flex;

--- a/frontend/src/lib/components/film/FilmSimilarRail.svelte
+++ b/frontend/src/lib/components/film/FilmSimilarRail.svelte
@@ -12,9 +12,7 @@
 {#if similar.length >= 2}
 	<section class="similar" aria-labelledby="similar-heading">
 		<header class="similar-head">
-			<h2 id="similar-heading" class="similar-title">
-				<span class="italic-cap">I</span>f you like this
-			</h2>
+			<h2 id="similar-heading" class="similar-title">If you like this</h2>
 		</header>
 		<div class="similar-rail">
 			{#each similar as s (s.id)}
@@ -55,11 +53,6 @@
 		line-height: 1;
 		color: var(--color-text);
 		font-variation-settings: '"SOFT" 100', '"opsz" 36';
-	}
-
-	.similar-title .italic-cap {
-		font-family: var(--font-serif-italic);
-		font-style: italic;
 	}
 
 	.similar-rail {

--- a/frontend/src/lib/components/filters/CalendarPopover.svelte
+++ b/frontend/src/lib/components/filters/CalendarPopover.svelte
@@ -84,7 +84,7 @@
 	<div class="cal-head">
 		<button class="cal-nav" onclick={prev} aria-label="Previous month" type="button">‹</button>
 		<div class="cal-title">
-			<span class="italic-cap">{MONTH_NAMES[viewMonth].charAt(0)}</span>{MONTH_NAMES[viewMonth].slice(1)}
+			{MONTH_NAMES[viewMonth]}
 			<span class="year">{viewYear}</span>
 		</div>
 		<button class="cal-nav" onclick={next} aria-label="Next month" type="button">›</button>
@@ -157,7 +157,6 @@
 		font-variation-settings: '"SOFT" 100', '"opsz" 72';
 	}
 
-	.cal-title .italic-cap { font-style: italic; font-weight: 400; }
 	.cal-title .year {
 		font-family: var(--font-serif-italic);
 		font-style: italic;

--- a/frontend/src/lib/components/filters/MobileDatePicker.svelte
+++ b/frontend/src/lib/components/filters/MobileDatePicker.svelte
@@ -81,14 +81,14 @@
 		<div class="grabber-wrap"><div class="grabber"></div></div>
 
 		<div class="sheet-head">
-			<h3 class="title"><span class="italic-cap">P</span>ick a date</h3>
+			<h3 class="title">Pick a date</h3>
 			<button class="close-btn" type="button" onclick={onClose}>Close</button>
 		</div>
 
 		<div class="month-head">
 			<button type="button" class="nav-btn" onclick={prev} aria-label="Previous month">‹</button>
 			<div class="month-name">
-				<span class="italic-cap">{MONTH_NAMES[viewMonth].charAt(0)}</span>{MONTH_NAMES[viewMonth].slice(1)}
+				{MONTH_NAMES[viewMonth]}
 				<span class="year">{viewYear}</span>
 			</div>
 			<button type="button" class="nav-btn" onclick={next} aria-label="Next month">›</button>
@@ -176,8 +176,6 @@
 		font-variation-settings: '"SOFT" 100', '"opsz" 48';
 	}
 
-	.title .italic-cap { font-style: italic; font-weight: 400; }
-
 	.close-btn {
 		background: transparent;
 		border: none;
@@ -215,7 +213,6 @@
 		font-variation-settings: '"SOFT" 100', '"opsz" 72';
 	}
 
-	.month-name .italic-cap { font-style: italic; font-weight: 400; }
 	.month-name .year {
 		font-family: var(--font-serif-italic);
 		font-style: italic;

--- a/frontend/src/lib/components/filters/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/filters/MobileFilterSheet.svelte
@@ -175,7 +175,7 @@
 {#if open}
 	<div class="sheet" role="dialog" aria-label="Filter programme" aria-modal="true">
 		<header class="sheet-head">
-			<h2 class="sheet-title"><span class="italic-cap">F</span>ilter</h2>
+			<h2 class="sheet-title">Filter</h2>
 			<button class="close" onclick={onClose} aria-label="Close filters" type="button">×</button>
 		</header>
 
@@ -318,8 +318,6 @@
 		color: var(--color-text);
 		font-variation-settings: '"SOFT" 100', '"opsz" 144';
 	}
-
-	.sheet-title .italic-cap { font-style: italic; font-weight: 400; }
 
 	.close {
 		width: 36px;

--- a/frontend/src/routes/film/[id]/+page.svelte
+++ b/frontend/src/routes/film/[id]/+page.svelte
@@ -136,9 +136,6 @@
 		return parts;
 	});
 
-	const titleFirst = $derived(film.title.charAt(0));
-	const titleRest = $derived(film.title.slice(1));
-
 	// Pulled from the shared today store so the "Today" pill in the day strip
 	// advances at midnight without requiring a route re-load.
 	const todayStr = $derived(todayStore.value);
@@ -198,9 +195,7 @@
 			{#if nextScreening} · next screening {nextScreeningLabel}{/if}
 		</div>
 
-		<h1 class="film-title">
-			<span class="italic-cap">{titleFirst}</span><span>{titleRest}</span>
-		</h1>
+		<h1 class="film-title">{film.title}</h1>
 
 		{#if film.originalTitle && film.originalTitle !== film.title}
 			<p class="original-title">{film.originalTitle}</p>
@@ -265,9 +260,7 @@
 <div class="body-grid">
 	<section class="showings" aria-labelledby="showings-heading">
 		<div class="showings-head">
-			<h2 id="showings-heading" class="showings-title">
-				<span class="italic-cap">S</span>howings
-			</h2>
+			<h2 id="showings-heading" class="showings-title">Showings</h2>
 
 			<div class="day-strip">
 				{#if groupedByDate.length > 1}
@@ -517,8 +510,6 @@
 		.film-title { font-size: 96px; }
 	}
 
-	.film-title .italic-cap { font-weight: 400; font-style: italic; }
-
 	.original-title {
 		font-family: var(--font-serif-italic);
 		font-style: italic;
@@ -661,8 +652,6 @@
 	@media (min-width: 1024px) {
 		.showings-title { font-size: 32px; }
 	}
-
-	.showings-title .italic-cap { font-style: italic; }
 
 	.day-strip {
 		display: flex;


### PR DESCRIPTION
## Summary
- Drops the `italic-cap` / `title-italic-cap` drop-cap-lite pattern that styled the first character of titles, day mastheads, and section headings with a distinct italic glyph (e.g. the italic *M* in "Monday, the fourth").
- Strips the `<span class=\"italic-cap\">…</span>` wrappers, matching CSS rules, and the now-orphaned `titleFirst` / `titleRest` `\$derived` declarations across 9 components/pages.
- Italic comma in the day masthead and italic month/year accents in the date pickers are intentionally preserved — only the first-letter treatment was removed.

### Files touched
- `frontend/src/lib/components/calendar/{DayMasthead,DesktopHybridCard,MobileFilmRow}.svelte`
- `frontend/src/lib/components/filters/{MobileFilterSheet,MobileDatePicker,CalendarPopover}.svelte`
- `frontend/src/lib/components/film/{FilmSimilarRail,FilmSidebar}.svelte`
- `frontend/src/routes/film/[id]/+page.svelte`

## Test plan
- [x] `grep -rn "italic-cap\\|title-italic-cap\\|titleFirst\\|titleRest"` in `frontend/src/` returns zero matches
- [x] `npm run check` — only pre-existing errors in unrelated files (FollowButton, CinemaMap, SyncProvider, letterboxd page) remain; none in any file touched here
- [x] Verified at desktop (1440×900) — homepage masthead and film cards render plain weight
- [x] Verified at mobile (390×844) — homepage masthead, mobile film rows, "Filter" sheet, "Pick a date" sheet, and "May 2026" all render without italic first letter
- [x] `document.querySelectorAll('.italic-cap, .title-italic-cap').length === 0` on every verified surface
- [x] Code review pass via Code Reviewer agent — no leftover dead code, no a11y/layout regressions, ship verdict
- [x] `RECENT_CHANGES.md` updated and `changelogs/2026-05-04-remove-italic-first-letter.md` added per project rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)