### PR TITLE
chore(data): delete phantom Stoma screening + surface duplicate-row issue

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-05-05: Delete phantom Stoma screening + surface (cinema, source_id) duplicate issue
+**PR**: TBD | **Files**: `scripts/delete-stoma-phantom.ts`
+- Stoma → Guo Ran from yesterday's audit was not a fuzzy-matcher misfire (trigram sim was 0.016, far below any threshold). Two distinct screening rows shared the same `(cinema_id, source_id, datetime)` for Garden's 2026-05-17 18:00 Stoma showing — one wrongly linked to Guo Ran (scraped 2026-04-29), one correctly linked to Stoma (scraped 2026-05-05).
+- Deleted the phantom Guo Ran row (id `cbcdfce0`) via `scripts/delete-stoma-phantom.ts --apply`. Four pre-flight guards: target id match, target film_title='Guo Ran', source_id contains 'stoma', sibling row linked to film_title='Stoma'.
+- **Broader finding (out of scope, separate ticket)**: the `screenings` table has no unique constraint beyond `PRIMARY KEY (id)`. The same audit surfaced 20+ other `(cinema_id, source_id, datetime)` collisions where re-scrapes inserted duplicate rows that resolved to different `film_id`s — across Picturehouse, Rio, Prince Charles, Everyman, ICA, Curzon, Garden. Calendar likely renders these as doubled screenings.
+
+---
+
 ## 2026-05-04: Remove Gemini from `/scrape` pipeline + fix two pre-existing data quality issues
 **PR**: #472 | **Files**: `src/lib/{event-classifier,content-classifier,film-similarity}.ts`, `src/lib/title-extraction/{ai-extractor,index}.ts`, `src/scrapers/cinemas/garden.ts`, `scripts/unmerge-bad-films.ts`, tests
 - `/scrape` no longer invokes any LLM. The three pipeline classifiers (event, content, title) are now deterministic rules engines / adapters on top of `extractFilmTitleSync`. Run time dropped ~33% (Garden: 35s → 23s) because the previous Gemini error path retried with exponential backoff before falling back.

--- a/changelogs/2026-05-05-delete-stoma-phantom-screening.md
+++ b/changelogs/2026-05-05-delete-stoma-phantom-screening.md
@@ -1,0 +1,82 @@
+# Delete phantom Stoma screening + surface broader (cinema, source_id) duplicate issue
+
+**PR**: TBD
+**Date**: 2026-05-05
+**Branch**: `chore/delete-stoma-phantom-screening`
+**Driven by**: Suspect merge surfaced by `scripts/unmerge-bad-films.ts` audit on 2026-05-04 (`Stoma → Guo Ran` at 0.016 trigram). Investigated tonight after PR #472 merged.
+
+## Why
+
+Yesterday's audit query (in `scripts/unmerge-bad-films.ts`) reported a Garden screening whose `source_id` contained `stoma` but whose linked film was `Guo Ran (2025)`, with a trigram similarity of 0.016 — well below any matcher threshold. PR #472's matcher hardening could not have caused or prevented this. We deferred the investigation to tonight.
+
+## Investigation findings
+
+### The Stoma-specific bug
+
+Two distinct screening rows shared the same `(cinema_id, source_id, datetime)` for Garden's 2026-05-17 18:00 showing of Stoma:
+
+| screening id | source_id | scraped_at | film | trigram sim |
+|---|---|---|---|---|
+| `cbcdfce0` | `garden-remind-film-festival-presents-stoma-...` | 2026-04-29 06:54 | Guo Ran (2025) ❌ | 0.016 |
+| `4257ddb6` | `garden-remind-film-festival-presents-stoma-...` | 2026-05-05 06:08 | Stoma (2020) ✅ | 0.111 |
+
+The 2026-04-29 scrape resolved to Guo Ran. The 2026-05-05 scrape (today) correctly resolved to Stoma — but it inserted a NEW row instead of updating the old one. Garden never actually scheduled Guo Ran at that slot; the row is a phantom from the older scrape.
+
+Why did the 04-29 scrape pick Guo Ran? Pre-PR #472 the `/scrape` pipeline also routed through Gemini-based classifiers, so the wrong link likely came from a non-deterministic LLM extraction or a bad fallback path that no longer exists in the codebase. The new pipeline is deterministic and would not reproduce the misclassification.
+
+### The broader bug
+
+The actual root cause of the duplicate-row pattern is structural:
+
+```
+SELECT conname, pg_get_constraintdef(oid)
+FROM pg_constraint
+WHERE conrelid = 'screenings'::regclass AND contype IN ('u', 'p');
+```
+
+returns just the primary key on `id`. There is no unique constraint on `(cinema_id, source_id)` or `(cinema_id, source_id, datetime)`. The scraper's "upsert" is therefore an insert-only path — every re-scrape that resolves the film_id differently can produce a new row.
+
+The same audit surfaced 20+ collisions across Picturehouse, Rio, PCC, Everyman, ICA, Curzon, Garden:
+
+| cinema | source_id | rows | distinct films |
+|---|---|---|---|
+| ritzy-brixton | picturehouse-ritzy-brixton-71392 | 3 | 3 |
+| rio-dalston | rio-dalston-2239065-... | 3 | 3 |
+| prince-charles | 31626132 | 3 | 3 |
+| everyman-barnet | everyman-everyman-barnet-1000021612-... | 3 | 3 |
+| ica | ica-the-machine-that-kills-bad-people-... | 3 | 3 |
+| arthouse-crouch-end | arthouse-nt-live:-les-liaisons-dangereuses-... | 3 | 3 |
+| ... (14 more with 2 rows / 2 films) |
+
+These very likely render as doubled screenings on the public calendar. **Out of scope for this PR**; logged as a follow-up.
+
+## Changes
+
+- **`scripts/delete-stoma-phantom.ts`**: one-shot deletion script with four pre-flight guards (target id match, target film_title='Guo Ran', source_id contains 'stoma', sibling row linked to film_title='Stoma'). Dry-run by default; `--apply` to commit. Idempotent (no-op if the row is already deleted).
+
+## Verification
+
+After running with `--apply`:
+
+```
+=== Garden screenings with source_id containing 'stoma' ===
+1 row remaining: 4257ddb6 → Stoma (2020) at 2026-05-17 18:00 ✓
+
+=== All Garden screenings linked to Guo Ran ===
+1 row remaining: 210e5b41 → garden-remind-film-festival-presents-guo-ran-2026-05-09T17:00:00.000Z ✓
+(the 2026-05-09 17:00 Guo Ran screening, correctly linked)
+```
+
+No code changes; tsc + lint + tests baseline preserved (887/887 from PR #472).
+
+## Impact
+
+- **Garden's 2026-05-17 18:00 Stoma screening** now appears once on the calendar, correctly attributed to Stoma (2020).
+- **Guo Ran's listing** is no longer polluted with a phantom 2026-05-17 18:00 entry.
+- **Broader duplicate issue surfaced** for separate handling — the lack of `(cinema_id, source_id)` unique constraint affects 20+ known collisions and likely many more we haven't audited yet.
+
+## Out of scope (deliberately)
+
+- **Add a unique constraint on `screenings(cinema_id, source_id)` or `(cinema_id, source_id, datetime)`** — needs analysis of which (cinema, source_id) shapes are actually keys, plus a backfill plan to dedupe existing rows before the constraint can be added. Separate PR.
+- **Sweep the other 20+ duplicate triples** — same analysis applies; pick a winning row per triple based on `scraped_at` / film-title-vs-source-id similarity.
+- **Investigate why the 2026-04-29 scrape picked Guo Ran** — pre-PR #472 codepath that no longer exists; not worth deep-diving.

--- a/scripts/delete-stoma-phantom.ts
+++ b/scripts/delete-stoma-phantom.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env tsx
+/**
+ * Delete the phantom Stoma screening that was wrongly linked to Guo Ran.
+ *
+ * Background:
+ *   Garden's "Remind film festival presents Stoma" screening on 2026-05-17
+ *   18:00 was scraped on 2026-04-29 and linked to the wrong film (Guo Ran).
+ *   On 2026-05-05 the scraper ran again, correctly matched to Stoma, but
+ *   inserted a NEW row instead of updating the old one (the screenings
+ *   table has no unique constraint on (cinema_id, source_id, datetime)).
+ *
+ *   Result: two rows with identical source_id+cinema+datetime, one wrong
+ *   (Guo Ran), one correct (Stoma). The wrong row is a phantom — Garden
+ *   never actually scheduled Guo Ran at that slot.
+ *
+ * Safety: this script only deletes if all of the following hold:
+ *   1. The target row id matches exactly.
+ *   2. The target row's film_title is 'Guo Ran'.
+ *   3. There is at least one OTHER row with the same source_id, cinema, and
+ *      datetime, linked to a film titled 'Stoma'.
+ *   4. Source_id contains the substring 'stoma' (sanity).
+ *
+ * Run dry by default; pass --apply to commit.
+ */
+import { db } from "@/db";
+import { films, screenings } from "@/db/schema";
+import { eq, and, ne } from "drizzle-orm";
+
+const APPLY = process.argv.includes("--apply");
+
+const TARGET_ID = "cbcdfce0-94c1-4a7c-bde2-da4fa86a3889";
+const EXPECTED_WRONG_FILM_TITLE = "Guo Ran";
+const EXPECTED_CORRECT_FILM_TITLE = "Stoma";
+const REQUIRED_SOURCE_SUBSTR = "stoma";
+
+async function main(): Promise<void> {
+  console.log(`Stoma phantom deletion (${APPLY ? "APPLY" : "DRY RUN"} mode)`);
+
+  // 1) Read the target row + its current film.
+  const targetRows = await db
+    .select({
+      id: screenings.id,
+      cinemaId: screenings.cinemaId,
+      sourceId: screenings.sourceId,
+      datetime: screenings.datetime,
+      filmId: screenings.filmId,
+      filmTitle: films.title,
+    })
+    .from(screenings)
+    .leftJoin(films, eq(films.id, screenings.filmId))
+    .where(eq(screenings.id, TARGET_ID))
+    .limit(1);
+
+  if (targetRows.length === 0) {
+    console.log(`  Target row ${TARGET_ID} does not exist — already cleaned up. Exiting.`);
+    process.exit(0);
+  }
+  const target = targetRows[0];
+  console.log(`  Target row:`, target);
+
+  // 2) Check guards.
+  if (target.filmTitle !== EXPECTED_WRONG_FILM_TITLE) {
+    console.error(
+      `  ABORT: target row's film title is '${target.filmTitle}', expected '${EXPECTED_WRONG_FILM_TITLE}'.`
+    );
+    process.exit(1);
+  }
+  if (!target.sourceId || !target.sourceId.toLowerCase().includes(REQUIRED_SOURCE_SUBSTR)) {
+    console.error(
+      `  ABORT: target row's source_id ('${target.sourceId}') does not contain '${REQUIRED_SOURCE_SUBSTR}'.`
+    );
+    process.exit(1);
+  }
+
+  // 3) Confirm a sibling correct row exists (same source_id+cinema+datetime, different id, film title = 'Stoma').
+  const siblings = await db
+    .select({
+      id: screenings.id,
+      filmId: screenings.filmId,
+      filmTitle: films.title,
+    })
+    .from(screenings)
+    .leftJoin(films, eq(films.id, screenings.filmId))
+    .where(
+      and(
+        eq(screenings.cinemaId, target.cinemaId),
+        eq(screenings.sourceId, target.sourceId),
+        eq(screenings.datetime, target.datetime),
+        ne(screenings.id, target.id)
+      )
+    );
+  console.log(`  Sibling rows with same (cinema, source_id, datetime):`);
+  for (const s of siblings) {
+    console.log(`    - ${s.id.slice(0, 8)} → ${s.filmTitle ?? "<null>"}`);
+  }
+
+  const correctSibling = siblings.find((s) => s.filmTitle === EXPECTED_CORRECT_FILM_TITLE);
+  if (!correctSibling) {
+    console.error(
+      `  ABORT: no sibling row linked to a film titled '${EXPECTED_CORRECT_FILM_TITLE}' — cannot safely delete.`
+    );
+    process.exit(1);
+  }
+  console.log(`  ✓ Correct sibling present: ${correctSibling.id.slice(0, 8)} → ${correctSibling.filmTitle}`);
+
+  // 4) Delete (or dry-run).
+  if (APPLY) {
+    const deleted = await db
+      .delete(screenings)
+      .where(eq(screenings.id, TARGET_ID))
+      .returning({ id: screenings.id });
+    console.log(`  ✅ Deleted ${deleted.length} row.`);
+  } else {
+    console.log(`  [DRY RUN] Would delete row ${TARGET_ID}.`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("ERR:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Deletes one phantom screening row in production Supabase.** Garden's 2026-05-17 18:00 Stoma showing had two rows with identical `(cinema_id, source_id, datetime)` — one wrongly linked to Guo Ran (scraped 2026-04-29, pre-#472 codepath), one correctly linked to Stoma (scraped 2026-05-05). The Guo Ran row is a phantom; Garden never scheduled Guo Ran at that slot.
- **Resolves the suspect merge surfaced by yesterday's audit** in PR #472. The Stoma → Guo Ran trigram similarity was 0.016 — far below any matcher threshold, confirming this was NOT a fuzzy-match misfire and PR #472's matcher hardening could not have caused or prevented it.
- **Surfaces a much bigger structural issue (out of scope)**: the `screenings` table has no unique constraint beyond `PRIMARY KEY (id)`. The same audit found 20+ `(cinema_id, source_id, datetime)` collisions across 7 cinemas (Picturehouse, Rio, PCC, Everyman, ICA, Curzon, Garden) where re-scrapes inserted duplicate rows that resolved to different film_ids. Logged as a separate follow-up.

## Changes

- New `scripts/delete-stoma-phantom.ts` — one-shot deletion with 4 pre-flight guards (target id match, target film_title='Guo Ran', source_id contains 'stoma', sibling correctly linked to film_title='Stoma'). Idempotent (no-op if already deleted). Already executed against prod with `--apply` during this work.
- `RECENT_CHANGES.md` + new `changelogs/2026-05-05-delete-stoma-phantom-screening.md` — full audit trail.

## Verification

After running with `--apply`:

```
=== Garden screenings with source_id containing 'stoma' ===
1 row remaining: 4257ddb6 → Stoma (2020) at 2026-05-17 18:00 ✓

=== All Garden screenings linked to Guo Ran ===
1 row remaining: 210e5b41 → garden-...presents-guo-ran-2026-05-09T17:00:00.000Z ✓
(the legitimate 2026-05-09 Guo Ran screening, untouched)
```

No code paths changed; tsc + lint + tests baseline preserved (887/887 from PR #472).

Code reviewer agent reviewed `delete-stoma-phantom.ts` pre-PR; no changes requested.

## Test plan

- [x] Dry-run output shows guards passing and target row matches expectation
- [x] `--apply` returns "Deleted 1 row"
- [x] Post-apply verification confirms exactly one Stoma row, exactly one (legitimate) Guo Ran row
- [x] Re-running the script after apply is a no-op (idempotency)
- [x] Code reviewer agent: archival quality OK, no fixes needed

## Out of scope (deliberately)

- **Add a unique constraint on `screenings(cinema_id, source_id)`** — needs analysis of whether `source_id` shapes are stable per cinema, plus a backfill plan to dedupe the existing 20+ duplicates first.
- **Sweep the other 20+ duplicate triples** — same analysis required; pick a winner per triple based on `scraped_at` recency and source_id-vs-film-title similarity.
- **Investigate why the 2026-04-29 scrape resolved to Guo Ran** — that codepath (Gemini classifiers / pre-#472 fallback logic) no longer exists; not worth deep-diving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)