### PR TITLE
fix(scrapers): expand Barbican horizon and Coldharbour category filter

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-05-06: Scraper coverage — Barbican horizon 14→30 days, Coldharbour Blue category filter relaxed
+**PR**: TBD | **Files**: `src/scrapers/cinemas/barbican.ts`, `src/scrapers/cinemas/coldharbour-blue.ts`
+- Per-cinema audit found Barbican capped at a hardcoded 14-day fetch horizon while the cinema publishes ~3 weeks ahead (verified day-19 endpoint returns 7 cards, day-30+ returns 0). Bumped `DAYS_AHEAD` to 30; trade-off is ~5 min scrape runtime vs ~2.3 min, well within the 6 req/min limit.
+- Coldharbour Blue's WordPress Tribe Events API returns 14 events but the scraper kept only the 10 tagged `screenings`. The other 4 are real film screenings tagged `events` (Crafty Movie Night, Herne Hill Free Film Festival, To Call You A Forest – Screening + Q&A, Crafty Movie Night x The Great British Yarn). Filter now also accepts `events`-only items whose title matches `\b(movie night|film club|film festival|film screening)\b` or the `screening + Q&A` pattern.
+- Regex tightened after code review: bare `screening`/`cinema` removed to avoid future false positives like "Health Screening Workshop". 9-case test (4 expected match + 5 false-positive guards) all passes.
+- Verified: `npm run test:run` 887/887, `npx tsc --noEmit` clean, `npm run lint` 0 errors.
+- Companion audit report: `Pictures/Audits/scraper-coverage-2026-05-06.md`. Castle / Castle Sidcup gaps (84 missing screenings combined) and Regent Street investigation deferred to a separate PR.
+
+---
+
 ## 2026-05-06: Dedupe 413 screening rows + prevent (cinema, source_id, datetime) duplicates
 **PR**: TBD | **Files**: `src/scrapers/utils/screening-classification.ts`, `src/scrapers/pipeline.ts`, `scripts/audit-screening-duplicates.ts`, `scripts/dedupe-screening-source-id-duplicates.ts`
 - Audit found 398 duplicate `(cinema_id, source_id, datetime)` triples in production — 813 rows / 413 excess / 387 future-dated / 45 cinemas affected. Every triple had a film mismatch. Calendar was rendering doubled screenings.

--- a/changelogs/2026-05-06-scraper-coverage-barbican-coldharbour.md
+++ b/changelogs/2026-05-06-scraper-coverage-barbican-coldharbour.md
@@ -1,0 +1,35 @@
+# Scraper coverage — Barbican horizon + Coldharbour category filter
+
+**PR**: TBD
+**Date**: 2026-05-06
+
+## Changes
+
+### `src/scrapers/cinemas/barbican.ts`
+
+- `DAYS_AHEAD` constant bumped from 14 → 30.
+- Comment updated to reflect new request count (30 pages vs 48+).
+
+### `src/scrapers/cinemas/coldharbour-blue.ts`
+
+- `convertToRawScreenings` filter relaxed to also accept WordPress Tribe events whose category is only `events` (not `screenings`) when the title matches a film-signal regex.
+- Regex: `\b(movie night|film club|film festival|film screening)\b|\bscreening\s*[+&]`. Items already tagged `screenings` continue to pass unconditionally.
+
+## Why
+
+Per-cinema audit (`Pictures/Audits/scraper-coverage-2026-05-06.md`) found:
+
+- **Barbican**: 29 upcoming screenings, all 23 in next 7 days, 29 in next 30 days — i.e. nothing past the 14-day window. Verified `https://www.barbican.org.uk/whats-on/cinema?day=YYYY-MM-DD` returns 7 cards on day 19 but 0 on day 30+, so 30-day horizon captures everything Barbican publishes.
+- **Coldharbour Blue**: API returns 14 events; we kept only the 10 in the `screenings` category. Verified the missing 4 are all real film screenings tagged only as `events` by their booking system.
+
+## Impact
+
+- Barbican: estimated +20 screenings on next scrape (the day-15 → day-30 window).
+- Coldharbour Blue: +4 screenings immediately picked up on next scrape.
+- Scraper runtime: Barbican goes from ~2.3 min to ~5 min (still well within rate limits and far inside the nightly cron window). Coldharbour unchanged.
+- Risk: regex was tightened after code review; verified with a 9-case test (4 expected matches + 5 false-positive guards) that "Health Screening Workshop", "Cinema Bar Quiz Night", etc. do not pass through.
+
+## Out of scope
+
+- **Castle Cinema / Castle Sidcup**: missing ~84 screenings combined because the scraper only parses homepage JSON-LD instead of the `/calendar/` page that has every performance button. Needs a more substantial rewrite — separate PR.
+- **Regent Street Cinema**: 26 upcoming, suspected to be truncated by the scraper's 3-second post-first-batch GraphQL timeout. Needs Playwright instrumentation — separate investigation.

--- a/src/scrapers/cinemas/barbican.ts
+++ b/src/scrapers/cinemas/barbican.ts
@@ -8,7 +8,7 @@
  * This is much more reliable than the old approach of scraping /whats-on/series/new-releases
  * then fetching individual film pages and performance endpoints, because:
  * 1. It covers ALL cinema series, not just "new-releases"
- * 2. Fewer HTTP requests (14 pages vs 48+)
+ * 2. Fewer HTTP requests (30 pages vs 48+)
  * 3. All data (title, time, booking URL) is on one page per day
  * 4. No fragile node ID extraction step
  *
@@ -24,7 +24,7 @@ import { parseScreeningTime, ukLocalToUTC } from "../utils/date-parser";
 import { FestivalDetector } from "../festivals/festival-detector";
 
 /** Number of days ahead to scrape from today */
-const DAYS_AHEAD = 14;
+const DAYS_AHEAD = 30;
 
 export class BarbicanScraper extends BaseScraper {
   config: ScraperConfig = {

--- a/src/scrapers/cinemas/coldharbour-blue.ts
+++ b/src/scrapers/cinemas/coldharbour-blue.ts
@@ -119,11 +119,19 @@ export class ColdharbourBlueScraper implements CinemaScraper {
   private convertToRawScreenings(events: TribeEvent[]): RawScreening[] {
     return events
       .filter((event) => {
-        // Only include events in the "Screenings" category
-        const isScreening = event.categories.some(
+        // Include events tagged "screenings", OR events whose title indicates a film screening
+        // (some film nights are tagged only as "events" but are still cinema screenings)
+        const inScreeningsCategory = event.categories.some(
           (cat) => cat.slug === "screenings" || cat.name.toLowerCase() === "screenings"
         );
-        return isScreening;
+        if (inScreeningsCategory) return true;
+
+        const title = event.title.toLowerCase();
+        // Strong cinema signals — bare "screening"/"cinema" excluded to avoid future
+        // false positives like "Health Screening Workshop". The "screening + q&a"
+        // pattern is intentional: it's the only standalone "screening" the regex
+        // catches, since film screenings overwhelmingly bundle a Q&A or discussion.
+        return /\b(movie night|film club|film festival|film screening)\b|\bscreening\s*[+&]/.test(title);
       })
       .map((event) => {
         // Parse the datetime - format is "2026-01-06 20:00:00"


### PR DESCRIPTION
## Summary

Two small scraper coverage fixes from a per-cinema audit.

- **Barbican**: bump `DAYS_AHEAD` 14 → 30. Cinema publishes ~3 weeks ahead; day-19 endpoint returns 7 cards while day-30+ returns 0. Estimated +20 screenings on next scrape.
- **Coldharbour Blue**: relax category filter to also accept Tribe `events` items whose title contains film signals (`movie night`, `film club`, `film festival`, `film screening`, or `screening +/&` for Q&A patterns). 4 verified film screenings were being dropped (Crafty Movie Night – Four Weddings and a Funeral, Herne Hill Free Film Festival, To Call You A Forest – Screening + Q&A, Crafty Movie Night x The Great British Yarn).

Regex tightened after code review — bare `screening`/`cinema` removed to prevent future false positives like "Health Screening Workshop". Verified with a 9-case test (4 expected matches + 5 false-positive guards).

Companion audit report: `Pictures/Audits/scraper-coverage-2026-05-06.md`. Castle / Castle Sidcup gaps (~84 missing screenings combined) and Regent Street investigation are deferred to a separate PR.

## Test plan

- [x] `npm run test:run` — 887/887 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] Regex unit test — 9/9 cases pass
- [ ] After merge: monitor next overnight scrape for Barbican (expect ~50 upcoming, was 29) and Coldharbour Blue (expect ~14, was 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)