### PR TITLE
feat(scrape): prioritise stale cinemas — stalest first within each wave

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,14 @@
+## 2026-05-07: Prioritise stale cinemas in /scrape — stalest first within each wave
+**PR**: TBD | **Files**: `src/lib/jobs/scrape-all.ts`
+- `runScrapeAll` now loads each cinema's last successful scrape timestamp from `scraper_runs` once, up front.
+- Within each wave (chains, playwright, cheerio), entries are sorted by their oldest-venue-staleness ASC: never-scraped venues first, then oldest, then most recent.
+- For chains/multi-venue entries, the staleness key is the OLDEST `MAX(completed_at)` across all venues the entry owns — so a chain runs early if any one of its venues is stale.
+- Logs the per-wave order: `[scrape-all] Chains order (stalest first): chain-curzon(7d), chain-everyman(2d), chain-picturehouse(0d)`.
+- Wave structure unchanged (chains still parallel for auth-sharing reasons; cheerio still cap-4 concurrency). Ordering is within-wave only.
+- Tests 890/890. tsc + lint clean. No new tests added — this is observability + ordering only, no behavior change to per-cinema logic.
+
+---
+
 ## 2026-05-07: Add postgres-js client timeouts to fix /scrape stalls
 **PR**: TBD | **Files**: `src/db/index.ts`
 - Local `/scrape` stalled twice for 12+ hours each before being killed manually. Cause: postgres-js with `max:1` connection on Supabase's transaction-mode pooler. When a pooler-side connection silently drops mid-query, the driver doesn't notice — the query promise never resolves and all subsequent queries queue behind it.

--- a/changelogs/2026-05-07-prioritise-stale-cinemas.md
+++ b/changelogs/2026-05-07-prioritise-stale-cinemas.md
@@ -1,0 +1,64 @@
+# Prioritise stale cinemas in `/scrape` — stalest first within each wave
+
+**PR**: TBD
+**Date**: 2026-05-07
+**Branch**: `feat/prioritise-stale-cinemas`
+**Driven by**: User wants `/scrape` to refresh the cinemas that haven't been scraped recently *first*, so that if a run is interrupted partway through, the freshest data has already been collected for the staler cinemas.
+
+## Why
+
+The previous `/scrape` order was the registry's hard-coded array order within each wave. After a partial run (which is what happened twice yesterday — postgres-js stalls killed manually), the cinemas at the END of each wave's array got the least refresh. That's exactly the wrong outcome — they're often the same ones that were stale before the run started.
+
+User said: "i want to prioritise cinemas that haven't been scraped recently".
+
+## Changes
+
+`src/lib/jobs/scrape-all.ts`:
+
+### New helpers
+
+- **`loadFreshnessMap(): Promise<Map<string, Date>>`** — queries `scraper_runs` once for `MAX(completed_at) GROUP BY cinema_id WHERE status = 'success'`. Cinemas that have never had a successful run are absent from the map.
+- **`getEntryCinemaIds(entry): string[]`** — builds the entry's config and extracts every cinema_id it touches. `single` → 1 id, `multi`/`chain` → all venues.
+- **`entryStaleness(entry, freshness): number`** — returns the OLDEST timestamp (epoch ms) across the entry's venues. Returns 0 for entries containing any never-scraped venue, putting them at the absolute top of the queue.
+
+### `runWave` change
+
+`runWave(wave, label, concurrency, freshness)` now sorts entries by `entryStaleness ASC` before fanning out to `runWithConcurrency`. Concurrency cap is unchanged (4 per wave), so the worker pool still picks up tasks in queue order — meaning the first 4 to start are the 4 stalest entries.
+
+The new logic logs the per-wave ordering with human-friendly age strings:
+
+```
+[scrape-all] Chains order (stalest first): chain-everyman(7d), chain-curzon(2d), chain-picturehouse(0d)
+[scrape-all] Playwright order (stalest first): bfi(never), barbican(5d), garden(2d), close-up-cinema(2d), riverside-studios(1d), olympic-studios(0d), coldharbour-blue(0d)
+[scrape-all] Cheerio order (stalest first): castle-sidcup(never), the-nickel(3d), genesis(2d), ...
+```
+
+### `runScrapeAll` change
+
+Loads the freshness map once at the top, passes it to each `runWave` call. One DB round-trip total, not per-wave.
+
+## What didn't change
+
+- **Wave structure** stays. Chains still run before playwright before cheerio. The reason is operational, not staleness-based: chains share auth-flow state, playwright cinemas are memory-heavy, cheerio is fast — these are concurrency-budget concerns that wave grouping handles correctly.
+- **Per-cinema scrape behavior** is unchanged. Same `runScraper` call, same retries, same validation.
+- **Concurrency cap** of 4 per wave is unchanged. Within a wave's stalest-first queue, up to 4 entries run in parallel.
+
+## Verification
+
+- `npx tsc --noEmit` — clean.
+- `npm run lint` — 0 errors.
+- `npm run test:run` — 890 / 890 passing.
+- No new tests — this is ordering + observability only. The sort is a pure function of `freshness` and `getEntryCinemaIds`; `entryStaleness` returns 0 for never-scraped which guarantees never-scraped venues come first by construction.
+
+## Edge cases
+
+- **Cinema retired from registry but rows remain in `scraper_runs`**: harmless — the map entry exists but no registry entry consumes it.
+- **Cinema added to registry but never run**: `loadFreshnessMap` returns no entry for it; `entryStaleness` returns 0; entry runs first.
+- **Tied timestamps** (sub-millisecond ties from a recent batched scrape): falls back to original array order via stable sort. Doesn't matter operationally.
+- **`completedAt` is null** (a run that started but didn't finish): `MAX(completed_at)` ignores nulls, so a partially-complete run doesn't update freshness for that cinema. Means a cinema whose last "completion" was a long time ago still sorts as stale even if a recent run started but never finished.
+
+## Out of scope
+
+- **Cross-wave staleness ordering** — could let a never-scraped cheerio venue jump ahead of a freshly-scraped chain. Deferred because waves exist for parallelism/memory reasons that staleness doesn't replace.
+- **Per-screening staleness** (skip cinemas whose data is <4h old entirely) — possible but not requested.
+- **CLI flag `/scrape --stalest-only N`** — could be useful for quick refresh runs, but not requested.

--- a/src/lib/jobs/scrape-all.ts
+++ b/src/lib/jobs/scrape-all.ts
@@ -17,7 +17,7 @@
  * dispatches a Telegram digest at the end (same shape as before).
  */
 
-import { gte, eq } from "drizzle-orm";
+import { gte, eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { scraperRuns } from "@/db/schema/admin";
 import { cinemas } from "@/db/schema/cinemas";
@@ -132,13 +132,74 @@ async function runScraperEntry(
   }
 }
 
+/**
+ * Map of cinema_id → last successful scrape timestamp. Cinemas that have never
+ * been scraped successfully are absent from the map.
+ */
+type FreshnessMap = Map<string, Date>;
+
+/** Load each cinema's most recent successful scrape timestamp from scraper_runs. */
+async function loadFreshnessMap(): Promise<FreshnessMap> {
+  const rows = await db
+    .select({
+      cinemaId: scraperRuns.cinemaId,
+      lastScrape: sql<Date>`MAX(${scraperRuns.completedAt})`.as("lastScrape"),
+    })
+    .from(scraperRuns)
+    .where(eq(scraperRuns.status, "success"))
+    .groupBy(scraperRuns.cinemaId);
+
+  const map: FreshnessMap = new Map();
+  for (const r of rows) {
+    if (r.lastScrape) map.set(r.cinemaId, new Date(r.lastScrape));
+  }
+  return map;
+}
+
+/** Extract every cinema_id a registry entry will scrape. */
+function getEntryCinemaIds(entry: ScraperRegistryEntry): string[] {
+  const config = entry.buildConfig();
+  if (config.type === "single") return [config.venue.id];
+  return config.venues.map((v) => v.id);
+}
+
+/**
+ * Staleness key for sorting: the OLDEST last-scrape across the entry's venues.
+ * Returns 0 (epoch) for entries with any never-scraped venue, so they sort first.
+ */
+function entryStaleness(entry: ScraperRegistryEntry, freshness: FreshnessMap): number {
+  const ids = getEntryCinemaIds(entry);
+  let oldest = Number.POSITIVE_INFINITY;
+  for (const id of ids) {
+    const last = freshness.get(id);
+    if (!last) return 0; // never-scraped venue → top priority
+    if (last.getTime() < oldest) oldest = last.getTime();
+  }
+  return oldest === Number.POSITIVE_INFINITY ? 0 : oldest;
+}
+
 /** Fan-out scrapers in a single wave with the given concurrency cap. */
 async function runWave(
   wave: ScraperWave,
   label: string,
   concurrency: number,
+  freshness: FreshnessMap,
 ): Promise<WaveSummary> {
-  const entries = SCRAPER_REGISTRY.filter((e) => e.wave === wave);
+  // Sort by staleness ASC (never-scraped first, then oldest, then most recent last).
+  // Compute the staleness key once per entry; sort + log share the result.
+  const ranked = SCRAPER_REGISTRY.filter((e) => e.wave === wave)
+    .map((entry) => ({ entry, ms: entryStaleness(entry, freshness) }))
+    .sort((a, b) => a.ms - b.ms);
+  if (ranked.length > 0) {
+    const orderStr = ranked
+      .map(({ entry, ms }) => {
+        const age = ms === 0 ? "never" : `${Math.floor((Date.now() - ms) / 86_400_000)}d`;
+        return `${entry.taskId.replace(/^scraper-/, "")}(${age})`;
+      })
+      .join(", ");
+    console.log(`[scrape-all] ${label} order (stalest first): ${orderStr}`);
+  }
+  const entries = ranked.map((r) => r.entry);
   const tasks = entries.map((entry) => () => runScraperEntry(entry));
   const settled = await runWithConcurrency(tasks, concurrency);
 
@@ -210,14 +271,19 @@ export async function runScrapeAll(): Promise<ScrapeAllResult> {
   const startedAt = new Date(startTime);
   const waveSummaries: WaveSummary[] = [];
 
+  // Load each cinema's last successful scrape timestamp once, up front.
+  // Within each wave, entries are sorted stalest-first so that if the run is
+  // interrupted, the cinemas that need the most refresh have already gone.
+  const freshness = await loadFreshnessMap();
+
   // Wave 1: Chain scrapers (3 — fully parallel)
-  waveSummaries.push(await runWave("chain", "Chains", 4));
+  waveSummaries.push(await runWave("chain", "Chains", 4, freshness));
 
   // Wave 2: Playwright independents (7 — cap at 4 for memory headroom)
-  waveSummaries.push(await runWave("playwright", "Playwright", 4));
+  waveSummaries.push(await runWave("playwright", "Playwright", 4, freshness));
 
   // Wave 3: Cheerio / API independents (16 — cap at 4 to mirror prior chunking)
-  waveSummaries.push(await runWave("cheerio", "Cheerio", 4));
+  waveSummaries.push(await runWave("cheerio", "Cheerio", 4, freshness));
 
   // Wave 4: Post-scrape enrichment (Letterboxd ratings)
   waveSummaries.push(await runEnrichmentWave());


### PR DESCRIPTION
## Summary

\`/scrape\` now refreshes cinemas that haven't been scraped recently *first*. If a run is interrupted partway through, the data that benefits most has already landed.

## Behavior

\`runScrapeAll\` loads each cinema's last successful scrape timestamp from \`scraper_runs\` once. Within each wave (chains → playwright → cheerio), entries sort stalest-first:

```
[scrape-all] Chains order (stalest first): chain-everyman(7d), chain-curzon(2d), chain-picturehouse(0d)
[scrape-all] Playwright order (stalest first): bfi(never), barbican(5d), garden(2d), ...
```

For chains/multi-venue entries (BFI = 2 venues, Curzon/Picturehouse/Everyman = N venues each), the staleness key is the **oldest** \`MAX(completed_at)\` across all venues — so a chain runs early if any single venue is stale.

Never-scraped venues sort to the absolute top (they win against any timestamp).

## What didn't change

- **Wave structure** — chains still run before playwright before cheerio. Reason is operational (auth-flow sharing, memory budgets), not staleness.
- **Per-cinema scrape behavior** — same \`runScraper\`, same retries, same validation.
- **Concurrency cap** of 4 per wave — within the stalest-first queue, up to 4 entries still run in parallel.

## Verification

- \`npm run test:run\` — **890 / 890** passing.
- \`npx tsc --noEmit\` — clean.
- \`npm run lint\` — 0 errors, 41 warnings (all pre-existing).
- Code reviewer agent: ship-ready. One small optimization applied (compute staleness once, share between sort + log).

## Test plan

- [x] tsc, lint, tests clean
- [x] \`loadFreshnessMap\` SQL verified — \`MAX(completed_at) GROUP BY cinema_id WHERE status = 'success'\` correctly skips nulls and partial runs
- [x] Sort is stable (V8 \`Array.prototype.sort\` is TimSort) — tied timestamps preserve registry order
- [x] Reviewer confirmed all chain scrapers' constructors are side-effect-free (no I/O during \`buildConfig()\`)
- [x] \`multi\` config (BFI) handled correctly — \`config.venues.map(v => v.id)\` covers both \`multi\` and \`chain\`
- [ ] Production: next \`/scrape\` should log the per-wave order at the top of each wave

## Out of scope

- **Cross-wave staleness ordering** — could let a never-scraped cheerio venue jump ahead of a freshly-scraped chain. Deferred because waves exist for parallelism/memory reasons that staleness shouldn't override.
- **Per-screening staleness skip** (skip cinemas whose data is <4h old entirely) — possible but not requested.
- **CLI flag \`/scrape --stalest-only N\`** — useful for quick refresh runs, not requested yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)