### PR TITLE
fix(db): client-side query timeout + DB_POOL_MAX — fix the /scrape hang #479 didn't catch

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,20 @@
+## 2026-05-07: Client-side DB query timeout + pool-max env override — fix the /scrape hang #479 didn't catch
+**PR**: TBD | **Files**: `src/db/index.ts`, `src/scrapers/pipeline.ts`, `src/scrapers/utils/scrape-diff.ts`, `src/scrapers/utils/film-matching.ts`
+- Local `/scrape` hung again at 32 cinemas in. Process at 0.0% CPU, sleeping for 87+ minutes after `[Pipeline] 58 valid screenings to process` with no errors logged.
+- Root cause: postgres-js + Supabase pooler half-open connection. The pooler silently dropped its end of the TCP socket between query bursts. The next query write succeeded (TCP send buffer accepts bytes), but `recv()` blocked forever waiting for a response the server never sees. Server-side `statement_timeout` (#479) doesn't fire because the server didn't receive the query. macOS default TCP keepalive is 7200s — useless.
+- Fix part 1 (query ceiling): added `withDbTimeout(p, ms, label)` helper in `src/db/index.ts` — Promise.race against a default 10s reject (overridable per call-site). Applied at every hot-path DB call in `runScraperPipeline`:
+  - `generateScrapeDiff` cinema lookup + existing-screenings query (15s each)
+  - `initFilmCache` films table load (15s)
+  - per-film `getOrCreateFilm` (20s — has TMDB calls inside)
+  - per-film `linkFilmToMatchingSeasons` (10s)
+  - per-screening `insertScreening` (15s — covers checkForDuplicate + insert/update)
+- Fix part 2 (no cascading failure): pool `max` is now configurable via `DB_POOL_MAX` env var (default 1 to keep serverless behavior on Vercel; bump to 3 in `.env.local` for local runs). Without this, a single wedged connection blocks every subsequent query for up to 30 min until `max_lifetime` rotates it. With `max: 3` locally, two healthy slots keep the run moving while the wedged one drains.
+- On timeout: throws → caught by the per-cinema try/catch in `pipeline.ts:218` → cinema gets skipped, the rest of the scrape continues. Same recovery posture as the existing `57014` (query_canceled) catch path.
+- Reviewed by code-reviewer agent before commit; addressed coverage gaps (per-film loop calls were unwrapped) and cascading-failure mode (single `max:1` slot caused 30min downtime per wedge). Deferred follow-up: client-recreate on timeout (requires re-architecting the `db` const export).
+- Tests 890/890. tsc + lint clean.
+
+---
+
 ## 2026-05-07: Prioritise stale cinemas in /scrape — stalest first within each wave
 **PR**: TBD | **Files**: `src/lib/jobs/scrape-all.ts`
 - `runScrapeAll` now loads each cinema's last successful scrape timestamp from `scraper_runs` once, up front.

--- a/changelogs/2026-05-07-db-client-side-timeout.md
+++ b/changelogs/2026-05-07-db-client-side-timeout.md
@@ -1,0 +1,111 @@
+# Client-side DB query timeout + pool-max override — fix the /scrape hang #479 didn't catch
+
+**PR**: TBD
+**Date**: 2026-05-07
+
+## Symptom
+
+Local `/scrape` hung at 32 cinemas in. Output silent for 87+ minutes after the line `[Pipeline] 58 valid screenings to process`. Process at 0.0% CPU, state `S` (sleeping). No errors in logs. No 60-second timeout fired.
+
+This is the same failure shape as the original 12-hour hangs that #479 was meant to fix.
+
+## Root cause
+
+postgres-js + Supabase pooler half-open connection.
+
+1. The Supabase transaction-mode pooler holds the underlying TCP socket between connection borrows.
+2. Between query bursts (Wave 1 had been running for ~10 minutes), the pooler silently dropped its end of the socket without sending TCP RST.
+3. The next query write from the client succeeded — TCP send buffer accepted the bytes locally.
+4. The server never received the query (the pooler dropped it).
+5. The client's `recv()` blocked forever waiting for a response.
+6. Server-side `statement_timeout: 60_000` (added in #479) didn't fire because the server didn't see the query at all.
+7. macOS default TCP keepalive is 7200 seconds — useless for this purpose.
+
+## Why #479's timeouts didn't help
+
+| Timeout | Scope | Why it didn't help |
+|---|---|---|
+| `statement_timeout: 60_000` | Server-side | Server never received the query |
+| `idle_timeout: 20` | Client-side | Only kills *idle* connections, not borrowed ones |
+| `connect_timeout: 15` | Client-side | Only governs initial handshake |
+| `max_lifetime: 30min` | Client-side | Only rotates *released* connections, not in-flight ones |
+
+There was no client-side hard ceiling on any individual query.
+
+## Fix
+
+### Part 1 — Query ceiling
+
+Added `withDbTimeout<T>(p, ms = 10_000, label)` helper in `src/db/index.ts`:
+
+```typescript
+export function withDbTimeout<T>(
+  p: Promise<T>,
+  ms = 10_000,
+  label = "db query",
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timeout after ${ms}ms (client-side)`)),
+      ms,
+    );
+  });
+  return Promise.race([p, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+```
+
+Applied at every hot-path DB call in `runScraperPipeline`:
+
+| Site | Ceiling | Why |
+|---|---|---|
+| `generateScrapeDiff` cinema lookup | 15s | Single-row select, p99 ≪1s |
+| `generateScrapeDiff` existing screenings | 15s | Joined select, p99 ≪1s |
+| `initFilmCache` films table load | 15s | ~1.2k rows full scan |
+| `getOrCreateFilm` (per-film) | 20s | Includes TMDB API calls |
+| `linkFilmToMatchingSeasons` (per-film) | 10s | Tiny lookup + optional inserts |
+| `insertScreening` (per-screening) | 15s | `checkForDuplicate` + insert/update |
+
+### Part 2 — No cascading failure
+
+Pool `max` is now configurable via `DB_POOL_MAX` env var:
+
+- Default `1` — preserves serverless-safe behavior on Vercel
+- Local `.env.local`: bump to `3`
+
+Without this, a single wedged connection on `max: 1` would block every subsequent query for up to 30 minutes until `max_lifetime` rotated it. With `max: 3` locally, two healthy slots keep the run moving while the wedged one drains.
+
+## Recovery posture
+
+On timeout the wrapper throws. The error propagates up to the per-cinema try/catch in `src/scrapers/pipeline.ts` (and to the per-film inner try/catch where applicable). Same posture as the existing `57014` (query_canceled) catch path — a single film loses, the rest of the cinema continues; if the whole cinema's prelude wedges, the cinema is skipped and the run continues.
+
+## What this still doesn't do (deferred)
+
+`Promise.race` only stops *waiting*. The underlying postgres-js promise is still alive, holding its connection slot until eventual rejection or `max_lifetime` rotation. With `DB_POOL_MAX=3`, this is fine — there are healthy slots available.
+
+A more thorough fix would force-recreate the postgres-js client on timeout (`client.end({ timeout: 0 })` + new client). That requires re-architecting the `db = drizzle(...)` const export, which is referenced widely. Deferred until evidence demands it.
+
+Other unwrapped DB calls (intentionally — they are not on the per-cinema hot path):
+
+- `cleanupSupersededScreenings` (post-loop cleanup)
+- `db.update(cinemas).set({ lastScrapedAt })` (single-row update at end of pipeline)
+- The 6 queries inside `screening-classification.ts` (called *inside* `insertScreening`, which is wrapped at the call site — covered transitively)
+
+## Verification
+
+- 890/890 tests pass.
+- `npx tsc --noEmit` clean.
+- `npm run lint` clean (0 errors, 41 pre-existing warnings unchanged).
+- Pending: end-to-end re-run of `/scrape` after merge.
+
+## Code review
+
+Reviewed by the project's code-reviewer agent before commit. The reviewer raised three substantive issues, two of which were addressed in-PR:
+
+1. Recovery posture (cascading failure with `max: 1`) — addressed via `DB_POOL_MAX` env var.
+2. Coverage gaps (per-film loop unwrapped) — addressed by wrapping `getOrCreateFilm`, `linkFilmToMatchingSeasons`, and `insertScreening` at the call-site boundary.
+3. Client-recreate on timeout — deferred (see above).
+
+Threshold also tightened from the initial 30s to 10–20s based on reviewer feedback (p99 is sub-1s).

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -31,10 +31,18 @@ const hasValidDatabaseUrl =
 //   - idle_timeout: client-side recycle of idle conns to dodge stale pooler links.
 //   - connect_timeout: bound the initial handshake so a dead pooler fails fast.
 //   - max_lifetime: rotate conns so no single one stays open across pooler restarts.
+// `max` is configurable via DB_POOL_MAX so local /scrape can use multiple
+// connection slots — a wedged half-open conn no longer blocks all subsequent
+// queries while we wait for max_lifetime rotation. Defaults to 1 to preserve
+// serverless-safe behavior on Vercel; bump to 3 in .env.local for local runs.
+const poolMax = process.env.DB_POOL_MAX
+  ? Math.max(1, Number(process.env.DB_POOL_MAX))
+  : 1;
+
 const client = hasValidDatabaseUrl
   ? postgres(connectionString, {
       prepare: false, // Required for Supabase connection pooling (transaction mode)
-      max: 1, // Limit connections in serverless
+      max: poolMax,
       idle_timeout: 20, // seconds
       connect_timeout: 15, // seconds
       max_lifetime: 60 * 30, // 30 minutes — if you add db.transaction(...), keep blocks under this
@@ -58,3 +66,39 @@ export { schema };
 
 // Type exports for convenience
 export type Database = typeof db;
+
+/**
+ * Client-side hard ceiling on a DB call. Rejects after `ms` if the underlying
+ * postgres-js promise hasn't settled.
+ *
+ * Why this exists (added 2026-05-07): postgres-js + Supabase pooler can leave
+ * the client blocked on `recv()` for a connection the pooler silently dropped
+ * at the TCP layer. The server-side `statement_timeout` only fires if the
+ * server receives the query. `idle_timeout` only kills idle conns. macOS's
+ * default TCP keepalive is 7200s. Net effect: a query promise hangs forever.
+ *
+ * This wrapper bounds every wrapped call. On timeout the per-cinema try/catch
+ * in pipeline.ts logs the failure and moves on — same recovery posture as the
+ * existing 57014 (query_canceled) catch path.
+ *
+ * Note: this stops *waiting* on the promise; the underlying socket is still
+ * held by postgres-js until its own cleanup runs. That's acceptable here
+ * because `max: 1` means at most one stuck conn, and `max_lifetime: 30min`
+ * eventually rotates it.
+ */
+export function withDbTimeout<T>(
+  p: Promise<T>,
+  ms = 10_000,
+  label = "db query",
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timeout after ${ms}ms (client-side)`)),
+      ms,
+    );
+  });
+  return Promise.race([p, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}

--- a/src/scrapers/pipeline.ts
+++ b/src/scrapers/pipeline.ts
@@ -3,7 +3,7 @@
  * Normalizes, enriches, and persists scraped screening data
  */
 
-import { db } from "@/db";
+import { db, withDbTimeout } from "@/db";
 import { screenings as screeningsTable, cinemas, festivals, festivalScreenings } from "@/db/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { extractFilmTitleCached, batchExtractTitles } from "@/lib/title-extraction";
@@ -208,17 +208,28 @@ export async function processScreenings(
   console.log(`[Pipeline] ${screeningsByFilm.size} unique films after AI extraction`);
 
   // Process each film
+  // The two awaited boundaries — getOrCreateFilm and insertScreening — are
+  // wrapped with withDbTimeout. If a half-open Supabase conn wedges any inner
+  // DB call (or a TMDB lookup hangs in getOrCreateFilm), the wrapper throws
+  // after the ceiling and the surrounding try/catch logs and skips. Same
+  // recovery posture as a Postgres 57014 — one film loses, the rest of the
+  // cinema (and the rest of the run) continues.
   for (const [normalizedTitle, filmScreenings] of screeningsByFilm) {
     try {
       // Get the first screening for film metadata (use any scraper-provided data)
       const firstScreening = filmScreenings[0];
 
-      // Get or create film record, passing any scraper-extracted metadata
-      const filmId = await getOrCreateFilm(
-        firstScreening.filmTitle,
-        firstScreening.year,
-        firstScreening.director,
-        firstScreening.posterUrl
+      // Get or create film record, passing any scraper-extracted metadata.
+      // 20s ceiling: covers internal DB selects + a TMDB API call.
+      const filmId = await withDbTimeout(
+        getOrCreateFilm(
+          firstScreening.filmTitle,
+          firstScreening.year,
+          firstScreening.director,
+          firstScreening.posterUrl
+        ),
+        20_000,
+        `getOrCreateFilm: ${firstScreening.filmTitle}`,
       );
 
       if (!filmId) {
@@ -229,12 +240,21 @@ export async function processScreenings(
 
       // Link film to any matching seasons
       // This ensures films are associated with seasons as soon as they're scraped
-      await linkFilmToMatchingSeasons(filmId, firstScreening.filmTitle);
+      await withDbTimeout(
+        linkFilmToMatchingSeasons(filmId, firstScreening.filmTitle),
+        10_000,
+        `linkFilmToMatchingSeasons: ${firstScreening.filmTitle}`,
+      );
 
-      // Insert screenings (normalize timestamps to zero seconds/ms)
+      // Insert screenings (normalize timestamps to zero seconds/ms).
+      // 15s ceiling per screening: covers checkForDuplicate + insert/update.
       for (const screening of filmScreenings) {
         const normalizedScreening = { ...screening, datetime: normalizeTimestamp(screening.datetime) };
-        const added = await insertScreening(filmId, cinemaId, normalizedScreening);
+        const added = await withDbTimeout(
+          insertScreening(filmId, cinemaId, normalizedScreening),
+          15_000,
+          `insertScreening: ${cinemaId}/${normalizedScreening.sourceId ?? "<nosrc>"}`,
+        );
         if (added) {
           result.added++;
         } else {

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -6,7 +6,7 @@
  * getOrCreateFilm() focused on orchestration.
  */
 
-import { db } from "@/db";
+import { db, withDbTimeout } from "@/db";
 import { films } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { matchFilmToTMDB, getTMDBClient, isRepertoryFilm, getDecade } from "@/lib/tmdb";
@@ -45,7 +45,11 @@ export async function initFilmCache(
   normalizeFn = normalizeTitle;
 
   cacheStats.dbQueries++;
-  const allFilms = await db.select().from(films);
+  const allFilms = await withDbTimeout(
+    db.select().from(films),
+    15_000,
+    "initFilmCache: select films",
+  );
 
   for (const film of allFilms) {
     const normalized = normalizeTitle(film.title);

--- a/src/scrapers/utils/scrape-diff.ts
+++ b/src/scrapers/utils/scrape-diff.ts
@@ -8,7 +8,7 @@
  * - Suspicious patterns (sudden drops, holiday screenings, etc.)
  */
 
-import { db } from "@/db";
+import { db, withDbTimeout } from "@/db";
 import { screenings, films, cinemas } from "@/db/schema";
 import { eq, and, gte, lte } from "drizzle-orm";
 import type { RawScreening } from "../types";
@@ -53,30 +53,35 @@ export async function generateScrapeDiff(
   const futureLimit = addDays(now, MAX_DAYS_IN_FUTURE_FOR_COMPARISON);
 
   // Get cinema info
-  const [cinema] = await db
-    .select()
-    .from(cinemas)
-    .where(eq(cinemas.id, cinemaId));
+  const [cinema] = await withDbTimeout(
+    db.select().from(cinemas).where(eq(cinemas.id, cinemaId)),
+    15_000,
+    `generateScrapeDiff: cinema lookup (${cinemaId})`,
+  );
 
   const cinemaName = cinema?.name ?? cinemaId;
 
   // Get existing screenings for this cinema (next 30 days)
-  const existingScreenings = await db
-    .select({
-      id: screenings.id,
-      datetime: screenings.datetime,
-      filmTitle: films.title,
-      scrapedAt: screenings.scrapedAt,
-    })
-    .from(screenings)
-    .innerJoin(films, eq(screenings.filmId, films.id))
-    .where(
-      and(
-        eq(screenings.cinemaId, cinemaId),
-        gte(screenings.datetime, now),
-        lte(screenings.datetime, futureLimit)
-      )
-    );
+  const existingScreenings = await withDbTimeout(
+    db
+      .select({
+        id: screenings.id,
+        datetime: screenings.datetime,
+        filmTitle: films.title,
+        scrapedAt: screenings.scrapedAt,
+      })
+      .from(screenings)
+      .innerJoin(films, eq(screenings.filmId, films.id))
+      .where(
+        and(
+          eq(screenings.cinemaId, cinemaId),
+          gte(screenings.datetime, now),
+          lte(screenings.datetime, futureLimit),
+        ),
+      ),
+    15_000,
+    `generateScrapeDiff: existing screenings (${cinemaId})`,
+  );
 
   // Create lookup key for screenings (title + datetime)
   const makeKey = (title: string, datetime: Date) =>


### PR DESCRIPTION
## Summary

- Adds `withDbTimeout` Promise.race wrapper at all hot-path DB calls in the scraper pipeline so a wedged Supabase pooler connection no longer hangs forever.
- Adds `DB_POOL_MAX` env var so local runs can use `max: 3` (keeps Vercel serverless on `max: 1`) — prevents one wedged conn from cascading into a 30-min outage for the rest of the run.

## What happened

Local `/scrape` hung at 32 cinemas in. Process at 0% CPU, sleeping for 87+ minutes after `[Pipeline] 58 valid screenings to process` with no errors. PR #479's timeouts didn't fire because:

| Timeout | Why it didn't help |
|---|---|
| `statement_timeout: 60s` | Server-side. The server never received the query — Supabase pooler silently dropped the TCP socket between query bursts. |
| `idle_timeout: 20s` | Only kills *idle* connections, not borrowed ones. |
| `connect_timeout: 15s` | Only governs initial handshake. |
| `max_lifetime: 30min` | Only rotates *released* connections. |

The client's `recv()` blocked forever waiting for a response the server never sees. macOS default TCP keepalive is 7200s — useless.

## Fix

### Part 1 — Query ceiling

New `withDbTimeout(p, ms = 10_000, label)` helper in `src/db/index.ts`. Applied at every hot-path DB call in `runScraperPipeline`:

| Site | Ceiling |
|---|---|
| `generateScrapeDiff` cinema lookup | 15s |
| `generateScrapeDiff` existing screenings | 15s |
| `initFilmCache` films table load | 15s |
| `getOrCreateFilm` (per-film) | 20s |
| `linkFilmToMatchingSeasons` (per-film) | 10s |
| `insertScreening` (per-screening) | 15s |

On timeout: throws → caught by the per-cinema (or per-film) try/catch → cinema/film skipped, run continues. Same posture as the existing `57014` (query_canceled) catch path.

### Part 2 — No cascading failure

Pool `max` now configurable via `DB_POOL_MAX` env var. Default `1` (Vercel-safe). Bump to `3` in `.env.local` so a wedged conn doesn't block healthy slots.

## Code review

Reviewed by the code-reviewer agent before commit. Addressed coverage gaps (per-film loop calls were unwrapped — would have hit the next hang) and cascading-failure mode (single `max:1` slot caused 30-min downtime per wedge). Tightened thresholds from initial 30s to 10–20s based on reviewer feedback (p99 is sub-1s).

Deferred follow-up: client-recreate on timeout (`client.end()` + new client) — requires re-architecting the `db = drizzle(...)` const export which is referenced widely. Acceptable to defer because `DB_POOL_MAX=3` provides the required mitigation.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 errors, 41 pre-existing warnings unchanged)
- [x] `npm run test:run` — 890/890 pass
- [ ] After merge: re-run `/scrape` end-to-end and confirm completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)