### PR TITLE
feat(scrape): observability + concurrency fixes (Ship 1 of plan)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ logs/
 
 # Data exports
 *.xlsx
+
+# /scrape progress stamp + scratch
+/tmp/

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,17 @@
+## 2026-05-07: /scrape observability + concurrency fixes (Ship 1 of plan)
+**PR**: TBD | **Files**: `src/lib/scrape-progress.ts` (new), `src/scrapers/pipeline.ts`, `src/scrapers/runner-factory.ts`, `src/scrapers/utils/film-matching.ts`, `src/lib/jobs/scrape-all.ts`, `src/scripts/run-scrape-and-enrich.ts`, `.gitignore`
+- After today's 87-minute silent hang, six specialised agents audited `/scrape` end-to-end. Plan at `~/.claude/plans/before-we-do-this-silly-deer.md`. Ship 1 lands the cheapest, highest-leverage findings: observability (so the next hang is visible in seconds, not 87 minutes) and two concurrency hazards we'd been getting away with.
+- **New `src/lib/scrape-progress.ts`** — atomic `tmp/scrape-progress.json` stamper (`tail -f | jq` to watch live state) plus a `runPhase(cinemaId, name, fn, meta)` helper that adds `[Pipeline] <cinema> > <phase> start/done <ms>ms` logs around any async phase. `tmp/` added to `.gitignore`.
+- **Pipeline phases instrumented** in `src/scrapers/pipeline.ts:processScreenings` — `diff`, `init-film-cache`, `extract-titles`, `film-loop`, `cleanup-superseded` are each wrapped with `runPhase`. The exact silent gap that produced today's 87-min hang now emits start/done lines + duration + progress stamps.
+- **Per-cinema visibility in `runScraperEntry`** (`src/lib/jobs/scrape-all.ts`) — `[scrape-all] {wave}: {cinema} started`/`done {ms}ms ok|fail (added X, updated Y)` lines fire for every wave entry, with progress stamps too.
+- **Pre-flight Phase 0** in `src/scripts/run-scrape-and-enrich.ts` — `detectSilentBreakers` runs at the START of `/scrape` so the user sees "N cinemas silently broken — consider /scrape-one first" before sitting through a 30–60 min full run.
+- **Concurrency fix #1: per-call film cache** (`src/scrapers/utils/film-matching.ts`) — module-level `filmCache`/`tmdbIdIndex`/`cacheStats`/`normalizeFn` singletons replaced with a `FilmCache` interface threaded through `initFilmCache` / `lookupFilmInCache` / `addToFilmCache` / `matchAndCreateFromTMDB` / `createFilmWithoutTMDB` / `logCacheStats`. Real bug: `runWave` runs cinemas concurrently (cap 4) and the previous shape reset module state per cinema, so cinema B's reset could wipe cinema A's mid-run cache → A re-creates films via `createFilmWithoutTMDB` → duplicate film rows for the dedup script to merge.
+- **Concurrency fix #2: per-`runScraper` pendingRecords via AsyncLocalStorage** (`src/scrapers/runner-factory.ts`) — module-level `pendingRecords: Promise<void>[]` was shared across all 26 scraper invocations in a process. `flushPendingRecords` doing `splice(0)` could swallow another concurrent `runScraper`'s pending writes mid-flush. Replaced with `AsyncLocalStorage<Promise<void>[]>` per-call context; `runScraper` wraps its body in `try/finally` so flush is guaranteed even on throw.
+- Reviewed by code-reviewer agent before commit; addressed the one blocker (no-op flush in `createMain`'s old failure path) by moving flush into the `runScraper` wrapper's `finally` and deleting the redundant outer call.
+- Tests 890/890. tsc + lint clean.
+
+---
+
 ## 2026-05-07: Client-side DB query timeout + pool-max env override — fix the /scrape hang #479 didn't catch
 **PR**: TBD | **Files**: `src/db/index.ts`, `src/scrapers/pipeline.ts`, `src/scrapers/utils/scrape-diff.ts`, `src/scrapers/utils/film-matching.ts`
 - Local `/scrape` hung again at 32 cinemas in. Process at 0.0% CPU, sleeping for 87+ minutes after `[Pipeline] 58 valid screenings to process` with no errors logged.

--- a/changelogs/2026-05-07-scrape-observability-and-cache-fix.md
+++ b/changelogs/2026-05-07-scrape-observability-and-cache-fix.md
@@ -1,0 +1,118 @@
+# /scrape observability + concurrency fixes (Ship 1)
+
+**PR**: TBD
+**Date**: 2026-05-07
+**Branch**: `feat/scrape-observability-and-cache-fix`
+
+## Why
+
+Earlier today `/scrape` hung at 32 cinemas in. Process at 0% CPU, sleeping for 87 minutes after `[Pipeline] 58 valid screenings to process` with no errors logged. Three PRs already shipped today (#479 server-side timeouts, #480 stalest-first ordering, #481 client-side `withDbTimeout` + `DB_POOL_MAX`). Before re-running, six specialised agents audited the pipeline end-to-end (Database Optimizer, Backend Architect, SRE, Performance Benchmarker, code-explorer, Code Reviewer).
+
+Their headline findings:
+
+1. **We had no visibility** into the silent gap between `[Pipeline] X valid screenings to process` and the next log line. That's where the 87 minutes lived.
+2. **Two concurrency hazards** we'd been silently getting away with — `filmCache` and `pendingRecords` were both module-level singletons in code paths that run cinemas concurrently (cap 4 per wave).
+3. Performance findings looked compelling but **none had been measured** — three different agents nominated three different bottlenecks. Recommendation: instrument first, optimise from evidence.
+
+This PR (Ship 1 of the plan at `~/.claude/plans/before-we-do-this-silly-deer.md`) lands the highest-leverage findings: observability + the two concurrency fixes. Performance work is deferred to Ship 2 and will be informed by the new instrumentation.
+
+## What changed
+
+### New file: `src/lib/scrape-progress.ts`
+
+- `stampProgress(input)` — atomically writes `tmp/scrape-progress.json` (write-temp + rename, last-writer-wins for concurrent waves). Failures are warned and swallowed so a broken progress stamp can never fail the scrape itself.
+- `readProgress()` — read the latest snapshot.
+- `runPhase(cinemaId, name, fn, meta)` — wraps an async phase with start/done console logs, duration measurement, and progress stamps at start/done/error boundaries. Re-throws to preserve existing try/catch semantics.
+- Output path overridable via `SCRAPE_PROGRESS_FILE` env var.
+
+### `src/scrapers/pipeline.ts`
+
+- Phases now wrapped with `runPhase`: `diff`, `init-film-cache`, `extract-titles`, `film-loop`, `cleanup-superseded`. The exact silent gap that produced today's 87-min hang now emits `[Pipeline] <cinema> > <phase> start` and `[Pipeline] <cinema> > <phase> done <ms>ms` lines.
+- `processScreenings` start beacon: `stampProgress({ phase: "pipeline-start", meta: { rawCount } })` so the progress file shows the cinema entering the pipeline before any phase starts.
+
+### `src/scrapers/utils/film-matching.ts` — concurrency fix #1
+
+Was: module-level `filmCache`, `tmdbIdIndex`, `cacheStats`, `normalizeFn` singletons. Per-cinema `initFilmCache` reset them all. Cinema B's reset could wipe cinema A's mid-run cache → A re-creates films via `createFilmWithoutTMDB` → duplicate film rows for the dedup script to merge later.
+
+Now: a `FilmCache` interface owned by each `runScraperPipeline` invocation:
+
+```ts
+export interface FilmCache {
+  byTitle: Map<string, FilmRecord>;
+  byTmdbId: Map<number, FilmRecord>;
+  stats: { hits: number; misses: number; dbQueries: number };
+  normalizeTitle: (title: string) => string;
+}
+```
+
+All cache-touching functions now take `cache: FilmCache` as their first arg: `initFilmCache`, `lookupFilmInCache`, `addToFilmCache`, `matchAndCreateFromTMDB`, `createFilmWithoutTMDB`, `logCacheStats`. `findFilmBySimilarity` and `tryUpdatePoster` are unchanged (they don't touch cache state).
+
+The TMDB-id lookup inside `matchAndCreateFromTMDB` is also wrapped with `withDbTimeout(p, 10_000)` for consistency with the rest of the pipeline.
+
+### `src/scrapers/runner-factory.ts` — concurrency fix #2
+
+Was: module-level `pendingRecords: Promise<void>[]` shared across every concurrent `runScraper` call in the process. `flushPendingRecords` did `splice(0)` to drain — racing flushes could swallow each other's pending writes.
+
+Now: `AsyncLocalStorage<Promise<void>[]>` per-call context.
+
+```ts
+export async function runScraper(...) {
+  return pendingRecordsContext.run([], async () => {
+    try {
+      return await runScraperInner(config, userOptions);
+    } finally {
+      await flushPendingRecords();
+    }
+  });
+}
+```
+
+The try/finally guarantees flush runs whether the inner body returns or throws — closes a pre-existing leak where a throw before the original line-712 flush would lose pending records.
+
+`pushPendingRecord` (the new fire-and-forget helper that replaces every `pendingRecords.push(...)` call site) emits a `console.warn` and detaches the promise's rejection chain if it ever runs outside a `runScraper` context — invariant violations are observable, not silent.
+
+Removed: the now-redundant `await flushPendingRecords()` call in `createMain`'s failure path. With AsyncLocalStorage scoping it would be a no-op (no active store) — the inner `finally` already covered the failure case.
+
+### `src/lib/jobs/scrape-all.ts` — per-cinema started/done logs
+
+`runScraperEntry(entry, waveLabel)` now emits `[scrape-all] {wave}: {cinema} started` and `[scrape-all] {wave}: {cinema} done {ms}ms ok|fail (added X, updated Y)` for every wave entry, plus matching `stampProgress` calls. Wave-order log lines from #480 are unchanged.
+
+### `src/scripts/run-scrape-and-enrich.ts` — Phase 0 pre-flight
+
+A new pre-flight `detectSilentBreakers` runs at the START of `/scrape`. If any cinemas are silently broken (≥2 consecutive `success && screening_count=0` runs) the report prints with a suggestion to investigate via `/scrape-one <slug>` before sitting through a 30–60 min full run. Read-only, ~1s.
+
+### `.gitignore`
+
+Added `/tmp/` so the progress stamp doesn't leak into commits.
+
+## What this enables for the next /scrape
+
+If the run hangs again — `tail -f tmp/scrape-progress.json | jq` shows exactly which cinema, which phase, when it started, and the time since last heartbeat. Diagnosis takes seconds, not 87 minutes.
+
+If a phase exceeds an unusual duration — the `[Pipeline] X > phase done Yms` lines stream live; we can spot a 60-second `init-film-cache` instead of an 87-minute mystery.
+
+If cinemas are silently broken — Phase 0 surfaces them before we wait 30+ minutes. Same `detectSilentBreakers` function; called twice (start + end).
+
+## Recovery posture (unchanged behaviour)
+
+- A `runPhase` failure re-throws — the surrounding per-cinema/per-film try/catch in `runScraper` and `runScraperPipeline` still handles it. Same posture as before.
+- A `stampProgress` failure logs a warning but never fails the scrape.
+- `runScraper`'s wrapper finally guarantees `flushPendingRecords` runs on success and on throw, with a 5s ceiling.
+
+## What is intentionally NOT in this PR (deferred to later Ships)
+
+- **Performance**: missing `(cinema_id, source_id, datetime)` partial index, hoisting `initFilmCache` to session-scope, hoisting Layer 0 lookup out of the per-screening loop, parallelising the per-screening loop. Deferred until we have measurements from this PR's `runPhase` durations.
+- **Resilience**: client-recreate on `withDbTimeout` rejection, retry shape (1 retry for Playwright, 3 for Cheerio), decoupling Letterboxd failure from whole-phase ok signal, blocking on `LARGE_DROP`, resumability checkpoint.
+- **Diff-key normalisation mismatch** (Code Reviewer Tier 1 #3) — important but orthogonal; separate PR.
+
+## Constraint reminder
+
+Everything in this PR runs **locally on the Mac via `/scrape`**. No Inngest, Trigger.dev, Vercel cron, GitHub Actions schedules. `tmp/scrape-progress.json` is a local file. `detectSilentBreakers` is a local DB read. See `~/.claude/projects/-Users-jamesbarge-code-filmcal2/memory/feedback_local_only_no_off_mac.md`.
+
+## Verification
+
+- 890/890 tests pass.
+- `npx tsc --noEmit` clean.
+- `npm run lint` clean (0 errors, 41 pre-existing warnings unchanged).
+- Reviewed by code-reviewer agent; one blocker addressed (`flushPendingRecords` no-op in `createMain` failure path → moved into `runScraper` wrapper's `finally`).
+- Pending: end-to-end `/scrape` run with the new instrumentation. The progress file will be the canonical post-run artefact for verifying the fix worked.

--- a/src/lib/jobs/scrape-all.ts
+++ b/src/lib/jobs/scrape-all.ts
@@ -22,6 +22,7 @@ import { db } from "@/db";
 import { scraperRuns } from "@/db/schema/admin";
 import { cinemas } from "@/db/schema/cinemas";
 import { sendTelegramAlert } from "@/lib/telegram";
+import { stampProgress } from "@/lib/scrape-progress";
 import { runScraper } from "@/scrapers/runner-factory";
 import {
   SCRAPER_REGISTRY,
@@ -120,14 +121,52 @@ async function runWithConcurrency<T>(
 /** Run a single scraper-registry entry and return wave-summary contribution. */
 async function runScraperEntry(
   entry: ScraperRegistryEntry,
+  waveLabel: string,
 ): Promise<{ succeeded: boolean; error?: string }> {
+  const taskId = entry.taskId.replace(/^scraper-/, "");
+  const startedAt = new Date();
+  const startedAtIso = startedAt.toISOString();
+  console.log(`[scrape-all] ${waveLabel}: ${taskId} started`);
+  await stampProgress({
+    wave: waveLabel,
+    cinemaId: taskId,
+    phase: "scraper-entry-start",
+    startedAt: startedAtIso,
+  });
   try {
     const config = entry.buildConfig();
     const result = await runScraper(config, { useValidation: true });
+    const ms = Date.now() - startedAt.getTime();
+    console.log(
+      `[scrape-all] ${waveLabel}: ${taskId} done ${ms}ms ${
+        result.success ? "ok" : "fail"
+      } (added ${result.totalScreeningsAdded}, updated ${result.totalScreeningsUpdated})`,
+    );
+    await stampProgress({
+      wave: waveLabel,
+      cinemaId: taskId,
+      phase: "scraper-entry-done",
+      startedAt: startedAtIso,
+      durationMs: ms,
+      meta: {
+        ok: result.success,
+        added: result.totalScreeningsAdded,
+        updated: result.totalScreeningsUpdated,
+      },
+    });
     return { succeeded: result.success };
   } catch (err) {
+    const ms = Date.now() - startedAt.getTime();
     const message = err instanceof Error ? err.message : String(err);
-    console.log(`[scrape-all] ${entry.taskId} threw: ${message}`);
+    console.log(`[scrape-all] ${waveLabel}: ${taskId} threw after ${ms}ms: ${message}`);
+    await stampProgress({
+      wave: waveLabel,
+      cinemaId: taskId,
+      phase: "scraper-entry-error",
+      startedAt: startedAtIso,
+      durationMs: ms,
+      error: message,
+    });
     return { succeeded: false, error: message };
   }
 }
@@ -200,7 +239,7 @@ async function runWave(
     console.log(`[scrape-all] ${label} order (stalest first): ${orderStr}`);
   }
   const entries = ranked.map((r) => r.entry);
-  const tasks = entries.map((entry) => () => runScraperEntry(entry));
+  const tasks = entries.map((entry) => () => runScraperEntry(entry, label));
   const settled = await runWithConcurrency(tasks, concurrency);
 
   let succeeded = 0;

--- a/src/lib/scrape-progress.ts
+++ b/src/lib/scrape-progress.ts
@@ -1,0 +1,110 @@
+/**
+ * Live progress snapshot for /scrape — written atomically to a local JSON
+ * file so we can answer "what's running RIGHT NOW" without grepping stdout.
+ *
+ * Writes to `<cwd>/tmp/scrape-progress.json` by default. The path is local
+ * to the Mac running /scrape — no network, no DB, no external service. See
+ * the local-only-no-off-mac auto-memory rule.
+ *
+ * Usage:
+ *   import { stampProgress } from "@/lib/scrape-progress";
+ *   await stampProgress({ wave: "Chains", cinemaId: "curzon-soho", phase: "diff" });
+ *
+ *   // From a separate terminal:
+ *   tail -f tmp/scrape-progress.json | jq
+ */
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface ProgressSnapshot {
+  /** Wave currently in flight: "Chains" | "Playwright" | "Cheerio" | "Vision" | "Phase 0" | "Phase 2" | "Phase 3" | "Phase 4" */
+  wave?: string;
+  /** Cinema id being processed when the stamp was written */
+  cinemaId?: string;
+  /** Free-text phase label, e.g. "diff", "init-film-cache", "extract-titles", "film-loop", "cleanup", "scrape-fetch" */
+  phase: string;
+  /** ISO timestamp when this phase began */
+  startedAt: string;
+  /** ISO timestamp of this stamp (always now) */
+  lastHeartbeatAt: string;
+  /** Optional duration in ms — set on phase completion stamps */
+  durationMs?: number;
+  /** Optional error message — set on phase failure stamps */
+  error?: string;
+  /** Free-form fields the caller wants to attach (counts, ids, etc.) */
+  meta?: Record<string, unknown>;
+}
+
+const DEFAULT_PATH = join(process.cwd(), "tmp", "scrape-progress.json");
+const PROGRESS_PATH = process.env.SCRAPE_PROGRESS_FILE ?? DEFAULT_PATH;
+
+let ensuredDir = false;
+
+async function ensureDir(): Promise<void> {
+  if (ensuredDir) return;
+  await fs.mkdir(dirname(PROGRESS_PATH), { recursive: true });
+  ensuredDir = true;
+}
+
+/**
+ * Atomically write the snapshot to `tmp/scrape-progress.json`. Failures are
+ * logged once and otherwise swallowed — a broken progress stamp must never
+ * fail the scrape itself.
+ */
+export async function stampProgress(input: Omit<ProgressSnapshot, "lastHeartbeatAt"> & { lastHeartbeatAt?: string }): Promise<void> {
+  const now = new Date().toISOString();
+  const snapshot: ProgressSnapshot = {
+    lastHeartbeatAt: now,
+    ...input,
+  };
+  try {
+    await ensureDir();
+    const tmp = `${PROGRESS_PATH}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(snapshot, null, 2) + "\n");
+    await fs.rename(tmp, PROGRESS_PATH);
+  } catch (err) {
+    // Surface once at warn level; don't spam.
+    console.warn(`[scrape-progress] write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Read the most recent snapshot, or null if no run has stamped yet. */
+export async function readProgress(): Promise<ProgressSnapshot | null> {
+  try {
+    const raw = await fs.readFile(PROGRESS_PATH, "utf8");
+    return JSON.parse(raw) as ProgressSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wrap an async phase with start/done logs, a duration measurement, and a
+ * progress-file stamp at every boundary. Errors are re-thrown so existing
+ * try/catch behavior is preserved.
+ */
+export async function runPhase<T>(
+  cinemaId: string | undefined,
+  phase: string,
+  fn: () => Promise<T>,
+  meta?: Record<string, unknown>,
+): Promise<T> {
+  const startedAt = new Date().toISOString();
+  const t0 = Date.now();
+  const tag = cinemaId ? `${cinemaId} > ${phase}` : phase;
+  console.log(`[Pipeline] ${tag} start`);
+  await stampProgress({ cinemaId, phase, startedAt, meta });
+  try {
+    const result = await fn();
+    const durationMs = Date.now() - t0;
+    console.log(`[Pipeline] ${tag} done ${durationMs}ms`);
+    await stampProgress({ cinemaId, phase: `${phase}:done`, startedAt, durationMs, meta });
+    return result;
+  } catch (err) {
+    const durationMs = Date.now() - t0;
+    const error = err instanceof Error ? err.message : String(err);
+    console.error(`[Pipeline] ${tag} threw after ${durationMs}ms: ${error}`);
+    await stampProgress({ cinemaId, phase: `${phase}:error`, startedAt, durationMs, error, meta });
+    throw err;
+  }
+}

--- a/src/scrapers/pipeline.ts
+++ b/src/scrapers/pipeline.ts
@@ -13,6 +13,8 @@ import { validateScreenings, printValidationSummary } from "./utils/screening-va
 import { generateScrapeDiff, printDiffReport, shouldBlockScrape } from "./utils/scrape-diff";
 import { linkFilmToMatchingSeasons } from "./seasons/season-linker";
 
+import { runPhase, stampProgress } from "@/lib/scrape-progress";
+
 // Extracted utility modules
 import {
   initFilmCache,
@@ -22,6 +24,7 @@ import {
   matchAndCreateFromTMDB,
   createFilmWithoutTMDB,
   tryUpdatePoster,
+  type FilmCache,
 } from "./utils/film-matching";
 import {
   classifyScreening,
@@ -134,6 +137,7 @@ export async function processScreenings(
   rawScreenings: RawScreening[]
 ): Promise<PipelineResult> {
   console.log(`[Pipeline] Processing ${rawScreenings.length} screenings for ${cinemaId}`);
+  await stampProgress({ cinemaId, phase: "pipeline-start", startedAt: new Date().toISOString(), meta: { rawCount: rawScreenings.length } });
 
   // Validate screenings before processing - reject invalid data early
   const { validScreenings, rejectedScreenings, summary } = validateScreenings(rawScreenings);
@@ -147,8 +151,13 @@ export async function processScreenings(
   const screeningsToProcess = validScreenings;
   console.log(`[Pipeline] ${screeningsToProcess.length} valid screenings to process`);
 
-  // Generate diff report to detect suspicious patterns
-  const diffReport = await generateScrapeDiff(cinemaId, screeningsToProcess);
+  // Generate diff report to detect suspicious patterns.
+  // Wrapped in runPhase: between this and initFilmCache below was the
+  // dead zone where /scrape silently hung for 87 minutes on 2026-05-07.
+  // We now log start/done + duration and stamp tmp/scrape-progress.json.
+  const diffReport = await runPhase(cinemaId, "diff", () =>
+    generateScrapeDiff(cinemaId, screeningsToProcess),
+  );
   if (diffReport.hasIssues) {
     printDiffReport(diffReport);
 
@@ -167,8 +176,11 @@ export async function processScreenings(
     }
   }
 
-  // Initialize film cache for O(1) lookups
-  await initFilmCache(normalizeTitle);
+  // Initialize per-cinema-run film cache for O(1) lookups.
+  // Per-call cache (not module-level) — see FilmCache JSDoc in film-matching.ts.
+  const filmCache = await runPhase(cinemaId, "init-film-cache", () =>
+    initFilmCache(normalizeTitle),
+  );
 
   const result: PipelineResult = {
     cinemaId,
@@ -180,12 +192,14 @@ export async function processScreenings(
     scrapedAt: new Date(),
   };
 
-  // Extract film titles using AI for event-style names
+  // Extract film titles for event-style names
   // This ensures "Saturday Morning Picture Club: The Muppets Christmas Carol" and
   // "The Muppets Christmas Carol" get grouped together
   const uniqueRawTitles = [...new Set(screeningsToProcess.map((s) => s.filmTitle))];
   console.log(`[Pipeline] Extracting titles from ${uniqueRawTitles.length} unique raw titles`);
-  const titleExtractions = await batchExtractTitles(uniqueRawTitles);
+  const titleExtractions = await runPhase(cinemaId, "extract-titles", () =>
+    batchExtractTitles(uniqueRawTitles),
+  );
 
   // Group screenings by canonical title for deduplication
   // This ensures "Apocalypse Now" and "Apocalypse Now : Final Cut" are grouped together
@@ -205,7 +219,7 @@ export async function processScreenings(
     screeningsByFilm.get(key)!.push(screening);
   }
 
-  console.log(`[Pipeline] ${screeningsByFilm.size} unique films after AI extraction`);
+  console.log(`[Pipeline] ${screeningsByFilm.size} unique films after extraction`);
 
   // Process each film
   // The two awaited boundaries — getOrCreateFilm and insertScreening — are
@@ -214,66 +228,76 @@ export async function processScreenings(
   // after the ceiling and the surrounding try/catch logs and skips. Same
   // recovery posture as a Postgres 57014 — one film loses, the rest of the
   // cinema (and the rest of the run) continues.
-  for (const [normalizedTitle, filmScreenings] of screeningsByFilm) {
-    try {
-      // Get the first screening for film metadata (use any scraper-provided data)
-      const firstScreening = filmScreenings[0];
+  await runPhase(
+    cinemaId,
+    "film-loop",
+    async () => {
+      for (const [normalizedTitle, filmScreenings] of screeningsByFilm) {
+        try {
+          // Get the first screening for film metadata (use any scraper-provided data)
+          const firstScreening = filmScreenings[0];
 
-      // Get or create film record, passing any scraper-extracted metadata.
-      // 20s ceiling: covers internal DB selects + a TMDB API call.
-      const filmId = await withDbTimeout(
-        getOrCreateFilm(
-          firstScreening.filmTitle,
-          firstScreening.year,
-          firstScreening.director,
-          firstScreening.posterUrl
-        ),
-        20_000,
-        `getOrCreateFilm: ${firstScreening.filmTitle}`,
-      );
+          // Get or create film record, passing any scraper-extracted metadata.
+          // 20s ceiling: covers internal DB selects + a TMDB API call.
+          const filmId = await withDbTimeout(
+            getOrCreateFilm(
+              filmCache,
+              firstScreening.filmTitle,
+              firstScreening.year,
+              firstScreening.director,
+              firstScreening.posterUrl
+            ),
+            20_000,
+            `getOrCreateFilm: ${firstScreening.filmTitle}`,
+          );
 
-      if (!filmId) {
-        console.warn(`[Pipeline] Could not create film: ${firstScreening.filmTitle}`);
-        result.failed += filmScreenings.length;
-        continue;
-      }
+          if (!filmId) {
+            console.warn(`[Pipeline] Could not create film: ${firstScreening.filmTitle}`);
+            result.failed += filmScreenings.length;
+            continue;
+          }
 
-      // Link film to any matching seasons
-      // This ensures films are associated with seasons as soon as they're scraped
-      await withDbTimeout(
-        linkFilmToMatchingSeasons(filmId, firstScreening.filmTitle),
-        10_000,
-        `linkFilmToMatchingSeasons: ${firstScreening.filmTitle}`,
-      );
+          // Link film to any matching seasons
+          // This ensures films are associated with seasons as soon as they're scraped
+          await withDbTimeout(
+            linkFilmToMatchingSeasons(filmId, firstScreening.filmTitle),
+            10_000,
+            `linkFilmToMatchingSeasons: ${firstScreening.filmTitle}`,
+          );
 
-      // Insert screenings (normalize timestamps to zero seconds/ms).
-      // 15s ceiling per screening: covers checkForDuplicate + insert/update.
-      for (const screening of filmScreenings) {
-        const normalizedScreening = { ...screening, datetime: normalizeTimestamp(screening.datetime) };
-        const added = await withDbTimeout(
-          insertScreening(filmId, cinemaId, normalizedScreening),
-          15_000,
-          `insertScreening: ${cinemaId}/${normalizedScreening.sourceId ?? "<nosrc>"}`,
-        );
-        if (added) {
-          result.added++;
-        } else {
-          result.updated++;
+          // Insert screenings (normalize timestamps to zero seconds/ms).
+          // 15s ceiling per screening: covers checkForDuplicate + insert/update.
+          for (const screening of filmScreenings) {
+            const normalizedScreening = { ...screening, datetime: normalizeTimestamp(screening.datetime) };
+            const added = await withDbTimeout(
+              insertScreening(filmId, cinemaId, normalizedScreening),
+              15_000,
+              `insertScreening: ${cinemaId}/${normalizedScreening.sourceId ?? "<nosrc>"}`,
+            );
+            if (added) {
+              result.added++;
+            } else {
+              result.updated++;
+            }
+          }
+        } catch (error) {
+          console.error(`[Pipeline] Error processing film "${normalizedTitle}":`, error);
+          result.failed += filmScreenings.length;
         }
       }
-    } catch (error) {
-      console.error(`[Pipeline] Error processing film "${normalizedTitle}":`, error);
-      result.failed += filmScreenings.length;
-    }
-  }
+    },
+    { uniqueFilms: screeningsByFilm.size },
+  );
 
   // Clean up superseded same-day screenings (time-shift orphans)
   // Only runs when the scrape wasn't blocked and produced results
   if (!result.blocked && result.added + result.updated > 0) {
-    const cleaned = await cleanupSupersededScreenings(cinemaId, result.scrapedAt);
-    if (cleaned > 0) {
-      console.log(`[Pipeline] Cleaned ${cleaned} superseded same-day screenings`);
-    }
+    await runPhase(cinemaId, "cleanup-superseded", async () => {
+      const cleaned = await cleanupSupersededScreenings(cinemaId, result.scrapedAt);
+      if (cleaned > 0) {
+        console.log(`[Pipeline] Cleaned ${cleaned} superseded same-day screenings`);
+      }
+    });
   }
 
   // Update cinema's lastScrapedAt
@@ -287,7 +311,7 @@ export async function processScreenings(
   );
 
   // Log cache performance stats
-  logCacheStats();
+  logCacheStats(filmCache);
 
   // Run agent-based analysis if enabled
   if (AGENTS_ENABLED && result.added > 0) {
@@ -371,6 +395,7 @@ async function runPostScrapeAgents(
  * Uses AI-powered title extraction for event-style titles
  */
 async function getOrCreateFilm(
+  filmCache: FilmCache,
   title: string,
   scraperYear?: number,
   scraperDirector?: string,
@@ -406,7 +431,7 @@ async function getOrCreateFilm(
   const normalized = normalizeTitle(matchingTitle);
 
   // Try to find existing film using the pre-loaded cache (O(1) lookup)
-  const existing = lookupFilmInCache(normalized);
+  const existing = lookupFilmInCache(filmCache, normalized);
 
   if (existing) {
     // If existing film lacks a poster, try to find one
@@ -425,6 +450,7 @@ async function getOrCreateFilm(
   // Try to match with TMDB
   try {
     const tmdbFilmId = await matchAndCreateFromTMDB(
+      filmCache,
       matchingTitle,
       scraperYear,
       scraperDirector,
@@ -438,7 +464,7 @@ async function getOrCreateFilm(
   }
 
   // Fallback: Create film without TMDB data
-  return createFilmWithoutTMDB(matchingTitle, scraperYear, scraperDirector, scraperPosterUrl);
+  return createFilmWithoutTMDB(filmCache, matchingTitle, scraperYear, scraperDirector, scraperPosterUrl);
 }
 
 /**

--- a/src/scrapers/runner-factory.ts
+++ b/src/scrapers/runner-factory.ts
@@ -8,6 +8,7 @@
  * - Consistent health checks and pipeline processing
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { CinemaScraper, ChainScraper, RawScreening } from "./types";
 import { processScreenings, saveScreenings, ensureCinemaExists } from "./pipeline";
 import { db, isDatabaseAvailable } from "../db";
@@ -133,19 +134,43 @@ function log(entry: Omit<LogEntry, "timestamp">): void {
 }
 
 // ============================================================================
-// Run Recording (fire-and-forget with flush)
+// Run Recording (fire-and-forget with per-call flush)
 // ============================================================================
 
-/** Pending record promises — collected so we can flush before process exit */
-const pendingRecords: Promise<void>[] = [];
-
 /**
- * Await all pending recordScraperRun writes (with a 5s timeout).
- * Call before process.exit to prevent data loss.
+ * Per-`runScraper`-call array of pending `recordScraperRun` promises.
+ *
+ * Was previously a module-level array shared across every concurrent
+ * `runScraper` call in the process. With waves running 4 scrapers in
+ * parallel and `flushPendingRecords` doing `splice(0)` to drain, two
+ * flushes overlapping could swallow each other's pending writes. Each
+ * `runScraper` invocation now enters its own `AsyncLocalStorage` context
+ * with its own array — fire-and-forget pushes go to the active call's
+ * list, the flush at the end of `runScraper` drains exactly that list.
  */
+const pendingRecordsContext = new AsyncLocalStorage<Promise<void>[]>();
+
+/** Push a fire-and-forget recordScraperRun into the current `runScraper` context. */
+function pushPendingRecord(promise: Promise<void>): void {
+  const list = pendingRecordsContext.getStore();
+  if (list) {
+    list.push(promise);
+    return;
+  }
+  // Caller is outside any runScraper context — invariant violation. Log it
+  // (so the next regression of the wiring is observable) and detach from the
+  // await chain so an unhandled rejection can't crash the process.
+  console.warn(
+    "[runner-factory] recordScraperRun pushed outside runScraper context — fire-and-forget without flush",
+  );
+  promise.catch(() => {});
+}
+
+/** Await all pending records in the current `runScraper` context (with 5s ceiling). */
 async function flushPendingRecords(): Promise<void> {
-  if (pendingRecords.length === 0) return;
-  const pending = pendingRecords.splice(0);
+  const list = pendingRecordsContext.getStore();
+  if (!list || list.length === 0) return;
+  const pending = list.splice(0);
   await Promise.race([
     Promise.allSettled(pending),
     new Promise((resolve) => setTimeout(resolve, 5000)),
@@ -324,7 +349,7 @@ async function runSingleVenue(
           event: "venue_blocked",
           data: { venueId: venue.id, screeningsFound: screenings.length, durationMs },
         });
-        pendingRecords.push(recordScraperRun({
+        pushPendingRecord(recordScraperRun({
           cinemaId: venue.id,
           startedAt: new Date(startTime),
           status: "failed",
@@ -363,7 +388,7 @@ async function runSingleVenue(
       });
 
       // Record successful scraper run (fire-and-forget)
-      pendingRecords.push(recordScraperRun({
+      pushPendingRecord(recordScraperRun({
         cinemaId: venue.id,
         startedAt: new Date(startTime),
         status: "success",
@@ -420,7 +445,7 @@ async function runSingleVenue(
   });
 
   // Record failed scraper run (fire-and-forget)
-  pendingRecords.push(recordScraperRun({
+  pushPendingRecord(recordScraperRun({
     cinemaId: venue.id,
     startedAt: new Date(startTime),
     status: "failed",
@@ -459,6 +484,23 @@ const DEFAULT_OPTIONS: Required<RunnerOptions> = {
  * Run a scraper configuration with unified error handling and logging
  */
 export async function runScraper(
+  config: ScraperRunnerConfig,
+  userOptions: RunnerOptions = {}
+): Promise<RunnerResult> {
+  // Per-call context for fire-and-forget recordScraperRun pushes — see
+  // pendingRecordsContext doc above. The try/finally guarantees the flush
+  // runs whether runScraperInner returns or throws, so pending records are
+  // always drained before the AsyncLocalStorage context unwinds.
+  return pendingRecordsContext.run([], async () => {
+    try {
+      return await runScraperInner(config, userOptions);
+    } finally {
+      await flushPendingRecords();
+    }
+  });
+}
+
+async function runScraperInner(
   config: ScraperRunnerConfig,
   userOptions: RunnerOptions = {}
 ): Promise<RunnerResult> {
@@ -579,7 +621,7 @@ export async function runScraper(
           }
 
           // Record chain per-venue scraper run (fire-and-forget)
-          pendingRecords.push(recordScraperRun({
+          pushPendingRecord(recordScraperRun({
             cinemaId: venueId,
             startedAt: new Date(venueStartTime),
             status: venueBlocked ? "failed" : "success",
@@ -612,7 +654,7 @@ export async function runScraper(
         // Mark all venues as failed
         for (const venue of venuesToScrape) {
           // Record chain failure per-venue (fire-and-forget)
-          pendingRecords.push(recordScraperRun({
+          pushPendingRecord(recordScraperRun({
             cinemaId: venue.id,
             startedAt: new Date(startTime),
             status: "failed",
@@ -675,9 +717,8 @@ export async function runScraper(
     },
   });
 
-  // Flush any pending record writes before returning
-  await flushPendingRecords();
-
+  // Note: flushPendingRecords runs in the runScraper wrapper's `finally`
+  // — guaranteed regardless of whether this function returns or throws.
   return result;
 }
 
@@ -772,7 +813,9 @@ export function createMain(
     const result = await runScraper(config, runnerOptions);
 
     if (!result.success) {
-      await flushPendingRecords();
+      // runScraper's wrapper finally already flushed pending records inside
+      // its AsyncLocalStorage context — calling flushPendingRecords here
+      // would be a no-op (no active store) so we just exit.
       process.exit(1);
     }
   };

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -23,28 +23,42 @@ type FilmRecord = typeof films.$inferSelect;
 // Film Cache
 // ============================================================================
 
-/** Film cache for efficient lookups during pipeline run (normalizedTitle -> film record) */
-let filmCache: Map<string, FilmRecord> | null = null;
-/** Secondary index: Maps tmdbId -> film record for dedup by TMDB ID */
-let tmdbIdIndex: Map<number, FilmRecord> | null = null;
-/** Track cache stats for logging */
-let cacheStats = { hits: 0, misses: 0, dbQueries: 0 };
-/** Stored normalizeTitle function reference (set during initFilmCache) */
-let normalizeFn: ((title: string) => string) | null = null;
+/**
+ * Per-pipeline-run film cache.
+ *
+ * Replaces module-level singletons (was a real concurrency hazard:
+ * `runWave` runs cinemas in parallel — cap 4 — and the pre-2026-05-07
+ * shape reset module-level cache state on every per-cinema call to
+ * `initFilmCache`, so cinema B's reset could wipe cinema A's mid-run
+ * cache and cause A to create duplicate film rows for entries it had
+ * already cached. Now each `processScreenings` invocation owns its own
+ * `FilmCache` object — no shared mutable state.)
+ */
+export interface FilmCache {
+  /** normalizedTitle -> film record */
+  byTitle: Map<string, FilmRecord>;
+  /** tmdbId -> film record, for dedup by TMDB ID */
+  byTmdbId: Map<number, FilmRecord>;
+  /** Stats for end-of-run logging */
+  stats: { hits: number; misses: number; dbQueries: number };
+  /** Stored normalizer so cache writes use the same one as the load */
+  normalizeTitle: (title: string) => string;
+}
 
 /**
- * Initialize film cache for O(1) lookups during pipeline run.
+ * Initialize a film cache for O(1) lookups during one pipeline run.
  * Loads all films once - with ~750 films this is fast and simple.
  */
 export async function initFilmCache(
-  normalizeTitle: (title: string) => string
-): Promise<Map<string, FilmRecord>> {
-  const cache = new Map<string, FilmRecord>();
-  const tmdbIndex = new Map<number, FilmRecord>();
-  cacheStats = { hits: 0, misses: 0, dbQueries: 0 };
-  normalizeFn = normalizeTitle;
+  normalizeTitle: (title: string) => string,
+): Promise<FilmCache> {
+  const cache: FilmCache = {
+    byTitle: new Map(),
+    byTmdbId: new Map(),
+    stats: { hits: 0, misses: 0, dbQueries: 1 },
+    normalizeTitle,
+  };
 
-  cacheStats.dbQueries++;
   const allFilms = await withDbTimeout(
     db.select().from(films),
     15_000,
@@ -54,48 +68,48 @@ export async function initFilmCache(
   for (const film of allFilms) {
     const normalized = normalizeTitle(film.title);
     // If duplicate normalized titles exist, keep the one with more data (has TMDB ID)
-    const existing = cache.get(normalized);
+    const existing = cache.byTitle.get(normalized);
     if (!existing || (film.tmdbId && !existing.tmdbId)) {
-      cache.set(normalized, film);
+      cache.byTitle.set(normalized, film);
     }
     // Build TMDB ID index — two films with same TMDB ID are always the same film
     if (film.tmdbId) {
-      tmdbIndex.set(film.tmdbId, film);
+      cache.byTmdbId.set(film.tmdbId, film);
     }
   }
 
-  tmdbIdIndex = tmdbIndex;
-  filmCache = cache;
-  console.log(`[Pipeline] Film cache initialized with ${cache.size} unique films, ${tmdbIndex.size} TMDB IDs (${allFilms.length} total)`);
+  console.log(
+    `[Pipeline] Film cache initialized with ${cache.byTitle.size} unique films, ${cache.byTmdbId.size} TMDB IDs (${allFilms.length} total)`,
+  );
   return cache;
 }
 
 /** Lookup a film in cache (O(1) access). Returns null on cache miss. */
-export function lookupFilmInCache(normalizedTitle: string): FilmRecord | null {
-  const cached = filmCache?.get(normalizedTitle);
+export function lookupFilmInCache(cache: FilmCache, normalizedTitle: string): FilmRecord | null {
+  const cached = cache.byTitle.get(normalizedTitle);
   if (cached) {
-    cacheStats.hits++;
+    cache.stats.hits++;
     return cached;
   }
-  cacheStats.misses++;
+  cache.stats.misses++;
   return null;
 }
 
 /** Log cache performance stats. */
-export function logCacheStats(): void {
-  const total = cacheStats.hits + cacheStats.misses;
-  const hitRate = total > 0 ? ((cacheStats.hits / total) * 100).toFixed(1) : "0";
-  console.log(`[Pipeline] Cache stats: ${cacheStats.hits} hits, ${cacheStats.misses} misses (${hitRate}% hit rate), ${cacheStats.dbQueries} DB queries`);
+export function logCacheStats(cache: FilmCache): void {
+  const total = cache.stats.hits + cache.stats.misses;
+  const hitRate = total > 0 ? ((cache.stats.hits / total) * 100).toFixed(1) : "0";
+  console.log(
+    `[Pipeline] Cache stats: ${cache.stats.hits} hits, ${cache.stats.misses} misses (${hitRate}% hit rate), ${cache.stats.dbQueries} DB queries`,
+  );
 }
 
 /** Add a new film to the cache. */
-function addToFilmCache(film: FilmRecord) {
-  if (filmCache && normalizeFn) {
-    const normalized = normalizeFn(film.title);
-    filmCache.set(normalized, film);
-  }
-  if (tmdbIdIndex && film.tmdbId) {
-    tmdbIdIndex.set(film.tmdbId, film);
+function addToFilmCache(cache: FilmCache, film: FilmRecord) {
+  const normalized = cache.normalizeTitle(film.title);
+  cache.byTitle.set(normalized, film);
+  if (film.tmdbId) {
+    cache.byTmdbId.set(film.tmdbId, film);
   }
 }
 
@@ -140,6 +154,7 @@ export async function findFilmBySimilarity(
  * Returns the new filmId or null if no TMDB match.
  */
 export async function matchAndCreateFromTMDB(
+  cache: FilmCache,
   matchingTitle: string,
   scraperYear?: number,
   scraperDirector?: string,
@@ -155,18 +170,18 @@ export async function matchAndCreateFromTMDB(
   }
 
   // Check if we already have this TMDB ID — cache first, then DB fallback
-  const cachedByTmdb = tmdbIdIndex?.get(match.tmdbId);
+  const cachedByTmdb = cache.byTmdbId.get(match.tmdbId);
   if (cachedByTmdb) {
-    cacheStats.hits++;
+    cache.stats.hits++;
     return cachedByTmdb.id;
   }
 
-  const byTmdbId = await db
-    .select()
-    .from(films)
-    .where(eq(films.tmdbId, match.tmdbId))
-    .limit(1);
-  cacheStats.dbQueries++;
+  const byTmdbId = await withDbTimeout(
+    db.select().from(films).where(eq(films.tmdbId, match.tmdbId)).limit(1),
+    10_000,
+    `matchAndCreateFromTMDB: tmdbId lookup ${match.tmdbId}`,
+  );
+  cache.stats.dbQueries++;
 
   if (byTmdbId.length > 0) {
     return byTmdbId[0].id;
@@ -221,7 +236,7 @@ export async function matchAndCreateFromTMDB(
   });
 
   // Add to cache so subsequent lookups in this run find it
-  addToFilmCache({
+  addToFilmCache(cache, {
     id: filmId,
     tmdbId: match.tmdbId,
     imdbId: details.details.imdb_id,
@@ -268,6 +283,7 @@ export async function matchAndCreateFromTMDB(
  * Returns the new filmId.
  */
 export async function createFilmWithoutTMDB(
+  cache: FilmCache,
   matchingTitle: string,
   scraperYear?: number,
   scraperDirector?: string,
@@ -309,7 +325,7 @@ export async function createFilmWithoutTMDB(
   });
 
   // Add to cache so subsequent lookups in this run find it
-  addToFilmCache({
+  addToFilmCache(cache, {
     id: filmId,
     title: matchingTitle,
     originalTitle: null,

--- a/src/scripts/run-scrape-and-enrich.ts
+++ b/src/scripts/run-scrape-and-enrich.ts
@@ -84,6 +84,25 @@ async function main(): Promise<void> {
   const startedAt = new Date();
   const phases: PhaseResult[] = [];
 
+  // Phase 0: Pre-flight quarantine — read-only, ~1s. Tells the user which
+  // cinemas have been silently broken for ≥2 runs BEFORE they sit through
+  // a 30-60 min /scrape that just re-runs them. Always runs.
+  phases.push(
+    await runPhase("Pre-flight (silent-breaker check)", async () => {
+      const breakers = await detectSilentBreakers();
+      if (breakers.length === 0) {
+        console.log("[pre-flight] No silently-broken cinemas detected — proceeding.");
+      } else {
+        console.log(formatQuarantineReport(breakers));
+        console.log(
+          `[pre-flight] ${breakers.length} cinema(s) above. Consider \`/scrape-one <slug>\` ` +
+            "to investigate before starting a full run.",
+        );
+      }
+      return { ok: true, detail: `${breakers.length} flagged` };
+    }),
+  );
+
   // Phase 1: Scrape (unless skipped)
   if (!SKIP_SCRAPE) {
     phases.push(


### PR DESCRIPTION
## Summary

After today's 87-minute silent `/scrape` hang, six specialised agents audited the pipeline. Plan lives at `~/.claude/plans/before-we-do-this-silly-deer.md`. **Ship 1** lands the highest-leverage findings: **observability** so the next hang is visible in seconds, and **two concurrency hazards** we'd been silently getting away with. Performance work deferred to **Ship 2** and will be informed by this PR's instrumentation.

## What changed

### Observability
- **New `src/lib/scrape-progress.ts`** — atomic `tmp/scrape-progress.json` stamper (`tail -f | jq` to watch live state) + a `runPhase(cinemaId, name, fn, meta)` helper that wraps any async phase with start/done console logs, duration, and progress stamps.
- **`pipeline.ts` phases instrumented** — `diff`, `init-film-cache`, `extract-titles`, `film-loop`, `cleanup-superseded` all emit `[Pipeline] <cinema> > <phase> start/done <ms>ms`. The exact silent gap that produced today's hang now has visibility.
- **Per-cinema logs in `scrape-all.ts:runScraperEntry`** — `[scrape-all] {wave}: {cinema} started/done {ms}ms ok|fail (added X, updated Y)`.
- **Pre-flight Phase 0** in `run-scrape-and-enrich.ts` — `detectSilentBreakers` runs at start so the user sees broken cinemas before a 30–60 min run begins.

### Concurrency fix #1 — per-call film cache
Module-level `filmCache`/`tmdbIdIndex`/`cacheStats`/`normalizeFn` singletons in `film-matching.ts` replaced with a `FilmCache` interface threaded through every cache-touching function. `runWave` runs cinemas concurrently (cap 4); previous shape reset module state per cinema so cinema B's reset could wipe cinema A's mid-run cache → A re-creates films → duplicate film rows.

### Concurrency fix #2 — per-`runScraper` `pendingRecords` via `AsyncLocalStorage`
Module-level `Promise<void>[]` shared across all 26 concurrent `runScraper` invocations replaced with `AsyncLocalStorage<Promise<void>[]>` per-call context. `runScraper` wraps body in `try/finally` so flush is guaranteed on success and on throw — closes a pre-existing leak.

## Local-only constraint preserved

`tmp/scrape-progress.json` is a local file. `detectSilentBreakers` is a local DB read. No Inngest, Trigger.dev, Vercel cron, or GitHub Actions schedules.

## Code review

Reviewed by the project's code-reviewer agent before commit. Addressed the one blocker (`flushPendingRecords` no-op in `createMain` failure path → moved into `runScraper` wrapper's `finally`, deleted the redundant outer call).

## What is intentionally NOT in this PR (deferred)

Performance findings (missing partial index, hoisting `initFilmCache` to session scope, hoisting Layer 0 lookup, parallelising the per-screening loop) — deferred until Ship 2 with measurements from this PR's `runPhase` durations. Resilience findings (client-recreate on timeout, retry shape, Letterboxd decoupling) — Ship 3.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 errors, 41 pre-existing warnings unchanged)
- [x] `npm run test:run` — 890/890 pass
- [ ] After merge: re-run `/scrape`, verify `tmp/scrape-progress.json` updates continuously and `[Pipeline] <cinema> > <phase> done <ms>ms` lines stream live

🤖 Generated with [Claude Code](https://claude.com/claude-code)