### PR TITLE
feat(scrape): order by fewest screenings first + finish BST hardening

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,19 @@
+## 2026-05-10: Sort /scrape by fewest screenings first + finish BST hardening
+**PR**: TBD | **Files**: `src/lib/jobs/scrape-all.ts`, `src/scrapers/cinemas/close-up.ts`, `src/scrapers/cinemas/electric.ts`, `src/scrapers/cinemas/electric-v2.ts`, `src/scrapers/cinemas/peckhamplex.ts`, `src/scrapers/cinemas/genesis.ts`, `src/scrapers/cinemas/genesis-v2.ts`, `src/scrapers/cinemas/lexi.ts`, `src/scrapers/cinemas/lexi-v2.ts`, `src/scrapers/bfi-pdf/pdf-parser.ts`, `src/scrapers/bfi-pdf/programme-changes-parser.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
+- **New primary sort key in `runWave`**: fewest upcoming screenings first, staleness (the prior key from #480) as tiebreaker. Cinemas with broken scrapers — which show as low screening counts in the 2026-05-06 coverage audit — now surface within the first concurrency slot of their wave instead of running last.
+- Added `loadScreeningCountMap()` next to `loadFreshnessMap()`, querying `SELECT cinema_id, COUNT(*) FROM screenings WHERE datetime >= NOW() GROUP BY cinema_id`. Both maps load in parallel via `Promise.all` at the top of `runScrapeAll`.
+- Added `entryScreeningCount(entry, countMap)` returning the MIN count across the entry's venues — mirrors `entryStaleness`'s "oldest within entry" semantics so a multi-venue chain with one starved venue sorts first.
+- Per-wave log now shows both signals: `[scrape-all] Cheerio order (fewest screenings, then stalest): peckhamplex(0scr, never), regent-street(26scr, 30d), …`.
+- **BST hardening — completes the in-progress migration**: replaced every remaining unsafe `new Date(year, month, day, hours, minutes)` constructor with `ukLocalToUTC(...)` from `src/scrapers/utils/date-parser.ts`. The native constructor interprets numeric args as the runtime TZ, silently producing +1h offsets during BST when scrapers run under `TZ=UTC`. Six additional callsites fixed beyond the five already in the working tree:
+  - `cinemas/close-up.ts:304` (second method — the diff at line 390 missed this one)
+  - `cinemas/electric.ts:242` + `cinemas/electric-v2.ts:173`
+  - `cinemas/peckhamplex.ts:225`
+  - `bfi-pdf/pdf-parser.ts:365` + `bfi-pdf/programme-changes-parser.ts:283`
+- Static guarantee: `grep -rn "new Date(.*month.*day.*hour" src/scrapers/` now returns zero hits outside `date-parser.ts` itself (where `Date.UTC` is the canonical, correct call).
+- `npx tsc --noEmit` clean. `npm run lint` 0 errors (41 pre-existing warnings). 890/890 tests pass.
+
+---
+
 ## 2026-05-07: /scrape observability + concurrency fixes (Ship 1 of plan)
 **PR**: TBD | **Files**: `src/lib/scrape-progress.ts` (new), `src/scrapers/pipeline.ts`, `src/scrapers/runner-factory.ts`, `src/scrapers/utils/film-matching.ts`, `src/lib/jobs/scrape-all.ts`, `src/scripts/run-scrape-and-enrich.ts`, `.gitignore`
 - After today's 87-minute silent hang, six specialised agents audited `/scrape` end-to-end. Plan at `~/.claude/plans/before-we-do-this-silly-deer.md`. Ship 1 lands the cheapest, highest-leverage findings: observability (so the next hang is visible in seconds, not 87 minutes) and two concurrency hazards we'd been getting away with.

--- a/changelogs/2026-05-10-scrape-ordering-and-bst-hardening.md
+++ b/changelogs/2026-05-10-scrape-ordering-and-bst-hardening.md
@@ -1,0 +1,52 @@
+# Sort /scrape by fewest screenings first + finish BST hardening
+
+**PR**: TBD
+**Date**: 2026-05-10
+
+## Changes
+
+### Part 1 — Within-wave sort: fewest screenings first, staleness as tiebreaker
+
+`src/lib/jobs/scrape-all.ts`
+
+- New `loadScreeningCountMap(): Promise<Map<string, number>>` — `SELECT cinema_id, COUNT(*)::int FROM screenings WHERE datetime >= NOW() GROUP BY cinema_id`. Filters to upcoming screenings only so cleanup of past rows doesn't distort the ranking.
+- New `entryScreeningCount(entry, countMap)` — returns the MIN count across an entry's venues. Multi-venue chains with one starved venue sort first.
+- `runWave(...)` signature extended with a `countMap` parameter. Sort comparator changed to two-key: `a.count - b.count || a.ms - b.ms`. Per-wave log updated to surface both signals.
+- `runScrapeAll(...)` loads both maps in parallel via `Promise.all`.
+
+Rationale: the 2026-05-06 scraper coverage audit identified Castle, Castle Sidcup, Barbican, and Coldharbour Blue as low-coverage outliers caused by scraper bugs. Sorting by count first surfaces such failures in the first concurrency slot of each wave — much faster signal than waiting for staleness rotation to expose them.
+
+### Part 2 — Eliminated every unsafe `new Date(y, m, d, h, mi)` callsite
+
+`SCRAPING_PLAYBOOK.md:17` already mandates `ukLocalToUTC(...)` over the native constructor, because the constructor interprets numeric args in the runtime TZ — under `TZ=UTC` (cron, CI, container), this silently adds 1h to BST-period screenings. Five scrapers were already migrated in the working tree (`close-up`, `genesis`, `genesis-v2`, `lexi`, `lexi-v2`). A grep revealed six more callsites still using the unsafe pattern; all are now migrated.
+
+| File:line | Notes |
+|---|---|
+| `src/scrapers/cinemas/close-up.ts:304` | Second method in the same file. The in-progress diff only fixed the line-390 method. |
+| `src/scrapers/cinemas/electric.ts:242` | API-based scraper, parses `YYYY-MM-DD` + `HH:MM`. |
+| `src/scrapers/cinemas/electric-v2.ts:173` | Sibling v2 scraper, same parser shape. |
+| `src/scrapers/cinemas/peckhamplex.ts:225` | Cheerio-based, parses split date/time parts. |
+| `src/scrapers/bfi-pdf/pdf-parser.ts:365` | BFI PDF importer — important for the BFI Southbank backfill path. |
+| `src/scrapers/bfi-pdf/programme-changes-parser.ts:283` | BFI programme-changes scraper. |
+
+Static guarantee: `grep -rn "new Date(.*month.*day.*hour" src/scrapers/` now returns zero hits outside `date-parser.ts` (which contains the canonical `Date.UTC(year, month, day, hours, minutes, 0, 0)` call inside `ukLocalToUTC`).
+
+### Not in scope (date-only constructions, no BST risk)
+
+- `bfi-pdf/fetcher.ts:226,237` — month range bounds, no time.
+- `cinemas/close-up.ts:270,299` — date-only `testDate` constructions.
+- `seasons/base.ts:270,271,290` — season month ranges.
+
+## Impact
+
+- **Operator UX**: When the user runs `/scrape`, broken scrapers now appear in the first ~4 cinemas of each wave instead of being randomly distributed by staleness. If the run is interrupted, the highest-signal cinemas have already been attempted.
+- **Time correctness**: Every scraper in the codebase now uses the same UTC-explicit BST handling. The "off by one hour" class of bug — flagged by the data-check patrols and visible to users on the live calendar — cannot reappear from any of the 11 covered scrapers without explicit regression in `date-parser.ts` itself.
+- **No behavioural change** for cinemas where the existing scraper already produced correct times (because `ukLocalToUTC` and `new Date(...)` agree when the runtime TZ is `Europe/London`). The fix is invisible on a developer Mac and load-bearing on a UTC server.
+
+## Verification
+
+- `npx tsc --noEmit` → 0 errors.
+- `npm run lint` → 0 errors, 41 pre-existing warnings.
+- `npm run test:run` → 890/890 pass.
+- `grep -rn "new Date(.*month.*day.*hour" src/scrapers/ | grep -v date-parser.ts` → empty.
+- Post-run DB spot-check across the 6 newly-migrated cinemas: London-local times match the live websites at the same screening (no ±1h drift).

--- a/scripts/_post-run-time-check.ts
+++ b/scripts/_post-run-time-check.ts
@@ -1,0 +1,88 @@
+import { db } from "@/db";
+import { screenings, films } from "@/db/schema";
+import { sql, eq, gte, inArray, and } from "drizzle-orm";
+
+const TARGET_CINEMAS = [
+  "electric-portobello",
+  "electric-white-city",
+  "peckhamplex",
+  "close-up-cinema",
+  "genesis",
+  "bfi-southbank",
+];
+
+async function main() {
+  // Per-cinema: bucket upcoming screenings by London hour-of-day; flag any in
+  // the 00:00-09:59 window (the classic BST-off-by-one signature).
+  const rows = await db
+    .select({
+      cinemaId: screenings.cinemaId,
+      londonHour: sql<number>`EXTRACT(HOUR FROM ${screenings.datetime} AT TIME ZONE 'Europe/London')::int`,
+      n: sql<number>`COUNT(*)::int`,
+    })
+    .from(screenings)
+    .where(
+      and(
+        gte(screenings.datetime, new Date()),
+        inArray(screenings.cinemaId, TARGET_CINEMAS),
+      ),
+    )
+    .groupBy(
+      screenings.cinemaId,
+      sql`EXTRACT(HOUR FROM ${screenings.datetime} AT TIME ZONE 'Europe/London')`,
+    )
+    .orderBy(screenings.cinemaId, sql`EXTRACT(HOUR FROM ${screenings.datetime} AT TIME ZONE 'Europe/London')`);
+
+  const byCinema = new Map<string, Map<number, number>>();
+  for (const r of rows) {
+    if (!byCinema.has(r.cinemaId)) byCinema.set(r.cinemaId, new Map());
+    byCinema.get(r.cinemaId)!.set(r.londonHour, r.n);
+  }
+
+  console.log("\n=== Upcoming-screenings hour distribution (London local) ===\n");
+  for (const cinemaId of TARGET_CINEMAS) {
+    const dist = byCinema.get(cinemaId);
+    if (!dist) {
+      console.log(`${cinemaId}: NO ROWS`);
+      continue;
+    }
+    const total = [...dist.values()].reduce((a, b) => a + b, 0);
+    const suspicious = [...dist.entries()]
+      .filter(([h]) => h >= 0 && h < 10)
+      .reduce((a, [, n]) => a + n, 0);
+    const distStr = [...dist.entries()]
+      .map(([h, n]) => `${String(h).padStart(2, "0")}:${n}`)
+      .join(" ");
+    const flag = suspicious > 0 ? ` ⚠️  ${suspicious} in 00:00-09:59` : " ✓";
+    console.log(`${cinemaId.padEnd(22)} total=${String(total).padStart(4)}  ${distStr}${flag}`);
+  }
+
+  // Sample 3 newest screenings per cinema (London time + film title)
+  console.log("\n=== Sample screenings (London time + film) ===\n");
+  for (const cinemaId of TARGET_CINEMAS) {
+    const samples = await db
+      .select({
+        london: sql<string>`to_char(${screenings.datetime} AT TIME ZONE 'Europe/London', 'YYYY-MM-DD HH24:MI')`,
+        title: films.title,
+      })
+      .from(screenings)
+      .innerJoin(films, eq(screenings.filmId, films.id))
+      .where(
+        and(
+          gte(screenings.datetime, new Date()),
+          eq(screenings.cinemaId, cinemaId),
+        ),
+      )
+      .orderBy(screenings.datetime)
+      .limit(3);
+    console.log(`-- ${cinemaId}`);
+    for (const s of samples) console.log(`   ${s.london}  ${s.title}`);
+    if (samples.length === 0) console.log("   (no upcoming rows)");
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/_run-summary.ts
+++ b/scripts/_run-summary.ts
@@ -1,0 +1,25 @@
+import { db } from "@/db";
+import { scraperRuns } from "@/db/schema";
+import { sql, gte } from "drizzle-orm";
+
+async function main() {
+  const since = new Date("2026-05-10T20:25:00.000Z");
+  const grouped = await db
+    .select({
+      status: scraperRuns.status,
+      n: sql<number>`count(*)::int`,
+    })
+    .from(scraperRuns)
+    .where(gte(scraperRuns.startedAt, since))
+    .groupBy(scraperRuns.status);
+  console.log(`Scraper runs since ${since.toISOString()} (grouped by status):`);
+  for (const row of grouped) {
+    console.log(`  ${row.status.padEnd(12)} ${row.n}`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_scrape-snapshot.ts
+++ b/scripts/_scrape-snapshot.ts
@@ -1,0 +1,20 @@
+import { db } from "@/db";
+import { screenings, scraperRuns } from "@/db/schema";
+import { sql, desc } from "drizzle-orm";
+
+async function main() {
+  const total = await db.select({ n: sql<number>`count(*)::int` }).from(screenings);
+  const lastRun = await db
+    .select({ at: scraperRuns.startedAt })
+    .from(scraperRuns)
+    .orderBy(desc(scraperRuns.startedAt))
+    .limit(1);
+  console.log("SCREENINGS_COUNT", total[0]?.n ?? 0);
+  console.log("LAST_RUN_AT", lastRun[0]?.at ?? "never");
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/lib/jobs/scrape-all.ts
+++ b/src/lib/jobs/scrape-all.ts
@@ -21,6 +21,7 @@ import { gte, eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { scraperRuns } from "@/db/schema/admin";
 import { cinemas } from "@/db/schema/cinemas";
+import { screenings } from "@/db/schema/screenings";
 import { sendTelegramAlert } from "@/lib/telegram";
 import { stampProgress } from "@/lib/scrape-progress";
 import { runScraper } from "@/scrapers/runner-factory";
@@ -195,6 +196,31 @@ async function loadFreshnessMap(): Promise<FreshnessMap> {
   return map;
 }
 
+/**
+ * Map of cinema_id → count of upcoming screenings. Used as the PRIMARY sort
+ * key within a wave so cinemas with low coverage (likely scraper failures)
+ * are scraped first. Cinemas absent from the map have 0 screenings.
+ */
+type ScreeningCountMap = Map<string, number>;
+
+/** Load each cinema's count of upcoming (future) screenings. */
+async function loadScreeningCountMap(): Promise<ScreeningCountMap> {
+  const rows = await db
+    .select({
+      cinemaId: screenings.cinemaId,
+      count: sql<number>`COUNT(*)::int`.as("count"),
+    })
+    .from(screenings)
+    .where(gte(screenings.datetime, new Date()))
+    .groupBy(screenings.cinemaId);
+
+  const map: ScreeningCountMap = new Map();
+  for (const r of rows) {
+    map.set(r.cinemaId, r.count);
+  }
+  return map;
+}
+
 /** Extract every cinema_id a registry entry will scrape. */
 function getEntryCinemaIds(entry: ScraperRegistryEntry): string[] {
   const config = entry.buildConfig();
@@ -217,26 +243,50 @@ function entryStaleness(entry: ScraperRegistryEntry, freshness: FreshnessMap): n
   return oldest === Number.POSITIVE_INFINITY ? 0 : oldest;
 }
 
+/**
+ * Screening-count key for sorting: the LOWEST upcoming-screening count across
+ * the entry's venues. A multi-venue chain with one starved venue sorts first
+ * — that venue is most likely broken. Missing venues are treated as 0.
+ */
+function entryScreeningCount(
+  entry: ScraperRegistryEntry,
+  countMap: ScreeningCountMap,
+): number {
+  const ids = getEntryCinemaIds(entry);
+  let lowest = Number.POSITIVE_INFINITY;
+  for (const id of ids) {
+    const n = countMap.get(id) ?? 0;
+    if (n < lowest) lowest = n;
+  }
+  return lowest === Number.POSITIVE_INFINITY ? 0 : lowest;
+}
+
 /** Fan-out scrapers in a single wave with the given concurrency cap. */
 async function runWave(
   wave: ScraperWave,
   label: string,
   concurrency: number,
   freshness: FreshnessMap,
+  countMap: ScreeningCountMap,
 ): Promise<WaveSummary> {
-  // Sort by staleness ASC (never-scraped first, then oldest, then most recent last).
-  // Compute the staleness key once per entry; sort + log share the result.
+  // Sort by screening count ASC (fewest first — broken scrapers surface fast),
+  // staleness ASC as tiebreaker (preserve rotation when counts are equal).
+  // Compute both keys once per entry; sort + log share the results.
   const ranked = SCRAPER_REGISTRY.filter((e) => e.wave === wave)
-    .map((entry) => ({ entry, ms: entryStaleness(entry, freshness) }))
-    .sort((a, b) => a.ms - b.ms);
+    .map((entry) => ({
+      entry,
+      count: entryScreeningCount(entry, countMap),
+      ms: entryStaleness(entry, freshness),
+    }))
+    .sort((a, b) => a.count - b.count || a.ms - b.ms);
   if (ranked.length > 0) {
     const orderStr = ranked
-      .map(({ entry, ms }) => {
+      .map(({ entry, count, ms }) => {
         const age = ms === 0 ? "never" : `${Math.floor((Date.now() - ms) / 86_400_000)}d`;
-        return `${entry.taskId.replace(/^scraper-/, "")}(${age})`;
+        return `${entry.taskId.replace(/^scraper-/, "")}(${count}scr, ${age})`;
       })
       .join(", ");
-    console.log(`[scrape-all] ${label} order (stalest first): ${orderStr}`);
+    console.log(`[scrape-all] ${label} order (fewest screenings, then stalest): ${orderStr}`);
   }
   const entries = ranked.map((r) => r.entry);
   const tasks = entries.map((entry) => () => runScraperEntry(entry, label));
@@ -310,19 +360,22 @@ export async function runScrapeAll(): Promise<ScrapeAllResult> {
   const startedAt = new Date(startTime);
   const waveSummaries: WaveSummary[] = [];
 
-  // Load each cinema's last successful scrape timestamp once, up front.
-  // Within each wave, entries are sorted stalest-first so that if the run is
-  // interrupted, the cinemas that need the most refresh have already gone.
-  const freshness = await loadFreshnessMap();
+  // Load sort signals once, up front. Within each wave, entries are sorted
+  // fewest-screenings first (broken scrapers surface fast) with staleness as
+  // a tiebreaker (preserves the rotation behaviour from commit 712ee16).
+  const [freshness, countMap] = await Promise.all([
+    loadFreshnessMap(),
+    loadScreeningCountMap(),
+  ]);
 
   // Wave 1: Chain scrapers (3 — fully parallel)
-  waveSummaries.push(await runWave("chain", "Chains", 4, freshness));
+  waveSummaries.push(await runWave("chain", "Chains", 4, freshness, countMap));
 
   // Wave 2: Playwright independents (7 — cap at 4 for memory headroom)
-  waveSummaries.push(await runWave("playwright", "Playwright", 4, freshness));
+  waveSummaries.push(await runWave("playwright", "Playwright", 4, freshness, countMap));
 
   // Wave 3: Cheerio / API independents (16 — cap at 4 to mirror prior chunking)
-  waveSummaries.push(await runWave("cheerio", "Cheerio", 4, freshness));
+  waveSummaries.push(await runWave("cheerio", "Cheerio", 4, freshness, countMap));
 
   // Wave 4: Post-scrape enrichment (Letterboxd ratings)
   waveSummaries.push(await runEnrichmentWave());

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -14,6 +14,7 @@ Update this playbook whenever you:
 - If a time is `1-9` with no AM/PM, default to PM.
 - Treat times before `10:00` as likely parse errors and log warnings.
 - Use `src/scrapers/utils/date-parser.ts` for shared parsing behavior.
+- **Never use `new Date(year, month, day, hours, minutes)` to construct screening datetimes.** That ctor interprets numeric args as the runtime's local timezone, which silently produces +1h offsets during BST when the scraper runs under `TZ=UTC` (cron, CI, container). Always call `ukLocalToUTC(...)` from `utils/date-parser.ts` — it builds UTC explicitly and applies BST. Same goes for `parseUKLocalDateTime()` for ISO-like strings without a timezone suffix.
 - After fixing time parsing bugs, verify and clean bad historical screenings (`00:00-09:59`) only when confirmed wrong.
 
 ## Primary Entrypoints

--- a/src/scrapers/bfi-pdf/pdf-parser.ts
+++ b/src/scrapers/bfi-pdf/pdf-parser.ts
@@ -21,6 +21,7 @@ import { extractText as unpdfExtractText, getDocumentProxy } from "unpdf";
 import type { RawScreening } from "../types";
 import type { FetchedPDF } from "./fetcher";
 import { buildBFISearchUrl } from "./url-builder";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // Venue mapping from PDF screen names to our cinema IDs
 const VENUE_MAP: Record<string, string> = {
@@ -362,7 +363,8 @@ function parseScreeningLine(line: string, pdfYear: number): ParsedScreening[] {
       year = pdfYear + 1;
     }
 
-    const datetime = new Date(year, monthNum, parseInt(date, 10), parseInt(hours, 10), parseInt(minutes, 10));
+    // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+    const datetime = ukLocalToUTC(year, monthNum, parseInt(date, 10), parseInt(hours, 10), parseInt(minutes, 10));
 
     // Map venue to cinema ID — reject unknown venues instead of defaulting
     const venueUpper = venue.toUpperCase();

--- a/src/scrapers/bfi-pdf/programme-changes-parser.ts
+++ b/src/scrapers/bfi-pdf/programme-changes-parser.ts
@@ -22,6 +22,7 @@ import type { CheerioSelection } from "../utils/cheerio-types";
 import { fetchWithRetry } from "../utils/fetch-with-retry";
 import { CHROME_USER_AGENT_FULL } from "../constants";
 import { buildBFISearchUrl } from "./url-builder";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 /**
  * Fetches a URL, optionally through a proxy service.
@@ -280,7 +281,8 @@ function parseScreeningsFromText(text: string): ParsedChangeScreening[] {
       year = currentYear + 1;
     }
 
-    const datetime = new Date(year, monthNum, parseInt(date, 10), parseInt(hours, 10), parseInt(minutes, 10));
+    // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+    const datetime = ukLocalToUTC(year, monthNum, parseInt(date, 10), parseInt(hours, 10), parseInt(minutes, 10));
 
     // Skip past screenings
     if (datetime < now) continue;

--- a/src/scrapers/cinemas/close-up.ts
+++ b/src/scrapers/cinemas/close-up.ts
@@ -19,6 +19,7 @@ import * as cheerio from "cheerio";
 import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
 import { normalizeUrl } from "../utils/url";
+import { ukLocalToUTC } from "../utils/date-parser";
 import { FestivalDetector } from "../festivals/festival-detector";
 
 /** Month name → zero-indexed month number (shared across date-parsing methods). */
@@ -300,7 +301,8 @@ export class CloseUpCinemaScraper extends BaseScraper {
       year++;
     }
 
-    return new Date(year, monthNum, parseInt(day, 10), hourNum, minuteNum, 0);
+    // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+    return ukLocalToUTC(year, monthNum, parseInt(day, 10), hourNum, minuteNum);
   }
 
   /**
@@ -389,7 +391,10 @@ export class CloseUpCinemaScraper extends BaseScraper {
     const minutes = parseInt(timeMatch[2], 10);
     const seconds = parseInt(timeMatch[3], 10);
 
-    return new Date(year, month, day, hours, minutes, seconds);
+    // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+    const date = ukLocalToUTC(year, month, day, hours, minutes);
+    if (seconds) date.setUTCSeconds(seconds);
+    return date;
   }
 
 }

--- a/src/scrapers/cinemas/electric-v2.ts
+++ b/src/scrapers/cinemas/electric-v2.ts
@@ -10,6 +10,7 @@
 
 import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // Re-export config and venue for compatibility
 export { ELECTRIC_CONFIG, ELECTRIC_VENUES } from "./electric";
@@ -170,7 +171,8 @@ export class ElectricScraperV2 extends BaseScraper {
       return null;
     }
 
-    const date = new Date(year, month - 1, day, hours, minutes, 0, 0);
+    // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+    const date = ukLocalToUTC(year, month - 1, day, hours, minutes);
     return isNaN(date.getTime()) ? null : date;
   }
 

--- a/src/scrapers/cinemas/electric.ts
+++ b/src/scrapers/cinemas/electric.ts
@@ -11,6 +11,7 @@
 import type { RawScreening, ScraperConfig, CinemaScraper, VenueConfig } from "../types";
 import { CHROME_USER_AGENT } from "../constants";
 import { checkHealth } from "../utils/health-check";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // ============================================================================
 // Electric Cinema Configuration
@@ -238,8 +239,8 @@ export class ElectricScraper implements CinemaScraper {
         return null;
       }
 
-      // Create date in local time (UK timezone)
-      const date = new Date(year, month - 1, day, hours, minutes, 0, 0);
+      // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+      const date = ukLocalToUTC(year, month - 1, day, hours, minutes);
 
       // Validate the date
       if (isNaN(date.getTime())) {

--- a/src/scrapers/cinemas/genesis-v2.ts
+++ b/src/scrapers/cinemas/genesis-v2.ts
@@ -15,6 +15,7 @@
 import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
 import type { CheerioAPI, CheerioSelection } from "../utils/cheerio-types";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // Re-export config and venue for compatibility
 export { GENESIS_CONFIG, GENESIS_VENUE } from "./genesis";
@@ -303,11 +304,12 @@ export class GenesisScraper extends BaseScraper {
         hours += 12;
       }
 
-      const date = new Date(year, month, day, hours, minutes);
+      // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+      let date = ukLocalToUTC(year, month, day, hours, minutes);
 
       // If date is in the past, assume next year (only for text-based dates without explicit year)
       if (date < new Date() && !/^\d{8}$/.test(dateStr)) {
-        date.setFullYear(date.getFullYear() + 1);
+        date = ukLocalToUTC(year + 1, month, day, hours, minutes);
       }
 
       return date;

--- a/src/scrapers/cinemas/genesis.ts
+++ b/src/scrapers/cinemas/genesis.ts
@@ -15,6 +15,7 @@ import type { RawScreening, ScraperConfig, CinemaScraper } from "../types";
 import { FestivalDetector } from "../festivals/festival-detector";
 import { checkHealth } from "../utils/health-check";
 import { CHROME_USER_AGENT } from "../constants";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // ============================================================================
 // Genesis Configuration
@@ -282,11 +283,14 @@ export class GenesisScraper implements CinemaScraper {
       if (ampm === "pm" && hours < 12) hours += 12;
       if (ampm === "am" && hours === 12) hours = 0;
 
-      const date = new Date(year, month, day, hours, minutes);
+      // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+      // `new Date(y,m,d,h,mi)` interprets args as local time, so a UTC-runtime
+      // would store London times one hour ahead during BST.
+      let date = ukLocalToUTC(year, month, day, hours, minutes);
 
       // If date is in the past, assume next year
       if (date < new Date()) {
-        date.setFullYear(date.getFullYear() + 1);
+        date = ukLocalToUTC(year + 1, month, day, hours, minutes);
       }
 
       return date;

--- a/src/scrapers/cinemas/lexi-v2.ts
+++ b/src/scrapers/cinemas/lexi-v2.ts
@@ -10,6 +10,7 @@
 
 import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // Re-export config and venue for compatibility
 export { LEXI_CONFIG, LEXI_VENUE } from "./lexi";
@@ -149,7 +150,8 @@ export class LexiScraperV2 extends BaseScraper {
       return null;
     }
 
-    return new Date(year, month, day, hours, minutes, 0);
+    // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+    return ukLocalToUTC(year, month, day, hours, minutes);
   }
 
   private cleanTitle(title: string): string {

--- a/src/scrapers/cinemas/lexi.ts
+++ b/src/scrapers/cinemas/lexi.ts
@@ -14,6 +14,7 @@
 import type { RawScreening, ScraperConfig, CinemaScraper } from "../types";
 import { CHROME_USER_AGENT } from "../constants";
 import { checkHealth } from "../utils/health-check";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 export const LEXI_CONFIG: ScraperConfig = {
   cinemaId: "lexi",
@@ -256,7 +257,8 @@ export class LexiScraper implements CinemaScraper {
       return null;
     }
 
-    return new Date(year, month, day, hours, minutes, 0);
+    // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+    return ukLocalToUTC(year, month, day, hours, minutes);
   }
 
   private cleanTitle(title: string): string {

--- a/src/scrapers/cinemas/peckhamplex.ts
+++ b/src/scrapers/cinemas/peckhamplex.ts
@@ -15,6 +15,7 @@ import type { RawScreening, ScraperConfig, CinemaScraper } from "../types";
 import type { CheerioAPI } from "../utils/cheerio-types";
 import { checkHealth } from "../utils/health-check";
 import { CHROME_USER_AGENT_FULL } from "../constants";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // ============================================================================
 // Peckhamplex Configuration
@@ -221,8 +222,8 @@ export class PeckhamplexScraper implements CinemaScraper {
         return null;
       }
 
-      // Create date in local time
-      const date = new Date(year, month - 1, day, hours, minutes);
+      // Build UTC explicitly with BST offset — never rely on the runtime TZ.
+      const date = ukLocalToUTC(year, month - 1, day, hours, minutes);
 
       // Validate the date
       if (isNaN(date.getTime())) {


### PR DESCRIPTION
## Summary

- **New within-wave sort**: fewest upcoming screenings first, staleness (from #480) as tiebreaker. Broken scrapers — flagged as low-coverage outliers in the 2026-05-06 audit — now run in the first concurrency slot of their wave.
- **Completes the BST/timezone migration**: replaces every remaining unsafe `new Date(year, month, day, hours, minutes)` with `ukLocalToUTC(...)` from `src/scrapers/utils/date-parser.ts`. The native constructor reads numeric args as the runtime TZ, silently producing +1h offsets under `TZ=UTC` during BST. Six new callsites fixed beyond the five in the working tree (close-up:304, electric, electric-v2, peckhamplex, bfi-pdf/pdf-parser, bfi-pdf/programme-changes-parser).
- **Live `/scrape` validation**: 27 ok / 0 failed in 31.7 min. The reorder surfaced chain-everyman first (was 0 screenings, never-successful) and the scraper rebuilt — added 816 screenings. Zero off-by-one signatures (00:00–09:59 London window) in any of the 6 newly-migrated cinemas.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (41 pre-existing warnings)
- [x] `npm run test:run` — 890/890 pass
- [x] `grep -rn "new Date(.*month.*day.*hour" src/scrapers/` returns no hits outside `date-parser.ts`
- [x] Live `/scrape` run: 27 ok / 0 failed, 0 silent breakers
- [x] Post-run DB spot-check: electric ×2, peckhamplex, close-up, genesis, bfi-southbank all have 0 rows in the 00:00–09:59 London window; sample times match cinema websites
- [x] Code-reviewer agent: "ship it" (sort correctness, BST migration, concurrency semantics all confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)