### PR TITLE
fix(scrape): Everyman chain scraper BST timezone bug

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,14 @@
+## 2026-05-11: Fix Everyman chain scraper BST timezone bug
+**PR**: TBD | **Files**: `src/scrapers/chains/everyman.ts`
+- Found via a 100-film post-merge spot-check: 2 `Hokum` screenings at Everyman Broadgate flagged in the 00:00–09:59 London window. Cross-referencing booking URLs revealed each appears twice in the DB — once at the correct evening time, once at +1h.
+- Root cause: `new Date(showtime.startsAt)` at `everyman.ts:458` interpreted the API's TZ-less ISO string (e.g. `"2026-05-12T11:15:00"`) in the runtime TZ. Under `TZ=Europe/London` (developer Mac) → correct; under `TZ=UTC` (cron, CI) → silently +1h during BST.
+- Same bug class as the 11 scrapers migrated in #483, but with a different surface (no-TZ string → `new Date(str)`). Fix: `parseUKLocalDateTime(showtime.startsAt)` from `utils/date-parser.ts` — treats no-TZ strings as UK local time explicitly.
+- **348 upcoming Everyman screenings are currently involved in duplicate sets** across all 15 Everyman venues. The +1h ghosts need to be cleaned up separately (destructive — requires explicit approval).
+- Curzon and Picturehouse chain scrapers have similar `new Date(api.startsAt)` patterns but no booking-URL duplicate evidence in current data. Worth probing their API formats as a follow-up.
+- `npx tsc --noEmit` clean. `npm run test:run src/scrapers/chains` 4/4 pass.
+
+---
+
 ## 2026-05-10: Sort /scrape by fewest screenings first + finish BST hardening
 **PR**: TBD | **Files**: `src/lib/jobs/scrape-all.ts`, `src/scrapers/cinemas/close-up.ts`, `src/scrapers/cinemas/electric.ts`, `src/scrapers/cinemas/electric-v2.ts`, `src/scrapers/cinemas/peckhamplex.ts`, `src/scrapers/cinemas/genesis.ts`, `src/scrapers/cinemas/genesis-v2.ts`, `src/scrapers/cinemas/lexi.ts`, `src/scrapers/cinemas/lexi-v2.ts`, `src/scrapers/bfi-pdf/pdf-parser.ts`, `src/scrapers/bfi-pdf/programme-changes-parser.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
 - **New primary sort key in `runWave`**: fewest upcoming screenings first, staleness (the prior key from #480) as tiebreaker. Cinemas with broken scrapers — which show as low screening counts in the 2026-05-06 coverage audit — now surface within the first concurrency slot of their wave instead of running last.

--- a/changelogs/2026-05-11-everyman-bst-timezone-fix.md
+++ b/changelogs/2026-05-11-everyman-bst-timezone-fix.md
@@ -1,0 +1,43 @@
+# Fix Everyman chain scraper BST timezone bug
+
+**PR**: TBD
+**Date**: 2026-05-11
+
+## Changes
+
+`src/scrapers/chains/everyman.ts:458` — replaced `new Date(showtime.startsAt)` with `parseUKLocalDateTime(showtime.startsAt)`.
+
+## The bug
+
+Everyman's API (`/api/gatsby-source-boxofficeapi/schedule`) returns `startsAt` as a TZ-less ISO string in UK local time, e.g. `"2026-05-12T11:15:00"`. The API call passes `theaters=[{id, timeZone: "Europe/London"}]` — the API is explicitly keyed by London time.
+
+`new Date(tzlessString)` interprets the string in the **runtime** timezone:
+- Under `TZ=Europe/London` (developer Mac): correctly stored as 10:15 UTC during BST.
+- Under `TZ=UTC` (cron, container, CI): incorrectly stored as 11:15 UTC — a silent +1h offset for every screening during BST.
+
+This is the same bug class as the 11 scrapers migrated in #483, just with a different API: TZ-less ISO string parsed by `new Date()` instead of `new Date(y, m, d, h, mi)`.
+
+## Discovery
+
+Found via a 100-film spot-check after #483 merged:
+
+- The check flagged 2 screenings of `Hokum` at Everyman Broadgate in the 00:00–09:59 London window (the classic BST-bug signature).
+- Tracing the booking URLs showed the same screening stored twice — once at the correct evening time (scraped tonight under London TZ), once at +1h (scraped overnight at ~03:01 UTC under `TZ=UTC`).
+- A repo-wide query for booking-URL duplicates at Everyman venues found **348 upcoming screenings involved in duplicate sets** — pervasive across all 15 Everyman venues.
+- Picturehouse and Peckhamplex did NOT show this pattern in the same dataset.
+
+## Verification
+
+- `npx tsc --noEmit` clean.
+- `npm run test:run src/scrapers/chains` — 4/4 pass.
+- Direct API probe confirmed the no-TZ format: `startsAt: "2026-05-12T11:15:00"`.
+
+## Impact
+
+- **Code**: Future Everyman scrapes will store correct UTC regardless of runtime TZ.
+- **Data**: The 348 existing +1h ghost rows remain in the DB. They need to be cleaned up by deleting the later-datetime row in each booking-URL pair (the correct row scraped tonight has the earlier UTC timestamp). **NOT done in this change** — destructive, requires explicit approval.
+
+## Open follow-ups (not in this PR)
+
+- Probe Curzon and Picturehouse chain APIs to confirm whether `startsAt` / `Showtime` fields include a TZ suffix. If they don't, those scrapers may have the same latent bug. No duplicate-pair evidence was found in the current data, but absence of evidence is not proof.
+- Run the 348-row cleanup script after this PR merges.

--- a/src/scrapers/chains/everyman.ts
+++ b/src/scrapers/chains/everyman.ts
@@ -15,6 +15,7 @@
  */
 
 import { CHROME_USER_AGENT } from "../constants";
+import { parseUKLocalDateTime } from "../utils/date-parser";
 
 import type { ChainConfig, VenueConfig, RawScreening, ChainScraper } from "../types";
 import { addDays, format } from "date-fns";
@@ -455,7 +456,12 @@ export class EverymanScraper implements ChainScraper {
         for (const showtime of showtimes) {
           if (showtime.isExpired) continue;
 
-          const datetime = new Date(showtime.startsAt);
+          // showtime.startsAt is a TZ-less ISO string in UK local time (the API
+          // is keyed by `timeZone: "Europe/London"`). `new Date(str)` interprets
+          // a TZ-less string in the runtime TZ — under TZ=UTC (cron, CI) that
+          // produces a silent +1h offset during BST. parseUKLocalDateTime treats
+          // the string as UK local time explicitly.
+          const datetime = parseUKLocalDateTime(showtime.startsAt);
           if (datetime < now) continue;
 
           // Get booking URL (prefer DESKTOP provider)


### PR DESCRIPTION
## Summary

- Fixes a silent +1h time offset for every Everyman screening scraped under `TZ=UTC` during BST. The API returns `startsAt` as a TZ-less ISO string (e.g. `"2026-05-12T11:15:00"`); `new Date(tzlessString)` parsed it in the runtime TZ. Replaced with `parseUKLocalDateTime()` from `utils/date-parser.ts`.
- Same bug class as #483, different surface: no-TZ string → `new Date(str)` instead of `new Date(y, m, d, h, mi)`.
- Found by a 100-film post-merge spot-check: 2 `Hokum` screenings at Everyman Broadgate were flagged in the 00:00–09:59 London window. Tracing booking URLs revealed **348 upcoming Everyman screenings involved in duplicate sets** (correct row + +1h ghost) across all 15 venues.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run src/scrapers/chains` — 4/4 pass
- [x] Direct API probe confirmed `startsAt` format: no TZ suffix
- [x] Code-reviewer agent: "ready to ship" (no issues found)
- [ ] **Out of scope**: cleanup of the 348 +1h ghost rows. Destructive and requires explicit approval. Pattern: same `(cinema_id, booking_url)` with two `datetime` values exactly 1h apart → drop the later UTC one.
- [ ] **Follow-up**: probe Curzon and Picturehouse `startsAt`/`Showtime` field TZ format. No duplicate evidence in current data, but the code pattern is similar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)