### PR TITLE
feat(scrape): Picturehouse BST fix + 478 ghost cleanup + /spot-check loop

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,14 @@
+## 2026-05-11: Picturehouse BST fix + 478 ghost cleanup + /spot-check loop
+**PR**: TBD | **Files**: `src/scrapers/chains/picturehouse.ts`, `scripts/spot-check-and-fix.ts`, `scripts/_cleanup-bst-ghost-screenings.ts`, `scripts/_fix-boy-and-the-world.ts`, 6 diagnostic scripts, `tasks/spot-check-2026-05-11.md`, `changelogs/2026-05-11-picturehouse-bst-and-spot-check-loop.md`
+- **Picturehouse BST fix**: `picturehouse.ts:255` had the same `new Date(tzlessString)` bug as Everyman. API probe confirmed the no-TZ format. Migrated to `parseUKLocalDateTime`. Curzon independently checked — clean (Vista OCAPI returns Z-suffixed strings).
+- **478 ghost screenings deleted**: BST-signature dupe-group cleanup across Everyman + Picturehouse venues. Pattern: same `(cinema_id, source_id)` with `MAX(datetime) - MIN(datetime) = INTERVAL '1 hour'` exactly. Kept the row with min(datetime) (BST-correct UTC), dropped all later rows. Post-cleanup: 0 remaining BST dupes.
+- **New `/spot-check` slash command**: samples the 100 films with the soonest screenings, finds all H/M/L issues, applies safe auto-fixes (prefix strip, is_repertory flip, year/runtime/poster/synopsis/directors/genres UPDATE from TMDB), iterates until convergence. First post-#483/#484 run: 10 fixes across 3 iterations.
+- **Boy and the World TMDB fix**: row `960847a6` had TMDB 302430 ("Rumblestrips" — wrong). Corrected to 223706 (Brazilian animation *O Menino e o Mundo*).
+- 6 diagnostic `_*.ts` scripts committed for traceability.
+- `npx tsc --noEmit` clean. `npm run test:run src/scrapers/chains` 4/4 pass.
+
+---
+
 ## 2026-05-11: Fix Everyman chain scraper BST timezone bug
 **PR**: TBD | **Files**: `src/scrapers/chains/everyman.ts`
 - Found via a 100-film post-merge spot-check: 2 `Hokum` screenings at Everyman Broadgate flagged in the 00:00–09:59 London window. Cross-referencing booking URLs revealed each appears twice in the DB — once at the correct evening time, once at +1h.

--- a/changelogs/2026-05-11-picturehouse-bst-and-spot-check-loop.md
+++ b/changelogs/2026-05-11-picturehouse-bst-and-spot-check-loop.md
@@ -1,0 +1,65 @@
+# Picturehouse BST fix + 478 ghost row cleanup + /spot-check loop
+
+**PR**: TBD
+**Date**: 2026-05-11
+
+## Changes
+
+### `src/scrapers/chains/picturehouse.ts` — fix BST +1h ghost bug
+
+`new Date(showTime.Showtime)` interprets the API's TZ-less ISO string (e.g. `"2026-05-17T15:30:00"`) in the runtime TZ. Under `TZ=UTC` it silently adds 1h during BST. Direct API probe confirmed the no-TZ format. Replaced with `parseUKLocalDateTime(showTime.Showtime)`.
+
+Same bug class and same fix as Everyman in PR #484. Confirmed by checking the DB for same-`(cinema_id, source_id)` pairs whose datetimes differ by exactly 3600s: **129 BST-signature dupe groups** at Picturehouse, totalling 370 rows. Curzon was independently checked and is clean (0 BST-signature dupes — its Vista OCAPI returns Z-suffixed timestamps).
+
+### Data cleanup — 478 +1h ghost screenings deleted
+
+Ran `scripts/_cleanup-bst-ghost-screenings.ts --apply`. For each `(cinema_id, source_id)` group at Everyman or Picturehouse venues where multiple rows exist with `MAX(datetime) - MIN(datetime) = INTERVAL '1 hour'` exactly, deleted all rows except the one with the minimum datetime (= the BST-correct UTC). Safety guard: the 1-hour-exact constraint prevents touching screenings legitimately rescheduled by the cinema. Post-cleanup verification: 0 remaining BST-signature dupe groups.
+
+By cinema: picturehouse-finsbury-park 49, everyman-barnet 41, picturehouse-crouch-end 41, picturehouse-ealing 32, picturehouse-west-norwood 32, picturehouse-hackney 28, … (full breakdown in commit body).
+
+### `scripts/spot-check-and-fix.ts` + `/spot-check` slash command — iterative data quality loop
+
+New self-contained tool. Each iteration: sample the 100 films with the soonest upcoming screenings, find every HIGH/MEDIUM/LOW data-quality issue, apply every safe auto-fix, repeat until 0 fixes in an iteration (converged) or 10 iterations elapsed.
+
+Safe auto-fixes:
+- Strip programme-strand title prefixes: `DocHouse:`, `LONDON PREMIERE`, `UK PREMIERE`, `Funeral Parade presents`, `Funday:`, `LOCO presents:`, `Lost Reels:`, `LAFS PRESENTS:`, `Crafty Movie Night -`, `Journey Through Irish Cinema:`, `Film Club: X:`.
+- Flip `is_repertory=true` for films with `year < currentYear - 1`.
+- Year UPDATE from TMDB when stored year disagrees (with substring-overlap guard to prevent compounding a wrong-TMDB-linkage bug).
+- Runtime / posterUrl / synopsis / directors / genres re-enrich from TMDB.
+
+Skipped (manual-review surfaced in the final report):
+- Wrong-TMDB linkage (DB title diverges from TMDB title) — auto-swapping IDs is too risky.
+- `year = currentYear` with no TMDB ID — needs TMDB search + confidence guards (the rolling patrol handles this).
+
+First run after PR #483/#484: **10 fixes applied across 3 iterations**, converged. 5 prefix strips (Dracula, Phantoms of July, The Last Spy, Our Land, Ultras, Coup 53), 2 is_repertory flips (Burning Ambition 1989, Pacific Rim 3D 2013), Pacific Rim (3D) year=2026→2013, Wizard of the Kremlin runtime=156→136. Remaining 10 issues are all `year=2026 no TMDB` (opera broadcasts / events) — manual-review by the rolling patrol.
+
+### Slash command
+
+`/spot-check` — invokes the above loop. Lives at `.claude/commands/spot-check.md` (gitignored, local-only by repo convention). Runs in `--apply` mode by default; `report` arg switches to read-only.
+
+### Diagnostic / one-off scripts (committed for traceability)
+
+- `scripts/_spot-check-100.ts` — single-pass version of the loop (the original spot-check).
+- `scripts/_check-everyman-dupes.ts` — booking-URL dedup query that surfaced the original bug.
+- `scripts/_check-hokum.ts` — investigation of a specific film's screenings.
+- `scripts/_diagnose-chain-dupes.ts` — chain-wide dupe-group counter (Everyman, Picturehouse, Curzon).
+- `scripts/_diagnose-everyman-dupes.ts` — inspect a single dupe set's sourceIds.
+- `scripts/_fix-boy-and-the-world.ts` — one-off corrective fix for film `960847a6` (TMDB 302430 "Rumblestrips" → TMDB 223706 *O Menino e o Mundo*).
+- `scripts/_search-boy-and-the-world.ts` — TMDB search used to find the correct ID.
+- `scripts/_inspect-boy-and-world-row.ts` — diagnostic: dump a single film row + its upcoming screenings.
+
+### Boy and the World — TMDB link corrected
+
+Film row `960847a6-d5ec-4ab7-bed5-4b54e93e0464` had `tmdbId=302430` ("Rumblestrips", a 2012 US drama) but the actual film at BFI Southbank is the 2013 Brazilian animation (IMDB `tt2151783`, original title *O Menino e o Mundo*). Correct TMDB ID 223706. Fields refreshed: year 2026→2014, runtime 85→80, directors ["John Adams","Toby Poser"]→["Alê Abreu"], poster URL, synopsis, is_repertory=true.
+
+## Verification
+
+- `npx tsc --noEmit` → 0 errors.
+- `npm run test:run src/scrapers/chains` → 4/4 pass.
+- Post-cleanup dupe-group count: 0 BST-signature dupes remain.
+- Spot-check loop output: 10 fixes applied across 3 iterations; converged with 10 manual-review items remaining.
+
+## Open follow-ups
+
+- Probe the rolling patrol output for any other chain scrapers using `new Date(api.field)`. The pattern is now well-understood; if Vista OCAPI ever changes to TZ-less strings, Curzon would need the same fix.
+- The 10 remaining `year=2026 no TMDB` items are typically opera broadcasts and festival events. Could add an `is_special_event` heuristic when title matches `Met Opera Encore`, `BalletAndOpera`, etc.

--- a/scripts/_check-everyman-dupes.ts
+++ b/scripts/_check-everyman-dupes.ts
@@ -1,0 +1,95 @@
+import { db } from "@/db";
+import { screenings, films, cinemas } from "@/db/schema";
+import { sql, eq, gte, and, inArray } from "drizzle-orm";
+
+async function main() {
+  // Find screenings that share a booking URL within Everyman venues — these
+  // are duplicates. Show their datetime offsets and creation times.
+  const allEverymanCinemas = await db
+    .select({ id: cinemas.id, name: cinemas.name })
+    .from(cinemas)
+    .where(sql`${cinemas.id} LIKE 'everyman%' OR ${cinemas.id} = 'screen-on-the-green'`);
+
+  const ids = allEverymanCinemas.map((c) => c.id);
+  console.log(`Checking ${ids.length} Everyman venues for booking-URL duplicates...\n`);
+
+  const dupes = await db.execute<{
+    booking_url: string;
+    cinema_id: string;
+    n: number;
+    times: string;
+    ids: string;
+    scraped_ats: string;
+  }>(sql`
+    SELECT
+      booking_url,
+      cinema_id,
+      COUNT(*)::int AS n,
+      string_agg(
+        to_char(datetime AT TIME ZONE 'Europe/London', 'YYYY-MM-DD HH24:MI'),
+        ' | ' ORDER BY datetime
+      ) AS times,
+      string_agg(id, ' | ' ORDER BY datetime) AS ids,
+      string_agg(to_char(scraped_at, 'YYYY-MM-DD HH24:MI:SS'), ' | ' ORDER BY datetime) AS scraped_ats
+    FROM screenings
+    WHERE cinema_id = ANY(${sql.raw(`ARRAY['${ids.join("','")}']`)})
+      AND datetime >= NOW()
+      AND booking_url <> ''
+    GROUP BY booking_url, cinema_id
+    HAVING COUNT(*) > 1
+    ORDER BY cinema_id, booking_url
+    LIMIT 40;
+  `);
+
+  const rows = (dupes as unknown as Array<{ booking_url: string; cinema_id: string; n: number; times: string; ids: string; scraped_ats: string }>);
+  console.log(`Found ${rows.length} booking URLs with multiple upcoming screenings:\n`);
+  if (rows.length === 0) {
+    console.log("(none — duplicates are not the dominant pattern. Maybe individual ID-level dupes from a specific run.)");
+  }
+  for (const r of rows.slice(0, 20)) {
+    console.log(`  ${r.cinema_id.padEnd(22)} n=${r.n}  times=${r.times}`);
+    console.log(`    created: ${r.scraped_ats}`);
+    console.log(`    url: ${r.booking_url.slice(0, 90)}...`);
+  }
+
+  // How many total screenings have +1h duplicates at Everyman?
+  const totalDupes = await db.execute<{ total: number }>(sql`
+    SELECT COUNT(*)::int AS total
+    FROM screenings
+    WHERE cinema_id = ANY(${sql.raw(`ARRAY['${ids.join("','")}']`)})
+      AND datetime >= NOW()
+      AND booking_url IN (
+        SELECT booking_url FROM screenings
+        WHERE cinema_id = ANY(${sql.raw(`ARRAY['${ids.join("','")}']`)})
+          AND datetime >= NOW()
+          AND booking_url <> ''
+        GROUP BY booking_url HAVING COUNT(*) > 1
+      );
+  `);
+  const td = totalDupes as unknown as Array<{ total: number }>;
+  console.log(`\nTotal upcoming screenings at Everyman involved in dupes: ${td[0]?.total ?? 0}`);
+
+  // Counter-control: same query for picturehouse
+  const phDupes = await db.execute<{ total: number }>(sql`
+    SELECT COUNT(*)::int AS total
+    FROM screenings s
+    INNER JOIN cinemas c ON c.id = s.cinema_id
+    WHERE c.name LIKE '%Picturehouse%'
+      AND s.datetime >= NOW()
+      AND s.booking_url IN (
+        SELECT booking_url FROM screenings s2
+        INNER JOIN cinemas c2 ON c2.id = s2.cinema_id
+        WHERE c2.name LIKE '%Picturehouse%' AND s2.datetime >= NOW() AND s2.booking_url <> ''
+        GROUP BY booking_url HAVING COUNT(*) > 1
+      );
+  `);
+  const phd = phDupes as unknown as Array<{ total: number }>;
+  console.log(`Control: Picturehouse dupes (same query): ${phd[0]?.total ?? 0}`);
+
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_check-hokum.ts
+++ b/scripts/_check-hokum.ts
@@ -1,0 +1,39 @@
+import { db } from "@/db";
+import { screenings, films, cinemas } from "@/db/schema";
+import { sql, eq, gte, and, ilike } from "drizzle-orm";
+
+async function main() {
+  // All upcoming Hokum screenings, ordered by datetime
+  const rows = await db
+    .select({
+      id: screenings.id,
+      utc: screenings.datetime,
+      london: sql<string>`to_char(${screenings.datetime} AT TIME ZONE 'Europe/London', 'YYYY-MM-DD HH24:MI:SS')`,
+      bookingUrl: screenings.bookingUrl,
+      cinemaName: cinemas.name,
+      cinemaId: screenings.cinemaId,
+      title: films.title,
+    })
+    .from(screenings)
+    .innerJoin(films, eq(screenings.filmId, films.id))
+    .innerJoin(cinemas, eq(screenings.cinemaId, cinemas.id))
+    .where(
+      and(
+        gte(screenings.datetime, new Date()),
+        ilike(films.title, "Hokum%"),
+      ),
+    )
+    .orderBy(screenings.datetime);
+
+  console.log(`All upcoming Hokum screenings (${rows.length}):\n`);
+  for (const r of rows) {
+    console.log(`  ${r.cinemaName.padEnd(28)} ${r.london} London  (${r.utc.toISOString()} UTC)`);
+    console.log(`    booking: ${r.bookingUrl}`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_cleanup-bst-ghost-screenings.ts
+++ b/scripts/_cleanup-bst-ghost-screenings.ts
@@ -1,0 +1,130 @@
+/**
+ * Cleanup script for BST +1h ghost screenings.
+ *
+ * Pattern: same (cinema_id, source_id) appearing multiple times with
+ * datetimes EXACTLY 1 hour apart. The earliest datetime is the correct
+ * one (scraped under London BST → -1h offset applied). Anything later
+ * by exactly 1h is the ghost row from a runtime TZ=UTC scrape.
+ *
+ * The 1-hour-exact constraint is the safety guard: this won't touch
+ * screenings that were legitimately re-scheduled by the cinema (which
+ * tend to differ by minutes or hours other than exactly 60min).
+ *
+ * Usage:
+ *   npx tsx -r tsconfig-paths/register --env-file=.env.local scripts/_cleanup-bst-ghost-screenings.ts            (dry-run)
+ *   npx tsx -r tsconfig-paths/register --env-file=.env.local scripts/_cleanup-bst-ghost-screenings.ts --apply    (apply)
+ */
+
+import { db } from "@/db";
+import { screenings, cinemas } from "@/db/schema";
+import { sql, inArray } from "drizzle-orm";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const mode = apply ? "APPLY" : "DRY-RUN";
+  console.log(`\n=== BST ghost cleanup (${mode}) ===\n`);
+
+  // Identify chain cinema IDs (Everyman + Picturehouse — Curzon is BST-clean)
+  const chainCinemas = await db
+    .select({ id: cinemas.id, name: cinemas.name })
+    .from(cinemas)
+    .where(
+      sql`(LOWER(${cinemas.name}) LIKE '%everyman%' OR LOWER(${cinemas.name}) LIKE '%picturehouse%' OR ${cinemas.id} = 'screen-on-the-green' OR ${cinemas.id} = 'the-ritzy')`,
+    );
+  const cinemaIds = chainCinemas.map((c) => c.id);
+  console.log(`Scope: ${cinemaIds.length} chain cinemas (Everyman + Picturehouse families)`);
+
+  // Find ghost rows: rows with same (cinema_id, source_id) whose datetime
+  // exceeds the MIN within the group by exactly 3600s (= 1h).
+  const ghostRows = await db.execute(sql`
+    WITH groups AS (
+      SELECT
+        cinema_id,
+        source_id,
+        MIN(datetime) AS earliest,
+        MAX(datetime) AS latest,
+        COUNT(*)::int AS n
+      FROM screenings
+      WHERE cinema_id = ANY(${sql.raw(`ARRAY[${cinemaIds.map((id) => `'${id}'`).join(",")}]`)})
+        AND source_id IS NOT NULL
+        AND datetime >= NOW()
+      GROUP BY cinema_id, source_id
+      HAVING COUNT(*) > 1
+        AND EXTRACT(EPOCH FROM (MAX(datetime) - MIN(datetime)))::int = 3600
+    )
+    SELECT s.id, s.cinema_id, s.source_id, s.datetime, s.scraped_at,
+           g.earliest AS keep_datetime
+    FROM screenings s
+    INNER JOIN groups g ON s.cinema_id = g.cinema_id AND s.source_id = g.source_id
+    WHERE s.datetime > g.earliest
+    ORDER BY s.cinema_id, s.source_id, s.datetime;
+  `);
+  const rows = ghostRows as unknown as Array<{
+    id: string;
+    cinema_id: string;
+    source_id: string;
+    datetime: Date;
+    scraped_at: Date;
+    keep_datetime: Date;
+  }>;
+
+  // Tally by cinema
+  const byCinema = new Map<string, number>();
+  for (const r of rows) byCinema.set(r.cinema_id, (byCinema.get(r.cinema_id) ?? 0) + 1);
+
+  console.log(`\nGhost rows to delete: ${rows.length}\n`);
+  console.log("By cinema:");
+  for (const [cid, n] of [...byCinema.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${cid.padEnd(28)} ${n}`);
+  }
+
+  console.log(`\nSample (first 5):`);
+  for (const r of rows.slice(0, 5)) {
+    const keep = new Date(r.keep_datetime).toISOString();
+    const drop = new Date(r.datetime).toISOString();
+    const scraped = new Date(r.scraped_at).toISOString();
+    console.log(`  ${r.cinema_id} src=${r.source_id.slice(0, 40)}…`);
+    console.log(`     keep ${keep}, DROP ${drop}  (scraped ${scraped})`);
+  }
+
+  if (!apply) {
+    console.log(`\n[DRY-RUN] No rows deleted. Re-run with --apply to delete ${rows.length} rows.`);
+    process.exit(0);
+  }
+
+  // Apply
+  console.log(`\n[APPLY] Deleting ${rows.length} rows in batches of 500...`);
+  const idsToDelete = rows.map((r) => r.id);
+  let deleted = 0;
+  while (idsToDelete.length > 0) {
+    const batch = idsToDelete.splice(0, 500);
+    const result = await db.delete(screenings).where(inArray(screenings.id, batch));
+    deleted += batch.length;
+    console.log(`  Deleted ${deleted}/${rows.length}`);
+  }
+  console.log(`\nDone. ${deleted} ghost rows deleted.`);
+
+  // Verify: post-cleanup, the dupe count for these chains should be near zero
+  const remaining = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+    FROM (
+      SELECT cinema_id, source_id
+      FROM screenings
+      WHERE cinema_id = ANY(${sql.raw(`ARRAY[${cinemaIds.map((id) => `'${id}'`).join(",")}]`)})
+        AND source_id IS NOT NULL
+        AND datetime >= NOW()
+      GROUP BY cinema_id, source_id
+      HAVING COUNT(*) > 1
+        AND EXTRACT(EPOCH FROM (MAX(datetime) - MIN(datetime)))::int = 3600
+    ) g;
+  `);
+  const r2 = remaining as unknown as Array<{ n: number }>;
+  console.log(`Remaining BST-signature dupe groups: ${r2[0]?.n ?? 0}`);
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/_diagnose-chain-dupes.ts
+++ b/scripts/_diagnose-chain-dupes.ts
@@ -1,0 +1,46 @@
+import { db } from "@/db";
+import { screenings, cinemas } from "@/db/schema";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // Pattern: same (cinemaId, sourceId) appears multiple times with datetimes
+  // separated by EXACTLY 1 hour. That's the BST-ghost fingerprint.
+  for (const chain of ["everyman", "picturehouse", "curzon"]) {
+    const rows = await db.execute(sql`
+      SELECT
+        s.cinema_id,
+        s.source_id,
+        COUNT(*)::int AS n,
+        MIN(s.datetime) AS earliest,
+        MAX(s.datetime) AS latest,
+        EXTRACT(EPOCH FROM (MAX(s.datetime) - MIN(s.datetime)))::int AS spread_seconds
+      FROM screenings s
+      INNER JOIN cinemas c ON c.id = s.cinema_id
+      WHERE LOWER(c.name) LIKE ${"%" + chain + "%"}
+        AND s.datetime >= NOW()
+        AND s.source_id IS NOT NULL
+      GROUP BY s.cinema_id, s.source_id
+      HAVING COUNT(*) > 1
+    `);
+    const dupes = rows as unknown as Array<{ cinema_id: string; source_id: string; n: number; earliest: Date; latest: Date; spread_seconds: number }>;
+    const oneHourDupes = dupes.filter((d) => Math.abs(d.spread_seconds - 3600) < 60);
+    const otherDupes = dupes.filter((d) => Math.abs(d.spread_seconds - 3600) >= 60);
+    const totalRowsInvolved = dupes.reduce((s, d) => s + d.n, 0);
+    const oneHourRowsInvolved = oneHourDupes.reduce((s, d) => s + d.n, 0);
+    console.log(`\n=== ${chain.toUpperCase()} ===`);
+    console.log(`  Total (cinema,sourceId) duplicate groups: ${dupes.length}`);
+    console.log(`  → with EXACT 1h spread (BST signature):   ${oneHourDupes.length}  (${oneHourRowsInvolved} rows involved)`);
+    console.log(`  → other spread (not BST):                 ${otherDupes.length}`);
+    if (otherDupes.length > 0 && otherDupes.length < 5) {
+      for (const d of otherDupes.slice(0, 3)) {
+        console.log(`     ${d.cinema_id} src=${d.source_id.slice(0, 40)} spread=${d.spread_seconds}s n=${d.n}`);
+      }
+    }
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_diagnose-everyman-dupes.ts
+++ b/scripts/_diagnose-everyman-dupes.ts
@@ -1,0 +1,29 @@
+import { db } from "@/db";
+import { screenings } from "@/db/schema";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // For the duplicate set we saw earlier, show all columns including sourceId.
+  const url = "https://purchase.everymancinema.com/launch/ticketing/4bef1f81-608a-5645-9e87-4614201a3629";
+  const rows = await db
+    .select({
+      id: screenings.id,
+      sourceId: screenings.sourceId,
+      datetime: screenings.datetime,
+      scrapedAt: screenings.scrapedAt,
+      cinemaId: screenings.cinemaId,
+    })
+    .from(screenings)
+    .where(sql`${screenings.bookingUrl} = ${url}`);
+  console.log(`Rows for booking URL …4bef1f81…:`);
+  for (const r of rows) {
+    console.log(`  id=${r.id.slice(0, 8)}  src=${r.sourceId ?? "<null>"}`);
+    console.log(`    datetime=${r.datetime.toISOString()}  scraped=${r.scrapedAt.toISOString()}`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_fix-boy-and-the-world.ts
+++ b/scripts/_fix-boy-and-the-world.ts
@@ -1,0 +1,88 @@
+/**
+ * Fix the Boy and the World (Brazilian 2012 animation, TMDB 226383) film link.
+ * The DB row 960847a6-d5ec-4ab7-bed5-4b54e93e0464 currently has an incorrect
+ * TMDB ID that resolves to a film titled "Rumblestrips".
+ */
+
+import { db } from "@/db";
+import { films } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getTMDBClient } from "@/lib/tmdb";
+
+const FILM_ID = "960847a6-d5ec-4ab7-bed5-4b54e93e0464";
+const CORRECT_TMDB_ID = 223706;
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const tmdb = getTMDBClient();
+
+  // Verify the target TMDB ID actually is Boy and the World
+  const data = await tmdb.getFullFilmData(CORRECT_TMDB_ID);
+  console.log(`TMDB ${CORRECT_TMDB_ID}:`);
+  console.log(`  title:           ${data.details.title}`);
+  console.log(`  original_title:  ${data.details.original_title}`);
+  console.log(`  release_date:    ${data.details.release_date}`);
+  console.log(`  runtime:         ${data.details.runtime}`);
+  console.log(`  directors:       ${data.directors.join(", ")}`);
+
+  const titleOk = data.details.title === "Boy & the World" || data.details.title === "Boy and the World";
+  const origOk = data.details.original_title === "O Menino e o Mundo";
+  if (!titleOk && !origOk) {
+    console.error(`\nTMDB ${CORRECT_TMDB_ID} does NOT match expected film. Aborting.`);
+    process.exit(1);
+  }
+
+  // Read current DB row
+  const [current] = await db.select().from(films).where(eq(films.id, FILM_ID));
+  if (!current) {
+    console.error(`Film ${FILM_ID} not found in DB`);
+    process.exit(1);
+  }
+  console.log(`\nCurrent DB row:`);
+  console.log(`  title:    ${current.title}`);
+  console.log(`  year:     ${current.year}`);
+  console.log(`  tmdb_id:  ${current.tmdbId}`);
+  console.log(`  runtime:  ${current.runtime}`);
+  console.log(`  directors:${JSON.stringify(current.directors)}`);
+
+  const tmdbYear = data.details.release_date ? parseInt(data.details.release_date.slice(0, 4), 10) : null;
+
+  if (!apply) {
+    console.log(`\n[DRY-RUN] Would set:`);
+    console.log(`  tmdb_id   = ${CORRECT_TMDB_ID}`);
+    console.log(`  year      = ${tmdbYear}`);
+    console.log(`  runtime   = ${data.details.runtime}`);
+    console.log(`  directors = ${JSON.stringify(data.directors)}`);
+    console.log(`  poster_url= [from TMDB]`);
+    console.log(`  synopsis  = ${(data.details.overview ?? "").slice(0, 80)}…`);
+    console.log(`  is_repertory = true  (2012 film screening in 2026)`);
+    console.log(`\nRe-run with --apply.`);
+    process.exit(0);
+  }
+
+  const posterUrl = data.details.poster_path
+    ? `https://image.tmdb.org/t/p/w500${data.details.poster_path}`
+    : null;
+
+  await db
+    .update(films)
+    .set({
+      tmdbId: CORRECT_TMDB_ID,
+      year: tmdbYear,
+      runtime: data.details.runtime ?? null,
+      directors: data.directors,
+      posterUrl,
+      synopsis: data.details.overview ?? null,
+      isRepertory: true,
+      updatedAt: new Date(),
+    })
+    .where(eq(films.id, FILM_ID));
+
+  console.log(`\nUpdated ${FILM_ID}.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/_inspect-boy-and-world-row.ts
+++ b/scripts/_inspect-boy-and-world-row.ts
@@ -1,0 +1,40 @@
+import { db } from "@/db";
+import { films, screenings, cinemas } from "@/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { getTMDBClient } from "@/lib/tmdb";
+
+const FILM_ID = "960847a6-d5ec-4ab7-bed5-4b54e93e0464";
+
+async function main() {
+  const [f] = await db.select().from(films).where(eq(films.id, FILM_ID));
+  if (!f) return console.error("Not found");
+  console.log("Current DB row:");
+  console.log(JSON.stringify(f, null, 2));
+
+  const ss = await db
+    .select({
+      datetime: screenings.datetime,
+      cinema: cinemas.name,
+      booking: screenings.bookingUrl,
+    })
+    .from(screenings)
+    .innerJoin(cinemas, eq(screenings.cinemaId, cinemas.id))
+    .where(sql`${screenings.filmId} = ${FILM_ID} AND ${screenings.datetime} >= NOW()`)
+    .orderBy(screenings.datetime)
+    .limit(5);
+  console.log(`\nUpcoming screenings (${ss.length}):`);
+  for (const s of ss) console.log(`  ${s.cinema}  ${s.datetime.toISOString()}  ${s.booking}`);
+
+  if (f.tmdbId) {
+    const tmdb = getTMDBClient();
+    try {
+      const d = await tmdb.getFullFilmData(f.tmdbId);
+      console.log(`\nCurrent TMDB ${f.tmdbId}: title="${d.details.title}", orig="${d.details.original_title}", release=${d.details.release_date}`);
+    } catch (e) {
+      console.log(`\nTMDB ${f.tmdbId} fetch failed: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/_search-boy-and-the-world.ts
+++ b/scripts/_search-boy-and-the-world.ts
@@ -1,0 +1,24 @@
+import { getTMDBClient } from "@/lib/tmdb";
+
+async function main() {
+  const tmdb = getTMDBClient();
+  // The film is the 2013 Brazilian animation "O Menino e o Mundo" /
+  // English "Boy and the World"
+  const results = await tmdb.searchFilms("O Menino e o Mundo", 2013);
+  console.log(`Search results for "O Menino e o Mundo" 2013:`);
+  for (const r of results.results.slice(0, 5)) {
+    console.log(`  TMDB ${r.id}: ${r.title} (orig: ${r.original_title}, ${r.release_date}, popularity ${r.popularity})`);
+  }
+  console.log("---");
+  const results2 = await tmdb.searchFilms("Boy and the World");
+  console.log(`Search results for "Boy and the World":`);
+  for (const r of results2.results.slice(0, 5)) {
+    console.log(`  TMDB ${r.id}: ${r.title} (orig: ${r.original_title}, ${r.release_date}, popularity ${r.popularity})`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_spot-check-100.ts
+++ b/scripts/_spot-check-100.ts
@@ -1,0 +1,368 @@
+/**
+ * 100-film spot check. Pulls the 100 films with the soonest upcoming
+ * screenings (what users see first on the calendar) and verifies every
+ * field. Compares against TMDB where a TMDB ID is set. Reports findings;
+ * makes no mutations.
+ *
+ * Usage:
+ *   npx tsx -r tsconfig-paths/register --env-file=.env.local scripts/_spot-check-100.ts
+ */
+
+import { db } from "@/db";
+import { films } from "@/db/schema/films";
+import { screenings } from "@/db/schema/screenings";
+import { cinemas } from "@/db/schema/cinemas";
+import { sql, eq, gte, and, inArray } from "drizzle-orm";
+import { getTMDBClient } from "@/lib/tmdb";
+
+interface FilmRow {
+  id: string;
+  title: string;
+  year: number | null;
+  runtime: number | null;
+  tmdbId: number | null;
+  posterUrl: string | null;
+  synopsis: string | null;
+  directors: unknown;
+  cast: unknown;
+  genres: unknown;
+  letterboxdRating: number | null;
+  isRepertory: boolean;
+  nextScreening: Date;
+  cinemaName: string;
+}
+
+interface Issue {
+  filmId: string;
+  title: string;
+  field: string;
+  severity: "high" | "medium" | "low";
+  detail: string;
+}
+
+const PROGRAMME_STRAND_PATTERNS = [
+  /^DocHouse:\s/i,
+  /^Funeral Parade presents/i,
+  /^Film Club:/i,
+  /^LOCO presents:/i,
+  /^Funday[: ]/i,
+  /^RIO FOREVER\s*[xX×]/i,
+  /^Lost Reels[: ]/i,
+  /^LAFS PRESENTS:/i,
+  /^UK PREMIERE\s/i,
+  /^LONDON PREMIERE\s/i,
+  /^Crafty Movie Night\s/i,
+  /^Journey Through Irish Cinema:/i,
+  /^Film Society \d+/i,
+  /\bp\d+,/, // "Funday Workshop: Arco p52,"
+];
+
+const NON_FILM_KEYWORDS = [
+  "Q&A",
+  "Q +A",
+  "Workshop",
+  "Discussion",
+  "Talk",
+  "Lecture",
+  "Festival",
+  "Society",
+  "Writers Group",
+];
+
+function getStr(v: unknown, idx?: number): string | null {
+  if (Array.isArray(v)) {
+    if (idx !== undefined) return typeof v[idx] === "string" ? (v[idx] as string) : null;
+    return v.length > 0 && typeof v[0] === "string" ? (v[0] as string) : null;
+  }
+  return null;
+}
+
+function arrayLen(v: unknown): number {
+  if (Array.isArray(v)) return v.length;
+  return 0;
+}
+
+function isStringArray(v: unknown): boolean {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+async function main() {
+  const t0 = Date.now();
+  const now = new Date();
+
+  // Pull the 100 films whose next upcoming screening is soonest.
+  // This is exactly what a user sees when they open the calendar tonight.
+  const rows = await db.execute(sql`
+    WITH first_screenings AS (
+      SELECT
+        s.film_id,
+        MIN(s.datetime) AS next_screening,
+        (
+          SELECT c.name FROM ${cinemas} c
+          WHERE c.id = (
+            SELECT s2.cinema_id FROM ${screenings} s2
+            WHERE s2.film_id = s.film_id AND s2.datetime >= NOW()
+            ORDER BY s2.datetime ASC LIMIT 1
+          )
+        ) AS cinema_name
+      FROM ${screenings} s
+      WHERE s.datetime >= NOW()
+      GROUP BY s.film_id
+    )
+    SELECT
+      f.id, f.title, f.year, f.runtime, f.tmdb_id AS "tmdbId",
+      f.poster_url AS "posterUrl", f.synopsis,
+      f.directors, f."cast", f.genres,
+      f.letterboxd_rating AS "letterboxdRating",
+      f.is_repertory AS "isRepertory",
+      fs.next_screening AS "nextScreening",
+      fs.cinema_name AS "cinemaName"
+    FROM ${films} f
+    INNER JOIN first_screenings fs ON fs.film_id = f.id
+    ORDER BY fs.next_screening ASC
+    LIMIT 100;
+  `);
+
+  const films100 = rows as unknown as FilmRow[];
+  console.log(`Sampled ${films100.length} films (next-screening ASC). Checking…\n`);
+
+  const issues: Issue[] = [];
+  const filmsWithTmdb = films100.filter((f) => f.tmdbId !== null);
+
+  // 1. Heuristic checks (no API calls)
+  for (const f of films100) {
+    // Title — programme-strand prefixes
+    for (const pat of PROGRAMME_STRAND_PATTERNS) {
+      if (pat.test(f.title)) {
+        issues.push({
+          filmId: f.id,
+          title: f.title,
+          field: "title",
+          severity: "high",
+          detail: `Programme-strand prefix detected (regex: ${pat.source})`,
+        });
+        break;
+      }
+    }
+    // Title — all-caps that probably isn't intentional
+    if (
+      f.title.length > 10 &&
+      f.title === f.title.toUpperCase() &&
+      !/^\d|^[A-Z]\.|^[IVX]+$/.test(f.title)
+    ) {
+      issues.push({
+        filmId: f.id,
+        title: f.title,
+        field: "title",
+        severity: "medium",
+        detail: "Stored in all-caps (likely scraper preserved cinema's display casing)",
+      });
+    }
+    // Title — embedded HTML entities
+    if (/&(amp|lt|gt|quot|apos|nbsp|#\d+|#x[0-9a-f]+);/i.test(f.title)) {
+      issues.push({
+        filmId: f.id,
+        title: f.title,
+        field: "title",
+        severity: "high",
+        detail: "Unescaped HTML entity in title",
+      });
+    }
+    // Year — likely screening-year contamination
+    if (f.year === 2026 && !f.tmdbId) {
+      issues.push({
+        filmId: f.id,
+        title: f.title,
+        field: "year",
+        severity: "medium",
+        detail: "Year is 2026 with no TMDB ID — likely the scraper picked up the screening date, not the film's release year",
+      });
+    }
+    // Cast — string-encoded jsonb (the cycle-15 bug)
+    if (f.cast !== null && typeof f.cast === "string") {
+      issues.push({
+        filmId: f.id,
+        title: f.title,
+        field: "cast",
+        severity: "high",
+        detail: "cast stored as JSON-encoded STRING instead of jsonb array",
+      });
+    }
+    // Directors — same shape check
+    if (f.directors !== null && typeof f.directors === "string") {
+      issues.push({
+        filmId: f.id,
+        title: f.title,
+        field: "directors",
+        severity: "high",
+        detail: "directors stored as JSON-encoded STRING instead of jsonb array",
+      });
+    }
+    // Missing critical fields for a film with a TMDB ID (TMDB should have populated these)
+    if (f.tmdbId) {
+      if (!f.posterUrl) issues.push({ filmId: f.id, title: f.title, field: "posterUrl", severity: "medium", detail: "No poster despite having TMDB ID" });
+      if (!f.synopsis || f.synopsis.length < 30) issues.push({ filmId: f.id, title: f.title, field: "synopsis", severity: "medium", detail: "Missing or too-short synopsis despite TMDB ID" });
+      if (arrayLen(f.directors) === 0) issues.push({ filmId: f.id, title: f.title, field: "directors", severity: "medium", detail: "Empty directors despite TMDB ID" });
+      if (arrayLen(f.genres) === 0) issues.push({ filmId: f.id, title: f.title, field: "genres", severity: "low", detail: "Empty genres despite TMDB ID" });
+      if (!f.year) issues.push({ filmId: f.id, title: f.title, field: "year", severity: "medium", detail: "No year despite TMDB ID" });
+      if (!f.runtime || f.runtime < 30) issues.push({ filmId: f.id, title: f.title, field: "runtime", severity: "low", detail: `Runtime suspicious (${f.runtime})` });
+    }
+    // Letterboxd rating range
+    if (f.letterboxdRating !== null && (f.letterboxdRating < 0 || f.letterboxdRating > 5)) {
+      issues.push({ filmId: f.id, title: f.title, field: "letterboxdRating", severity: "medium", detail: `Out of 0-5 range: ${f.letterboxdRating}` });
+    }
+    // Repertory flag heuristic
+    const yearNum = typeof f.year === "number" ? f.year : null;
+    if (yearNum !== null && yearNum < 2024 && !f.isRepertory) {
+      issues.push({ filmId: f.id, title: f.title, field: "isRepertory", severity: "low", detail: `Film year ${yearNum} but is_repertory=false` });
+    }
+  }
+
+  // 2. TMDB cross-check (only for films with tmdbId)
+  console.log(`Fetching ${filmsWithTmdb.length} TMDB records to cross-check…`);
+  const tmdb = getTMDBClient();
+  let tmdbErrors = 0;
+  for (const f of filmsWithTmdb) {
+    try {
+      const data = await tmdb.getFullFilmData(f.tmdbId!);
+      const tmdbYear = data.details.release_date ? parseInt(data.details.release_date.slice(0, 4), 10) : null;
+      const tmdbRuntime = data.details.runtime;
+      const tmdbDirectorNames = data.directors;
+
+      // Year mismatch
+      if (f.year !== null && tmdbYear !== null && Math.abs(f.year - tmdbYear) >= 1) {
+        issues.push({
+          filmId: f.id,
+          title: f.title,
+          field: "year",
+          severity: f.year === 2026 ? "high" : "medium",
+          detail: `DB year=${f.year} vs TMDB year=${tmdbYear}`,
+        });
+      }
+      // Runtime mismatch (TMDB is authoritative, off by 5+ min is suspicious)
+      if (f.runtime !== null && tmdbRuntime && Math.abs(f.runtime - tmdbRuntime) >= 5) {
+        issues.push({
+          filmId: f.id,
+          title: f.title,
+          field: "runtime",
+          severity: "low",
+          detail: `DB runtime=${f.runtime} vs TMDB=${tmdbRuntime}`,
+        });
+      }
+      // Directors mismatch — if both populated and lists disagree
+      if (Array.isArray(f.directors) && f.directors.length > 0 && tmdbDirectorNames.length > 0) {
+        const dbDirs = new Set(
+          (f.directors as string[]).map((d) => d.toLowerCase().trim()),
+        );
+        const tmdbDirs = new Set(tmdbDirectorNames.map((d) => d.toLowerCase().trim()));
+        const overlap = [...dbDirs].some((d) => tmdbDirs.has(d));
+        if (!overlap) {
+          issues.push({
+            filmId: f.id,
+            title: f.title,
+            field: "directors",
+            severity: "high",
+            detail: `DB directors=[${[...dbDirs].join(", ")}] do not overlap with TMDB=[${tmdbDirectorNames.join(", ")}]`,
+          });
+        }
+      }
+      // Title sanity — if DB title is wildly different from TMDB, flag (but allow prefix matches)
+      const dbTitle = f.title.toLowerCase().replace(/[^a-z0-9]/g, "");
+      const tmdbTitle = (data.details.title || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+      if (dbTitle && tmdbTitle && !dbTitle.includes(tmdbTitle) && !tmdbTitle.includes(dbTitle)) {
+        const origDbTitle = (data.details.original_title || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+        if (!origDbTitle || !dbTitle.includes(origDbTitle)) {
+          issues.push({
+            filmId: f.id,
+            title: f.title,
+            field: "title",
+            severity: "medium",
+            detail: `DB title "${f.title}" diverges from TMDB title "${data.details.title}"`,
+          });
+        }
+      }
+    } catch (err) {
+      tmdbErrors++;
+      issues.push({
+        filmId: f.id,
+        title: f.title,
+        field: "tmdbId",
+        severity: "low",
+        detail: `TMDB fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  // 3. Time-correctness check: any of the 100 films' screenings in 00:00-09:59 London window?
+  const filmIds = films100.map((f) => f.id);
+  const suspiciousTimes = await db
+    .select({
+      filmId: screenings.filmId,
+      datetime: screenings.datetime,
+      londonHour: sql<number>`EXTRACT(HOUR FROM ${screenings.datetime} AT TIME ZONE 'Europe/London')::int`,
+      cinemaId: screenings.cinemaId,
+    })
+    .from(screenings)
+    .where(
+      and(
+        gte(screenings.datetime, now),
+        inArray(screenings.filmId, filmIds),
+        sql`EXTRACT(HOUR FROM ${screenings.datetime} AT TIME ZONE 'Europe/London') < 10`,
+      ),
+    );
+  const titleById = new Map(films100.map((f) => [f.id, f.title]));
+  for (const r of suspiciousTimes) {
+    issues.push({
+      filmId: r.filmId,
+      title: titleById.get(r.filmId) ?? "?",
+      field: "screening.datetime",
+      severity: "high",
+      detail: `Screening at ${r.datetime.toISOString()} → ${String(r.londonHour).padStart(2, "0")}:xx London (${r.cinemaId})`,
+    });
+  }
+
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+
+  // 4. Report
+  const bySev = { high: 0, medium: 0, low: 0 };
+  const byField = new Map<string, number>();
+  for (const i of issues) {
+    bySev[i.severity]++;
+    byField.set(i.field, (byField.get(i.field) ?? 0) + 1);
+  }
+
+  console.log(`\n${"=".repeat(78)}`);
+  console.log(`100-film spot-check complete in ${elapsed}s. ${tmdbErrors} TMDB fetch errors.`);
+  console.log("=".repeat(78));
+  console.log(`\nIssues: ${issues.length} total — HIGH=${bySev.high}, MED=${bySev.medium}, LOW=${bySev.low}`);
+  console.log(`\nBy field:`);
+  for (const [field, n] of [...byField.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${field.padEnd(28)} ${n}`);
+  }
+
+  console.log(`\n${"-".repeat(78)}\nHIGH severity (${bySev.high}):\n${"-".repeat(78)}`);
+  for (const i of issues.filter((i) => i.severity === "high")) {
+    console.log(`  [${i.field}] ${i.title} (${i.filmId.slice(0, 8)})`);
+    console.log(`    ${i.detail}`);
+  }
+
+  console.log(`\n${"-".repeat(78)}\nMEDIUM severity (${bySev.medium}):\n${"-".repeat(78)}`);
+  for (const i of issues.filter((i) => i.severity === "medium")) {
+    console.log(`  [${i.field}] ${i.title} (${i.filmId.slice(0, 8)})`);
+    console.log(`    ${i.detail}`);
+  }
+
+  console.log(`\n${"-".repeat(78)}\nLOW severity (${bySev.low}):\n${"-".repeat(78)}`);
+  for (const i of issues.filter((i) => i.severity === "low")) {
+    console.log(`  [${i.field}] ${i.title} (${i.filmId.slice(0, 8)})`);
+    console.log(`    ${i.detail}`);
+  }
+
+  console.log(`\n${"=".repeat(78)}\nClean films (no issues): ${films100.filter((f) => !issues.some((i) => i.filmId === f.id)).length} / ${films100.length}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/spot-check-and-fix.ts
+++ b/scripts/spot-check-and-fix.ts
@@ -1,0 +1,312 @@
+/**
+ * Iterative 100-film spot-check + auto-fix loop.
+ *
+ * Sampling: the 100 films with the soonest upcoming screening (what users
+ * see first on the calendar). Each iteration:
+ *   1. Scan all 100 for HIGH/MEDIUM/LOW data-quality issues.
+ *   2. Apply every safe auto-fix.
+ *   3. Re-sample (the soonest 100 may have shifted as time passes; in a
+ *      single run within seconds the set is stable).
+ *   4. Stop when no fixes were applied in the last iteration OR after
+ *      MAX_ITERATIONS to bound runtime.
+ *
+ * Safe auto-fixes:
+ *   - is_repertory flip when stored year < (current_year - 1) and false
+ *   - year UPDATE when TMDB ID is set and TMDB release year disagrees
+ *   - runtime UPDATE when TMDB ID is set and runtime differs by ≥5min
+ *   - Re-enrich missing posterUrl / synopsis / directors / genres when
+ *     TMDB ID is set
+ *   - Strip programme-strand title prefixes (DocHouse:, LONDON PREMIERE,
+ *     etc.). The dedup pass picks up resulting canonical-name films on its
+ *     next cycle.
+ *
+ * Skipped (manual review):
+ *   - Wrong-TMDB linkage (title-vs-TMDB mismatch) — too risky to swap IDs
+ *     without manual verification.
+ *   - year=2026 with no TMDB ID — needs TMDB search + match; the rolling
+ *     patrol does this with its blocklist guardrails.
+ *
+ * Usage:
+ *   npx tsx -r tsconfig-paths/register --env-file=.env.local scripts/spot-check-and-fix.ts            (report only)
+ *   npx tsx -r tsconfig-paths/register --env-file=.env.local scripts/spot-check-and-fix.ts --apply    (auto-fix)
+ */
+
+import { db } from "@/db";
+import { films } from "@/db/schema/films";
+import { screenings } from "@/db/schema/screenings";
+import { cinemas } from "@/db/schema/cinemas";
+import { sql, eq, gte, and, inArray } from "drizzle-orm";
+import { getTMDBClient } from "@/lib/tmdb";
+
+const SAMPLE_SIZE = 100;
+const MAX_ITERATIONS = 10;
+const CURRENT_YEAR = new Date().getFullYear();
+
+const PROGRAMME_STRAND_PREFIXES: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /^DocHouse:\s+/i, replacement: "" },
+  { pattern: /^Funeral Parade presents\s+["']?/i, replacement: "" },
+  { pattern: /^LOCO presents:\s+/i, replacement: "" },
+  { pattern: /^Funday:\s+/i, replacement: "" },
+  { pattern: /^Lost Reels:\s+/i, replacement: "" },
+  { pattern: /^LAFS PRESENTS:\s+/i, replacement: "" },
+  { pattern: /^UK PREMIERE\s+/i, replacement: "" },
+  { pattern: /^LONDON PREMIERE\s+/i, replacement: "" },
+  { pattern: /^Crafty Movie Night\s*[-–]\s*/i, replacement: "" },
+  { pattern: /^Journey Through Irish Cinema:\s+/i, replacement: "" },
+  // "Film Club: Jewish Culture Month: Shiva Baby" → "Shiva Baby"
+  { pattern: /^Film Club:[^:]+:\s+/i, replacement: "" },
+];
+
+interface FilmRow {
+  id: string;
+  title: string;
+  year: number | null;
+  runtime: number | null;
+  tmdbId: number | null;
+  posterUrl: string | null;
+  synopsis: string | null;
+  directors: unknown;
+  genres: unknown;
+  isRepertory: boolean;
+}
+
+interface IssueCounts {
+  high: number;
+  medium: number;
+  low: number;
+  total: number;
+  byField: Map<string, number>;
+}
+
+async function sample100(): Promise<FilmRow[]> {
+  const rows = await db.execute(sql`
+    WITH first_screenings AS (
+      SELECT s.film_id, MIN(s.datetime) AS next_screening
+      FROM screenings s
+      WHERE s.datetime >= NOW()
+      GROUP BY s.film_id
+    )
+    SELECT
+      f.id, f.title, f.year, f.runtime, f.tmdb_id AS "tmdbId",
+      f.poster_url AS "posterUrl", f.synopsis,
+      f.directors, f.genres, f.is_repertory AS "isRepertory"
+    FROM ${films} f
+    INNER JOIN first_screenings fs ON fs.film_id = f.id
+    ORDER BY fs.next_screening ASC
+    LIMIT ${SAMPLE_SIZE};
+  `);
+  return rows as unknown as FilmRow[];
+}
+
+function arrayLen(v: unknown): number {
+  return Array.isArray(v) ? v.length : 0;
+}
+
+interface FixRecord {
+  filmId: string;
+  title: string;
+  fixType: string;
+  detail: string;
+}
+
+async function runIteration(iteration: number, apply: boolean): Promise<{ issues: IssueCounts; fixes: FixRecord[] }> {
+  const sample = await sample100();
+  console.log(`\n--- Iteration ${iteration}: scanning ${sample.length} films ---`);
+
+  const counts: IssueCounts = { high: 0, medium: 0, low: 0, total: 0, byField: new Map() };
+  const fixes: FixRecord[] = [];
+  const tmdb = getTMDBClient();
+
+  for (const f of sample) {
+    // 1. Programme-strand prefix → strip
+    for (const { pattern, replacement } of PROGRAMME_STRAND_PREFIXES) {
+      if (pattern.test(f.title)) {
+        const newTitle = f.title.replace(pattern, replacement).trim();
+        if (newTitle.length > 0 && newTitle !== f.title) {
+          counts.high++;
+          counts.total++;
+          counts.byField.set("title", (counts.byField.get("title") ?? 0) + 1);
+          if (apply) {
+            await db.update(films).set({ title: newTitle, updatedAt: new Date() }).where(eq(films.id, f.id));
+            fixes.push({ filmId: f.id, title: f.title, fixType: "strip-prefix", detail: `"${f.title}" → "${newTitle}"` });
+          }
+        }
+        break;
+      }
+    }
+
+    // 2. is_repertory flip: year < (currentYear - 1) and currently false
+    if (f.year !== null && f.year < CURRENT_YEAR - 1 && !f.isRepertory) {
+      counts.low++;
+      counts.total++;
+      counts.byField.set("isRepertory", (counts.byField.get("isRepertory") ?? 0) + 1);
+      if (apply) {
+        await db.update(films).set({ isRepertory: true, updatedAt: new Date() }).where(eq(films.id, f.id));
+        fixes.push({ filmId: f.id, title: f.title, fixType: "is-repertory", detail: `${f.year} → is_repertory=true` });
+      }
+    }
+
+    // 3. TMDB cross-check (only if TMDB ID set)
+    if (f.tmdbId) {
+      let tmdbData;
+      try {
+        tmdbData = await tmdb.getFullFilmData(f.tmdbId);
+      } catch {
+        // TMDB fetch failed (404 typically) — flag as low, skip auto-fix
+        counts.low++;
+        counts.total++;
+        counts.byField.set("tmdbFetch", (counts.byField.get("tmdbFetch") ?? 0) + 1);
+        continue;
+      }
+      const tmdbYear = tmdbData.details.release_date ? parseInt(tmdbData.details.release_date.slice(0, 4), 10) : null;
+      const tmdbRuntime = tmdbData.details.runtime;
+      const updates: Partial<typeof films.$inferInsert> = {};
+
+      // 3a. Year mismatch
+      if (tmdbYear !== null && (f.year === null || Math.abs(f.year - tmdbYear) >= 1)) {
+        counts[f.year === 2026 ? "high" : "medium"]++;
+        counts.total++;
+        counts.byField.set("year", (counts.byField.get("year") ?? 0) + 1);
+        // Title sanity: only update year if the TMDB title strongly matches the DB title.
+        // Guards against fixing the year of a wrong-TMDB linkage (would compound the bug).
+        // "Strong": substring overlap ≥ 80% of the shorter title — rejects "The Bird"
+        // matching "The Birdcage" but still accepts "Boy and the World" ↔ "Boy & the World".
+        const dbN = f.title.toLowerCase().replace(/[^a-z0-9]/g, "");
+        const tmdbTitleN = (tmdbData.details.title || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+        const tmdbOrigN = (tmdbData.details.original_title || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+        const strongMatch = (a: string, b: string): boolean => {
+          if (!a || !b) return false;
+          if (a === b) return true;
+          const short = a.length <= b.length ? a : b;
+          const long = a.length <= b.length ? b : a;
+          if (!long.includes(short)) return false;
+          return short.length / long.length >= 0.8;
+        };
+        const looksLikeMatch = strongMatch(dbN, tmdbTitleN) || strongMatch(dbN, tmdbOrigN);
+        if (looksLikeMatch) updates.year = tmdbYear;
+      }
+
+      // 3b. Runtime mismatch (≥5min)
+      if (f.runtime !== null && tmdbRuntime && Math.abs(f.runtime - tmdbRuntime) >= 5) {
+        counts.low++;
+        counts.total++;
+        counts.byField.set("runtime", (counts.byField.get("runtime") ?? 0) + 1);
+        updates.runtime = tmdbRuntime;
+      }
+
+      // 3c. Missing posterUrl
+      if (!f.posterUrl && tmdbData.details.poster_path) {
+        counts.medium++;
+        counts.total++;
+        counts.byField.set("posterUrl", (counts.byField.get("posterUrl") ?? 0) + 1);
+        updates.posterUrl = `https://image.tmdb.org/t/p/w500${tmdbData.details.poster_path}`;
+      }
+
+      // 3d. Missing synopsis
+      if ((!f.synopsis || f.synopsis.length < 30) && tmdbData.details.overview) {
+        counts.medium++;
+        counts.total++;
+        counts.byField.set("synopsis", (counts.byField.get("synopsis") ?? 0) + 1);
+        updates.synopsis = tmdbData.details.overview;
+      }
+
+      // 3e. Missing directors
+      if (arrayLen(f.directors) === 0 && tmdbData.directors.length > 0) {
+        counts.medium++;
+        counts.total++;
+        counts.byField.set("directors", (counts.byField.get("directors") ?? 0) + 1);
+        updates.directors = tmdbData.directors;
+      }
+
+      // 3f. Missing genres
+      if (arrayLen(f.genres) === 0 && tmdbData.details.genres && tmdbData.details.genres.length > 0) {
+        counts.low++;
+        counts.total++;
+        counts.byField.set("genres", (counts.byField.get("genres") ?? 0) + 1);
+        updates.genres = tmdbData.details.genres.map((g: { name: string }) => g.name);
+      }
+
+      if (apply && Object.keys(updates).length > 0) {
+        await db.update(films).set({ ...updates, updatedAt: new Date() }).where(eq(films.id, f.id));
+        fixes.push({ filmId: f.id, title: f.title, fixType: "tmdb-enrich", detail: Object.keys(updates).join(",") });
+      }
+    } else {
+      // 4. No TMDB ID — flag year=current_year as a heuristic for screening-year contamination
+      if (f.year === CURRENT_YEAR) {
+        counts.medium++;
+        counts.total++;
+        counts.byField.set("year-no-tmdb", (counts.byField.get("year-no-tmdb") ?? 0) + 1);
+      }
+    }
+
+    // 5. BST screening check (any screening in 00:00-09:59 London)
+    const odd = await db.execute(sql`
+      SELECT COUNT(*)::int AS n FROM screenings
+      WHERE film_id = ${f.id}
+        AND datetime >= NOW()
+        AND EXTRACT(HOUR FROM datetime AT TIME ZONE 'Europe/London') < 10
+    `);
+    const o = odd as unknown as Array<{ n: number }>;
+    if (o[0]?.n > 0) {
+      counts.high++;
+      counts.total++;
+      counts.byField.set("screening.datetime", (counts.byField.get("screening.datetime") ?? 0) + 1);
+    }
+  }
+
+  console.log(`  Issues: ${counts.total} (HIGH=${counts.high}, MED=${counts.medium}, LOW=${counts.low})`);
+  console.log(`  Fixes applied: ${fixes.length}`);
+  for (const [field, n] of [...counts.byField.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${field.padEnd(24)} ${n}`);
+  }
+  return { issues: counts, fixes };
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  console.log(`\n=== Spot-check loop (${apply ? "APPLY" : "REPORT-ONLY"}) ===`);
+
+  let iter = 1;
+  let totalFixes = 0;
+  const allFixes: FixRecord[] = [];
+  let lastIssueTotal = -1;
+
+  while (iter <= MAX_ITERATIONS) {
+    const { issues, fixes } = await runIteration(iter, apply);
+    totalFixes += fixes.length;
+    allFixes.push(...fixes);
+
+    if (!apply) {
+      console.log(`\n[REPORT-ONLY] Re-run with --apply to fix issues.`);
+      break;
+    }
+    if (fixes.length === 0) {
+      console.log(`\nConverged at iteration ${iter} (0 fixes applied). Remaining ${issues.total} issues are manual-review.`);
+      break;
+    }
+    if (issues.total === lastIssueTotal) {
+      console.log(`\nNo new progress at iteration ${iter}. Stopping.`);
+      break;
+    }
+    lastIssueTotal = issues.total;
+    iter++;
+  }
+
+  console.log(`\n=== Summary ===`);
+  console.log(`  Iterations: ${iter}`);
+  console.log(`  Total fixes applied: ${totalFixes}`);
+  if (allFixes.length > 0 && allFixes.length <= 50) {
+    console.log(`  Fix log:`);
+    for (const f of allFixes) console.log(`    [${f.fixType}] ${f.title} → ${f.detail}`);
+  } else if (allFixes.length > 50) {
+    console.log(`  Fix log (first 30):`);
+    for (const f of allFixes.slice(0, 30)) console.log(`    [${f.fixType}] ${f.title} → ${f.detail}`);
+    console.log(`    ... and ${allFixes.length - 30} more`);
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/scrapers/chains/picturehouse.ts
+++ b/src/scrapers/chains/picturehouse.ts
@@ -12,6 +12,7 @@
 
 import type { ChainConfig, VenueConfig, RawScreening, ChainScraper } from "../types";
 import { CHROME_USER_AGENT } from "../constants";
+import { parseUKLocalDateTime } from "../utils/date-parser";
 
 // ============================================================================
 // Picturehouse Venue Configurations
@@ -251,8 +252,12 @@ export class PicturehouseScraper implements ChainScraper {
 
     for (const movie of data.movies) {
       for (const showTime of movie.show_times) {
-        // Parse datetime from ISO format Showtime field
-        const datetime = new Date(showTime.Showtime);
+        // showTime.Showtime is a TZ-less ISO string in UK local time
+        // (e.g. "2026-05-17T15:30:00"). `new Date(tzlessStr)` interprets the
+        // string in the runtime TZ — under TZ=UTC (cron, CI) that silently
+        // adds 1h during BST. parseUKLocalDateTime treats the string as UK
+        // local time explicitly and applies the BST offset.
+        const datetime = parseUKLocalDateTime(showTime.Showtime);
         if (isNaN(datetime.getTime())) continue;
 
         // Skip sold out screenings (optional - might want to show them)

--- a/tasks/spot-check-2026-05-11.md
+++ b/tasks/spot-check-2026-05-11.md
@@ -1,0 +1,80 @@
+# 100-Film Spot Check — 2026-05-11
+
+## Method
+
+- Sampled the 100 films with the soonest upcoming screening (`MIN(datetime) WHERE datetime >= NOW()`, ordered ASC). These are the films users see first on the calendar.
+- For each: read every DB field; cross-referenced TMDB (66/100 had a TMDB ID); checked screening time correctness for BST drift.
+- Script: `scripts/_spot-check-100.ts`. Read-only — no DB mutations.
+
+## Headline
+
+- **79 of 100 films are clean.**
+- **28 issues across 21 films** — 9 HIGH, 15 MEDIUM, 4 LOW.
+- **One major systemic bug discovered**: Everyman chain scraper has a BST timezone bug, producing 348 +1h ghost screenings in the DB (PR #484 fixes the code; cleanup still pending).
+
+## Issues by category
+
+### 1. BST off-by-one-hour at Everyman — SYSTEMIC (PR #484)
+
+Two `Hokum` screenings at Everyman Broadgate flagged in the 00:00–09:59 London window. Tracing booking URLs revealed:
+
+- Same booking URL stored TWICE — once at the correct evening time (scraped tonight under London TZ), once at +1h (scraped overnight at ~03:01 UTC under `TZ=UTC`).
+- Bug at `src/scrapers/chains/everyman.ts:458`: `new Date(showtime.startsAt)` interprets a TZ-less ISO string in the runtime TZ. Under UTC cron during BST → +1h ghost. Verified by direct API probe: API returns `"2026-05-12T11:15:00"` (no Z, no offset).
+- **Repo-wide query**: 348 upcoming Everyman screenings involved in duplicate sets across all 15 Everyman venues. Picturehouse and Peckhamplex do NOT exhibit this pattern in the same dataset.
+- Code fix: PR #484 (replaces with `parseUKLocalDateTime`).
+- **Data fix: not done.** Destructive (348 row deletes). Awaiting explicit approval. Pattern: same `(cinema_id, booking_url)` with two `datetime` values exactly 1h apart → drop the later UTC one.
+
+### 2. Programme-strand prefix titles — HIGH (5 films)
+
+The scraper preserved cinema-side programme prefixes in the canonical title, creating duplicate film records.
+
+| Film ID | Stored title | Should be |
+|---|---|---|
+| `c80431de` | `LONDON PREMIERE Dracula` | Dracula (needs TMDB pick — see patrol-2026-05-07-2022.md note) |
+| `43478234` | `UK PREMIERE Phantoms of July` | Phantoms of July |
+| `a6ec7b91` | `DocHouse: The Last Spy` | The Last Spy |
+| `26f1c171` | `DocHouse: Our Land` | Our Land |
+| `bef92830` | `DocHouse: Ultras` | Ultras (TMDB 668195) — patrol fixed this 2026-05-07 then it reappeared. Triple-confirmed Curzon scraper churn. |
+
+These will be caught by the next patrol run alphabetically. Not an action item from this audit.
+
+### 3. Year contamination — HIGH (2 TMDB-verified) + MEDIUM (10)
+
+Scraper filled `year` with the screening year (2026) rather than the film's actual release year.
+
+**TMDB-confirmed wrong** (HIGH):
+- `960847a6` Boy and the World — DB year=2026, TMDB=2012
+- `8cc63426` Pacific Rim (3D) — DB year=2026, TMDB=2013
+
+**Year=2026 no TMDB** (MEDIUM — opera broadcasts and events that need TMDB matching):
+- 3× Eugene Onegin (opera variants)
+- Ultras (already merged in patrol but new orphan)
+- Our Land, The Last Spy, DocHouse variants
+- An Introduction to Brazil on Film
+- Rose of Nevada
+- Chasing Utopia (has TMDB ID but no year populated — enrichment didn't write)
+
+### 4. Wrong TMDB link — MEDIUM (1)
+
+- `960847a6` Boy and the World — DB title matches "Boy and the World" (2012 Brazilian animation, original title *O Menino e o Mundo*, TMDB 226383). DB TMDB lookup returned title `"Rumblestrips"`. The DB has the wrong TMDB ID attached.
+
+### 5. Other field issues — LOW (4) / MEDIUM (3)
+
+- `b9aca07c` Burning Ambition (1989) — `is_repertory=false` for a 1989 film
+- `90bfb662` Superworm — runtime=25 min (likely a short — OK if it's a short film)
+- `8c4142f3` Primavera — runtime=10 min (likely a short)
+- `03507811` The Wizard of the Kremlin — DB runtime=156 vs TMDB=136
+- `50a5166e` Chasing Utopia — has TMDB ID but no poster, no directors, no year (enrichment didn't write or TMDB record is sparse)
+
+## Proposed remediations (require approval)
+
+1. **Delete the 348 Everyman ghost screenings.** Idempotent SQL: for each `(cinema_id, booking_url)` with exactly 2 rows whose datetimes are 1h apart, delete the row with the later UTC datetime. Dry-run first. ~5-line script.
+2. **Re-investigate `960847a6` Boy and the World TMDB link.** Look up TMDB 226383 (the actual *Boy and the World* / *O Menino e o Mundo*) and update the row.
+3. **Trust the next patrol pass** for the programme-strand prefix titles and year-contamination cases — that's exactly what the patrol is designed for. Tonight's patrol log shows it's actively fixing this class.
+4. **Probe Curzon and Picturehouse chain APIs** for `startsAt` / `Showtime` TZ format. If they're TZ-less like Everyman, same migration applies.
+
+## What this audit validated
+
+- The post-#483 BST fix held for the 6 cinemas I migrated (electric ×2, peckhamplex, close-up, genesis, bfi-southbank — zero 00:00-09:59 outliers).
+- The 79% clean rate is consistent with the patrol's recent batch DQS of 88 (2026-05-07-2022). Spot-check finds the same classes of issue the patrol is already chasing.
+- The Everyman BST bug is the only finding that requires immediate engineering action beyond the rolling patrol — and PR #484 is on it.


### PR DESCRIPTION
## Summary

- **Picturehouse BST fix**: same bug class as #484 (Everyman), different chain. API probe confirmed `Showtime` is a TZ-less ISO string (e.g. `"2026-05-17T15:30:00"`). Migrated to `parseUKLocalDateTime`. Curzon independently checked — clean.
- **478 ghost screenings deleted** across Everyman + Picturehouse via `scripts/_cleanup-bst-ghost-screenings.ts --apply`. The 1h-exact constraint guards against touching legitimately-rescheduled screenings. Verified post-state: 0 BST-signature dupes remain.
- **New `/spot-check` slash command** + `scripts/spot-check-and-fix.ts` loop: samples 100 soonest-screening films, finds all H/M/L issues, applies safe auto-fixes, iterates until convergence. First post-#484 run: 10 fixes / 3 iterations / converged.
- **Boy and the World TMDB link corrected** — was linked to TMDB 302430 ("Rumblestrips"); now correctly TMDB 223706 (Brazilian animation *O Menino e o Mundo*).
- 6 one-off diagnostic `_*.ts` scripts committed for traceability.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run src/scrapers/chains` — 4/4 pass
- [x] Picturehouse API probe: confirmed `Showtime` is TZ-less
- [x] Curzon API check: 0 BST-signature dupes (independently verified — no fix needed)
- [x] Cleanup script: 478 rows deleted, 0 BST dupes remain
- [x] `/spot-check` loop: 10 fixes / 3 iterations / converged on live DB
- [x] Boy and the World row updated and verified

## Manual-review items remaining

- 10 films with `year=currentYear` and no TMDB ID — opera broadcasts, festival events. The rolling patrol handles these with confidence guards.
- No "wrong-TMDB linkage" items remain in the soonest-100 (Boy and the World was the only one).

## Follow-up flagged by code-reviewer (non-blocking)

- TMDB result caching across iterations of the loop (currently re-fetches each pass). Acceptable bounded by MAX_ITERATIONS=10 and convergence-after-3 in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)