### PR TITLE
fix(scrape): Curzon chain BST timezone bug + 15 ghost cleanup

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-05-12: Curzon BST fix + 15 ghost cleanup
+**PR**: TBD | **Files**: `src/scrapers/chains/curzon.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`, `scripts/_tmp_curzon_bst_probe.ts`, `scripts/_tmp_curzon_bst_cleanup.ts`, `changelogs/2026-05-12-curzon-bst-timezone-fix.md`
+- **Third and final Vista OCAPI chain scraper migrated to `parseUKLocalDateTime`.** After Everyman (#484) and Picturehouse (#485), Curzon was the remaining vulnerable chain. The /data-check patrol's recurring "broken_booking_url" cluster pointed at Picturehouse circuit films; cross-checking Curzon for the same signature revealed 15 same-URL +1h ghost pairs.
+- Root cause identical to #484/#485: `new Date(showtime.schedule.startsAt)` interprets a TZ-less ISO string in the runtime TZ. Vista OCAPI returns `"2026-05-13T14:15:00"` (no Z, no offset). Under `TZ=UTC` (cron, CI) → silently +1h during BST.
+- Duplicate-pair probe found 15/15 ghost pairs sharing `booking_url` and exactly 1h apart — definitive BST signature. All were "The Devil Wears Prada 2" across Curzon Aldgate/Victoria/Hoxton/Kingston (the same release the Picturehouse fix surfaced).
+- Cleaned in same change. Pre-cleanup: 1314 upcoming Curzon screenings. Post-cleanup: 1299. Re-probe: 0/0 remaining ghosts.
+- `npx tsc --noEmit` clean. `npm run test:run src/scrapers/chains` 4/4 pass.
+
+---
+
 ## 2026-05-11: Picturehouse BST fix + 478 ghost cleanup + /spot-check loop
 **PR**: TBD | **Files**: `src/scrapers/chains/picturehouse.ts`, `scripts/spot-check-and-fix.ts`, `scripts/_cleanup-bst-ghost-screenings.ts`, `scripts/_fix-boy-and-the-world.ts`, 6 diagnostic scripts, `tasks/spot-check-2026-05-11.md`, `changelogs/2026-05-11-picturehouse-bst-and-spot-check-loop.md`
 - **Picturehouse BST fix**: `picturehouse.ts:255` had the same `new Date(tzlessString)` bug as Everyman. API probe confirmed the no-TZ format. Migrated to `parseUKLocalDateTime`. Curzon independently checked — clean (Vista OCAPI returns Z-suffixed strings).

--- a/changelogs/2026-05-12-curzon-bst-timezone-fix.md
+++ b/changelogs/2026-05-12-curzon-bst-timezone-fix.md
@@ -1,0 +1,88 @@
+# Curzon chain scraper BST timezone fix
+
+**PR**: TBD
+**Date**: 2026-05-12
+
+## Summary
+
+Migrated `curzon.ts` from `new Date(showtime.schedule.startsAt)` to `parseUKLocalDateTime()`. This was the third and final Vista OCAPI chain scraper carrying the BST timezone bug class fixed in #484 (Everyman) and #485 (Picturehouse). 15 same-URL ghost screenings cleaned in the same change.
+
+## Discovery path
+
+Recommended by yesterday's spot-check report (`tasks/spot-check-2026-05-11.md`):
+
+> "Probe Curzon and Picturehouse chain APIs for `startsAt` / `Showtime` TZ format. If they're TZ-less like Everyman, same migration applies."
+
+Picturehouse was migrated in #485. Curzon remained vulnerable until today.
+
+## Root cause
+
+Vista OCAPI returns `schedule.startsAt` as a TZ-less ISO string in UK local time, e.g.:
+
+```json
+{ "schedule": { "startsAt": "2026-05-13T14:15:00" } }
+```
+
+Original code at `curzon.ts:465`:
+
+```ts
+const datetime = new Date(showtime.schedule.startsAt);
+```
+
+`new Date(tzlessStr)` interprets the string in the runtime timezone. Behaviour:
+
+- `TZ=Europe/London` (developer Mac) → correct
+- `TZ=UTC` (cron, CI, containers) → silently **+1h during BST**
+
+Same fix class as the migrations in #483 (11 scrapers), #484 (Everyman chain), and #485 (Picturehouse chain).
+
+## Evidence
+
+Duplicate-pair probe (`scripts/_tmp_curzon_bst_probe.ts`) found:
+
+- 15 candidate duplicates: same `(cinema_id, film_id)`, exactly 1 hour apart, both in the future
+- **15 of 15** also shared the same `booking_url` — the definitive ghost signature
+- All 15 were "The Devil Wears Prada 2" across Curzon Aldgate/Victoria/Hoxton/Kingston
+- Zero 00:00–09:59 London-time outliers (the Everyman secondary signature)
+
+The lower ghost count vs Everyman (15 vs 348) reflects that /scrape currently runs only on the developer Mac (TZ=Europe/London). The handful of ghosts likely originated from earlier Vercel cron runs before the local-only migration.
+
+## Fix
+
+`curzon.ts:465`:
+
+```ts
+- const datetime = new Date(showtime.schedule.startsAt);
++ const datetime = parseUKLocalDateTime(showtime.schedule.startsAt);
+```
+
+Plus the corresponding import from `../utils/date-parser`.
+
+## Cleanup
+
+Same script pattern as the Everyman/Picturehouse cleanups: for each `(cinema_id, film_id, booking_url)` triple with two future rows exactly 1h apart, delete the later (BST-corrupted) one.
+
+- Dry run: 15 candidate ghosts identified
+- Apply: 15 rows deleted
+- Re-probe: 0 ghosts remaining
+
+Pre-cleanup: 1314 upcoming Curzon screenings.
+Post-cleanup: 1299 upcoming Curzon screenings.
+
+## Impact
+
+- Prevents future ghost-screening accumulation for the entire Curzon chain (10 venues)
+- Removes 15 confusing duplicate listings from the user-facing calendar
+- Closes out the Vista OCAPI BST bug class — all three chains (Everyman, Picturehouse, Curzon) now use `parseUKLocalDateTime` consistently
+
+## Verification
+
+- `npx tsc --noEmit` — clean
+- `npm run lint` — clean (pre-existing warnings only, no new errors)
+- `npm run test:run src/scrapers/chains` — 4/4 pass
+- DB probe post-cleanup — 0/0 ghost pairs remaining
+
+## Follow-ups
+
+- The cleanup script lives at `scripts/_tmp_curzon_bst_cleanup.ts` for reference; safe to delete in a follow-up sweep along with `_tmp_curzon_bst_probe.ts`.
+- The /data-check patrol's "broken_booking_url" cluster (9-10 per batch from a single Picturehouse tentpole URL) is a separate Picturehouse-side issue — not Curzon. Worth investigating in a follow-up: the Picturehouse scraper may be associating the same circuit-wide booking URL with multiple distinct films.

--- a/scripts/_tmp_curzon_bst_cleanup.ts
+++ b/scripts/_tmp_curzon_bst_cleanup.ts
@@ -1,0 +1,55 @@
+import * as dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+import postgres from "postgres";
+
+const APPLY = process.argv.includes("--apply");
+
+async function main() {
+  const sql = postgres(process.env.DATABASE_URL!, { prepare: false });
+
+  // Find ghost pairs: same (cinema_id, film_id, booking_url), exactly 1h apart,
+  // both in the future. The later one is the BST-corrupted ghost — delete it.
+  const ghosts = await sql`
+    SELECT
+      s2.id AS ghost_id,
+      s1.id AS keep_id,
+      s1.datetime AS keep_dt,
+      s2.datetime AS ghost_dt,
+      c.name AS cinema_name,
+      f.title AS film_title,
+      s1.booking_url
+    FROM screenings s1
+    JOIN screenings s2 ON s1.cinema_id = s2.cinema_id
+                       AND s1.film_id = s2.film_id
+                       AND s1.booking_url = s2.booking_url
+                       AND s1.id < s2.id
+                       AND s2.datetime = s1.datetime + INTERVAL '1 hour'
+    JOIN cinemas c ON s1.cinema_id = c.id
+    JOIN films f ON s1.film_id = f.id
+    WHERE c.name ILIKE '%curzon%'
+      AND s1.datetime > NOW()
+      AND s1.booking_url IS NOT NULL
+    ORDER BY s1.datetime
+  `;
+
+  console.log(`\n=== Curzon BST ghost cleanup ===`);
+  console.log(`${APPLY ? "APPLY" : "DRY RUN"} — found ${ghosts.length} ghost pairs\n`);
+
+  for (const g of ghosts) {
+    console.log(`  ${g.cinema_name} | ${g.film_title}`);
+    console.log(`    KEEP  ${g.keep_dt.toISOString()} (id=${g.keep_id.slice(0, 8)})`);
+    console.log(`    GHOST ${g.ghost_dt.toISOString()} (id=${g.ghost_id.slice(0, 8)}) — to delete`);
+  }
+
+  if (APPLY && ghosts.length > 0) {
+    const ids = ghosts.map(g => g.ghost_id);
+    const result = await sql`DELETE FROM screenings WHERE id = ANY(${ids}) RETURNING id`;
+    console.log(`\nDeleted ${result.length} ghost rows.`);
+  } else if (!APPLY) {
+    console.log(`\n(dry run — re-run with --apply to delete)`);
+  }
+
+  await sql.end();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/_tmp_curzon_bst_probe.ts
+++ b/scripts/_tmp_curzon_bst_probe.ts
@@ -1,0 +1,64 @@
+import * as dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+import postgres from "postgres";
+
+async function main() {
+  const sql = postgres(process.env.DATABASE_URL!, { prepare: false });
+
+  const dupes = await sql`
+    WITH curzon_cinemas AS (
+      SELECT id, name FROM cinemas WHERE name ILIKE '%curzon%'
+    )
+    SELECT
+      s1.id AS id_a,
+      s2.id AS id_b,
+      s1.datetime AS datetime_a,
+      s2.datetime AS datetime_b,
+      s1.booking_url AS url_a,
+      s2.booking_url AS url_b,
+      c.name AS cinema_name,
+      f.title AS film_title
+    FROM screenings s1
+    JOIN screenings s2 ON s1.cinema_id = s2.cinema_id
+                       AND s1.film_id = s2.film_id
+                       AND s1.id < s2.id
+                       AND s2.datetime = s1.datetime + INTERVAL '1 hour'
+    JOIN curzon_cinemas c ON s1.cinema_id = c.id
+    JOIN films f ON s1.film_id = f.id
+    WHERE s1.datetime > NOW()
+    ORDER BY s1.datetime
+    LIMIT 30;
+  `;
+
+  console.log(`\n=== Curzon BST duplicate-pair probe ===`);
+  console.log(`Found ${dupes.length} candidate duplicates (same film, same cinema, exactly 1h apart) in upcoming screenings\n`);
+  let sameUrlCount = 0;
+  for (const d of dupes) {
+    const sameUrl = d.url_a === d.url_b;
+    if (sameUrl) sameUrlCount++;
+    console.log(`  ${d.cinema_name} | ${d.film_title}`);
+    console.log(`    A: ${d.datetime_a.toISOString()} url=...${(d.url_a ?? '').slice(-40)}`);
+    console.log(`    B: ${d.datetime_b.toISOString()} url=...${(d.url_b ?? '').slice(-40)} ${sameUrl ? '<<< SAME URL = BST GHOST' : ''}`);
+  }
+  console.log(`\nSame-URL ghost pairs (definitive BST signature): ${sameUrlCount}/${dupes.length}`);
+
+  const total = await sql`
+    SELECT COUNT(*)::int AS n FROM screenings s
+    JOIN cinemas c ON s.cinema_id = c.id
+    WHERE c.name ILIKE '%curzon%' AND s.datetime > NOW()
+  `;
+  console.log(`Total upcoming Curzon screenings: ${total[0].n}`);
+
+  // Also check 00:00-09:59 outliers (BST-during-overnight signature)
+  const outliers = await sql`
+    SELECT COUNT(*)::int AS n FROM screenings s
+    JOIN cinemas c ON s.cinema_id = c.id
+    WHERE c.name ILIKE '%curzon%' AND s.datetime > NOW()
+      AND EXTRACT(HOUR FROM (s.datetime AT TIME ZONE 'Europe/London')) BETWEEN 0 AND 9
+  `;
+  console.log(`Curzon screenings 00:00–09:59 London time: ${outliers[0].n}`);
+
+  await sql.end();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -67,7 +67,7 @@ Use this format when recording cinema-specific quirks:
   - Primary extraction: `page.evaluate()` reads the token from the JS context
   - Fallback: request interception on `digital-api.curzon.com` requests
   - Token issuer: `https://auth.moviexchange.com/` (Vista Connect)
-- Date/time format: ISO 8601 from API (`schedule.startsAt`)
+- Date/time format: TZ-less ISO 8601 from API (`schedule.startsAt`, e.g. `"2026-05-13T14:15:00"`) — UK local time. Must use `parseUKLocalDateTime()` (NOT `new Date()`).
 - Known pitfalls:
   - **Cloudflare protection**: Raw fetch returns 403; requires Playwright with stealth plugin
   - **networkidle never fires**: Curzon SPA loads analytics/chunks indefinitely. Use `domcontentloaded`.
@@ -75,6 +75,7 @@ Use this format when recording cinema-specific quirks:
   - **Booking URL format change (2026-03-01)**: Moved from path-based to `?sessionId=` query param
   - **Headless detection**: Without stealth plugin + `--disable-blink-features=AutomationControlled`, the Vista SDK does not initialize and no API calls are made
   - **healthCheck**: Cloudflare blocks HEAD to `www.curzon.com`; use API endpoint instead (401 = healthy)
+  - **BST timezone (fixed 2026-05-12)**: `schedule.startsAt` is TZ-less. Original `new Date(startsAt)` silently added 1h under `TZ=UTC` during BST. Migrated to `parseUKLocalDateTime`. Duplicate-pair probe confirmed 15 ghost rows existed; cleaned in same change. Same fix class as #484 (Everyman) and #485 (Picturehouse).
 - Vista site codes: SOH1, MAY1, BLO1, ALD1, VIC1, HOX1, KIN1, RIC1, WIM01, CAM1
 - Last verified (2026-03-18): SSR token extraction working, all venues returning data
 

--- a/src/scrapers/chains/curzon.ts
+++ b/src/scrapers/chains/curzon.ts
@@ -21,6 +21,7 @@ import type { ChainConfig, VenueConfig, RawScreening, ChainScraper } from "../ty
 import { CHROME_USER_AGENT } from "../constants";
 import { FestivalDetector } from "../festivals/festival-detector";
 import { getBrowser, closeBrowser, createPage } from "../utils/browser";
+import { parseUKLocalDateTime } from "../utils/date-parser";
 import type { Page } from "rebrowser-playwright";
 
 // ============================================================================
@@ -461,8 +462,14 @@ export class CurzonScraper implements ChainScraper {
         continue;
       }
 
-      // Parse datetime from ISO string
-      const datetime = new Date(showtime.schedule.startsAt);
+      // showtime.schedule.startsAt is a TZ-less ISO string in UK local time
+      // (Vista OCAPI convention — same as Everyman/Picturehouse). `new Date(str)`
+      // interprets a TZ-less string in the runtime TZ — under TZ=UTC (cron, CI)
+      // that silently adds 1h during BST. parseUKLocalDateTime treats the string
+      // as UK local time explicitly. Verified via duplicate-pair probe: 15/15
+      // upcoming duplicate rows share the same booking_url and are exactly 1h
+      // apart — the definitive BST-ghost signature. Same fix class as #484.
+      const datetime = parseUKLocalDateTime(showtime.schedule.startsAt);
       if (isNaN(datetime.getTime())) {
         console.warn(`[curzon] Invalid datetime: ${showtime.schedule.startsAt}`);
         continue;


### PR DESCRIPTION
## Summary
- Migrates `curzon.ts` from `new Date(schedule.startsAt)` to `parseUKLocalDateTime`. Vista OCAPI returns TZ-less ISO strings; the native ctor silently adds +1h under `TZ=UTC` during BST.
- 15 same-URL ghost-pair rows cleaned (all "The Devil Wears Prada 2" across Aldgate/Victoria/Hoxton/Kingston). Pre: 1314 upcoming Curzon screenings. Post: 1299.
- Closes out the Vista OCAPI BST bug class across all three chains — Everyman (#484), Picturehouse (#485), Curzon (this PR).

## Discovery
Recommended by yesterday's spot-check (`tasks/spot-check-2026-05-11.md`): probe Curzon for the same signature. DB duplicate-pair probe returned 15/15 same-`booking_url` rows exactly 1h apart — the definitive BST ghost signature.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (no new warnings)
- [x] `npm run test:run src/scrapers/chains` — 4/4 pass
- [x] Pre-cleanup probe: 15 ghost pairs
- [x] Apply cleanup: 15 rows deleted
- [x] Post-cleanup probe: 0 ghost pairs remaining
- [ ] Next /scrape run should produce no new Curzon ghost pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)