### PR TITLE
feat(scrape): route BFI scraper in /scrape to the PDF importer

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,14 @@
+## 2026-05-14: Route BFI scraper in /scrape to the PDF importer
+**PR**: TBD | **Files**: `src/scrapers/cinemas/bfi.ts`
+- Follow-up to #488. The PDF importer worked via `npm run scrape:bfi-pdf` but the unified `/scrape` registry still ran the broken Playwright click-flow.
+- `BFIScraper.scrape()` now delegates to `runBFIImport()` and returns `[]`. The importer saves to DB directly via the standard `saveScreenings` path, covering both Southbank and IMAX in one PDF fetch.
+- Module-scope `bfiImportRunPromise` cache dedupes across the two venue invocations — second call shares the cached promise (~1s instead of re-fetching).
+- The old Playwright click-flow is kept as `_legacyPlaywrightScrape()` for reference; structurally broken under Cloudflare's per-action challenges.
+- Verified: `npm run scrape:bfi` now imports 94 screenings (vs 0). BFI Southbank: 1031 upcoming. Total run time: 25s (was 4+ min).
+- Known limitation: unified pipeline reports `0 added, 0 updated` for both BFI venues in its per-cinema summary because we route around the pipeline. The data IS in the DB; the count is just not credited to BFI in the unified summary. Accept the trade-off vs leaving BFI broken.
+
+---
+
 ## 2026-05-14: BFI scraper — Cloudflare bypass via persistent context + PDF importer revived (0 → 99 screenings)
 **PR**: TBD | **Files**: `src/scrapers/utils/browser.ts`, `src/scrapers/cinemas/bfi.ts`, `src/scrapers/bfi-pdf/fetcher.ts`, `src/scrapers/bfi-pdf/pdf-parser.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`, `changelogs/2026-05-14-bfi-scraper-fix.md`
 - **Symptom**: BFI Southbank + BFI IMAX returned 0 screenings in the 2026-05-12 /scrape run (Cloudflare timeout, "Found 0 active dates" for both venues). Was the only silent breaker from /scrape.

--- a/changelogs/2026-05-14-bfi-route-to-pdf-importer.md
+++ b/changelogs/2026-05-14-bfi-route-to-pdf-importer.md
@@ -1,0 +1,44 @@
+# Route BFI scraper in /scrape to the PDF importer
+
+**PR**: TBD
+**Date**: 2026-05-14
+
+## Summary
+
+Follow-up to #488. That PR made `npm run scrape:bfi-pdf` work end-to-end but the unified `/scrape` registry was still wired to the Playwright click-flow scraper, which is structurally broken under Cloudflare. This change routes the registered BFI scraper to the PDF importer so `/scrape` produces real screenings for BFI.
+
+**Before**: `npm run scrape:bfi` → Playwright click-flow → 0 screenings (Cloudflare blocks each click)
+**After**: `npm run scrape:bfi` → PDF importer → 94 screenings
+
+## Changes
+
+`src/scrapers/cinemas/bfi.ts`:
+
+- `BFIScraper.scrape()` now calls `getOrRunBFIImport()` (a wrapper around `runBFIImport()` from `bfi-pdf/`) and returns `[]`. The importer saves screenings for both BFI Southbank and BFI IMAX directly via the standard `saveScreenings` pipeline.
+
+- New module-scope `bfiImportRunPromise` cache dedupes across the two venue invocations. The unified scrape calls `createBFIScraper("bfi-southbank").scrape()` and `createBFIScraper("bfi-imax").scrape()` in sequence — without the cache, the PDF would be fetched and parsed twice. With the cache, the second invocation awaits the first one's promise (~1s vs 23s).
+
+- The old Playwright click-flow is kept as `_legacyPlaywrightScrape()` for reference, in case Cloudflare relaxes its per-action challenges or we add a paid proxy service.
+
+## Trade-off
+
+The unified pipeline's per-cinema summary will show `0 added, 0 updated` for both `bfi-southbank` and `bfi-imax` because `scrape()` returns `[]`. The actual DB write happens inside `runBFIImport`'s own `saveScreenings` call, which is outside the unified pipeline's accounting.
+
+This is the wrong direction for observability but the right direction for correctness — the alternative is leaving BFI broken. The unified pipeline's overall screening count delta (before → after) will still show the BFI screenings; just the per-cinema attribution is misleading.
+
+Future cleanup: refactor `runBFIImport` to return `RawScreening[]` separated by venue, then have `scrape()` return the appropriate venue's slice. Then the unified pipeline saves it normally and the per-cinema count is correct.
+
+## Verification
+
+- `npx tsc --noEmit` — clean
+- `npm run test:run` — 910/910 pass
+- `npm run scrape:bfi` — 94 screenings imported in 25s (was 0 in 4+ min)
+- DB confirms: BFI Southbank `recent_scrapes=94` in last 5 min, total upcoming 1031
+- BFI IMAX `recent_scrapes=0` (parser venue-mapping issue, see follow-up)
+
+## Known follow-ups
+
+- BFI IMAX gets 0 fresh scrapes from this run. The PDF parser's `convertToRawScreenings` may not be mapping `BFI IMAX` venue codes from the PDF to the `bfi-imax` cinema_id. Worth investigating.
+- Improve coverage from ~57% (94 imported vs 174 screening patterns in the same PDF). Tighten segmentation.
+- Parse both available PDFs (`fetchAllRelevantPDFs` exists but `runBFIImport` calls `fetchLatestPDF`).
+- Programme changes page still 403s.

--- a/src/scrapers/cinemas/bfi.ts
+++ b/src/scrapers/cinemas/bfi.ts
@@ -10,6 +10,7 @@ import { createPersistentPage, waitForCloudflare } from "../utils/browser";
 import type { BrowserContext, Page } from "rebrowser-playwright";
 import { parseFilmMetadata } from "../utils/metadata-parser";
 import { FestivalDetector } from "../festivals/festival-detector";
+import { runBFIImport } from "../bfi-pdf";
 
 interface BFIVenueConfig {
   id: "bfi-southbank" | "bfi-imax";
@@ -48,6 +49,42 @@ export class BFIScraper {
   }
 
   async scrape(): Promise<RawScreening[]> {
+    // The Playwright click-flow below is structurally broken under Cloudflare:
+    // every internal navigation triggers a fresh challenge that doesn't clear
+    // locally. Verified 2026-05-14: it produces 0 screenings for both venues.
+    //
+    // Route to the PDF importer instead, which is the playbook-preferred path
+    // anyway. runBFIImport handles BOTH bfi-southbank and bfi-imax in one pass:
+    // - Fetches the monthly PDF guide (via persistent Playwright context to
+    //   bypass Cloudflare on the discovery page)
+    // - Parses screenings for both venues
+    // - Saves directly via the standard `saveScreenings` pipeline
+    //
+    // We dedupe across the two venue instances with `bfiImportRunPromise`
+    // so the PDF is fetched + parsed once per /scrape session. The second
+    // venue instance shares the cached promise and the importer's per-venue
+    // save side-effects are already complete.
+    //
+    // Returning [] is correct here: runBFIImport has already persisted both
+    // venues' screenings. The unified pipeline will report "0 added, 0 updated"
+    // for each BFI venue in its per-cinema summary, but the DB state is right.
+    console.log(`[${this.config.cinemaId}] Routing to PDF importer (Playwright click-flow is Cloudflare-blocked)...`);
+    try {
+      await getOrRunBFIImport();
+    } catch (error) {
+      console.error(`[${this.config.cinemaId}] PDF importer failed:`, error);
+      // Fall through with [] — better to underreport than to throw and abort
+      // the rest of the /scrape wave.
+    }
+    return [];
+  }
+
+  /**
+   * @deprecated Kept for reference / future use if the Playwright path becomes
+   * viable again (e.g. Cloudflare relaxes, or we add a paid proxy). Currently
+   * unreachable — `scrape()` always routes to the PDF importer.
+   */
+  async _legacyPlaywrightScrape(): Promise<RawScreening[]> {
     console.log(`[${this.config.cinemaId}] Starting scrape with Playwright stealth mode...`);
     await FestivalDetector.preload();
 
@@ -493,4 +530,31 @@ export class BFIScraper {
 /** Creates a scraper for a BFI venue (Southbank or IMAX). */
 export function createBFIScraper(venueId: "bfi-southbank" | "bfi-imax"): BFIScraper {
   return new BFIScraper(venueId);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// PDF importer dedupe
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Module-scope cache so the PDF import runs ONCE per process even when the
+ * unified scrape calls `createBFIScraper("bfi-southbank").scrape()` and
+ * `createBFIScraper("bfi-imax").scrape()` in succession (or in parallel).
+ *
+ * runBFIImport saves screenings for BOTH venues in a single call, so the
+ * second invocation would just re-fetch and re-save the same data. Caching
+ * the promise lets the second caller await the first one's result.
+ *
+ * Reset each session by re-importing the module; the cache lives in memory
+ * only for one Node process.
+ */
+let bfiImportRunPromise: Promise<void> | null = null;
+
+async function getOrRunBFIImport(): Promise<void> {
+  if (!bfiImportRunPromise) {
+    bfiImportRunPromise = (async () => {
+      await runBFIImport();
+    })();
+  }
+  return bfiImportRunPromise;
 }


### PR DESCRIPTION
## Summary
Follow-up to #488. That PR fixed the PDF importer end-to-end but the unified /scrape registry was still wired to the broken Playwright click-flow. This routes BFI through the working PDF path.

**Before**: \`npm run scrape:bfi\` → Playwright → 0 screenings
**After**: \`npm run scrape:bfi\` → PDF importer → 94 screenings in 25s

## Changes
- \`BFIScraper.scrape()\` delegates to \`runBFIImport()\` and returns \`[]\`
- Module-scope \`bfiImportRunPromise\` cache dedupes across both venue invocations (Southbank + IMAX share one PDF fetch)
- Legacy Playwright path preserved as \`_legacyPlaywrightScrape()\` for reference

## Trade-off
Unified pipeline shows \`0 added, 0 updated\` for both BFI venues in per-cinema summary because \`scrape()\` returns \`[]\`. Actual DB writes happen inside \`runBFIImport\`'s own \`saveScreenings\` call. Total screening delta still reflects BFI; per-cinema attribution is misleading. Accept vs leaving BFI broken.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 910/910 pass
- [x] \`npm run scrape:bfi\` — 94 screenings imported, 25s total
- [x] DB verified: BFI Southbank recent_scrapes=94, upcoming=1031

## Known follow-ups
- BFI IMAX gets 0 fresh scrapes (parser venue-mapping issue, separate)
- Improve coverage from ~57%
- Parse both available PDFs (not just latest)
- Programme changes endpoint still 403s

🤖 Generated with [Claude Code](https://claude.com/claude-code)