### PR TITLE
fix(scrape): BFI scraper returns venue-filtered screenings so /scrape tracks them

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-05-14: BFI scraper returns venue-filtered screenings so /scrape records them properly
+**PR**: TBD | **Files**: `src/scrapers/cinemas/bfi.ts`, `src/scrapers/bfi-pdf/importer.ts`, `src/scrapers/bfi-pdf/index.ts`
+- Follow-up to #489. That PR routed BFI to the PDF importer but had `scrape()` return `[]` (because `runBFIImport` saved directly). Result: `scraper_runs.screening_count` was 0, triggering the silent-breaker detector to quarantine BFI.
+- New `loadBFIScreenings()` exported from `bfi-pdf/` — fetches + parses + merges without saving. `BFIScraper.scrape()` calls it (cached across the two venue instances), filters by `getBFIVenueKey`, returns the slice for its venue. The unified pipeline saves them normally and `screening_count` reflects reality.
+- `runBFIImport` (the standalone CLI path) is unchanged — still does load + save + persist run record.
+- Verified: BFI Southbank now returns 94 screenings to the pipeline (was 0). Silent-breaker detector should clear after the next /scrape.
+- Known limitation surfaced: BFI IMAX still returns 0 because the PDF parser doesn't catch IMAX entries (the IMAX section uses screening-first-then-title ordering, opposite of Southbank's title-first format). Separate follow-up.
+
+---
+
 ## 2026-05-14: Route BFI scraper in /scrape to the PDF importer
 **PR**: TBD | **Files**: `src/scrapers/cinemas/bfi.ts`
 - Follow-up to #488. The PDF importer worked via `npm run scrape:bfi-pdf` but the unified `/scrape` registry still ran the broken Playwright click-flow.

--- a/changelogs/2026-05-14-bfi-return-screenings.md
+++ b/changelogs/2026-05-14-bfi-return-screenings.md
@@ -1,0 +1,78 @@
+# BFI scraper returns venue-filtered screenings so /scrape records them properly
+
+**PR**: TBD
+**Date**: 2026-05-14
+
+## Summary
+
+Follow-up to #489. That PR successfully routed BFI through the working PDF importer path, but `BFIScraper.scrape()` returned `[]` because `runBFIImport` was saving screenings directly via its own DB path. The consequence: every entry in `scraper_runs` had `status=success, screening_count=0`, which is the exact pattern the silent-breaker detector quarantines as broken.
+
+After #489 the silent-breaker check flagged both BFI venues:
+
+```
+=== Silent-breaker health check ===
+2 cinema(s) flagged:
+  bfi-imax (BFI IMAX) — 2 consecutive zero-yield runs
+  bfi-southbank (BFI Southbank) — 2 consecutive zero-yield runs
+```
+
+The BFI data was in the DB. The accounting was wrong.
+
+## Changes
+
+### `bfi-pdf/importer.ts` — new `loadBFIScreenings()` export
+
+Splits the fetch + parse + merge steps from the save step:
+
+```ts
+export async function loadBFIScreenings(): Promise<{
+  screenings: RawScreening[];
+  pdfInfo: { label: string; contentHash: string } | undefined;
+  sourceStatus: { pdf: SourceStatus; programmeChanges: SourceStatus };
+}>;
+```
+
+Returns merged screenings (PDF + programme changes, both venues) without persisting anything. `runBFIImport` is unchanged — it still calls the same primitives (fetchLatestPDF + parsePDF + fetchProgrammeChanges + mergeScreenings) and then does `saveByVenue` + run-record persistence.
+
+Also promoted `getVenueKey` to a named export `getBFIVenueKey` so callers can filter screenings to a specific venue without duplicating the IMAX-detection logic.
+
+### `cinemas/bfi.ts` — return venue-filtered screenings
+
+`BFIScraper.scrape()` now:
+1. Calls `getOrLoadBFIScreenings()` (cached) to get merged screenings for both venues
+2. Filters by `getBFIVenueKey(s) === this.config.cinemaId`
+3. Returns the filtered slice
+
+The unified pipeline then processes them through its standard path:
+- `pipeline.ts` calls `getOrCreateFilm` + `insertScreening` for each
+- `scraper_runs` records `screening_count` matching the array length
+- Silent-breaker detector sees a real count and doesn't quarantine
+
+The module-scope `bfiLoadPromise` cache means the PDF is fetched + parsed once per process; the second venue invocation just filters the same cached array.
+
+## Trade-off considerations
+
+Double-write risk: if someone runs both `npm run scrape:bfi-pdf` AND `/scrape` in the same session, the screenings get saved twice — once via `runBFIImport`'s `saveByVenue`, once via the unified pipeline. `saveScreenings` is idempotent (upsert on the unique index), so this is safe; the second write is a no-op update.
+
+## Verification
+
+- `npx tsc --noEmit` — clean
+- `npm run test:run` — 910/910 pass
+- `npm run scrape:bfi` — BFI Southbank: 94 screenings returned to pipeline, `screening_count=94` in scraper_runs (was 0)
+- BFI IMAX still 0 — see follow-up below
+
+## Known follow-up: BFI IMAX still returns 0
+
+The PDF parser uses title-first ordering (`title → metadata → screenings`) which matches the BFI Southbank section format. The BFI IMAX section at the end of the PDF uses **screening-first** ordering:
+
+```
+SAT 30 MAY 13:00 BFI IMAX        ← screening line
+E.T. the Extra Terrestrial       ← film title
+USA 1982. Director Spielberg.    ← metadata
+```
+
+`tryParseFilm` walks forward from a title line and only attaches *subsequent* screening lines. The leading screening for an IMAX entry is never associated with E.T. and the film is never added to the parsed output. The IMAX section's films also tend to have richer descriptive copy ("Visit the BFI IMAX website for information on...") that intercedes between the screening and the title.
+
+Fix would require a second pass that walks the structure in reverse for IMAX-tagged entries, or recognising the IMAX section's specific layout. Documented in `tasks/` for a follow-up.
+
+In the meantime, BFI IMAX retains 63 screenings from prior scrapes (no regression).

--- a/src/scrapers/bfi-pdf/importer.ts
+++ b/src/scrapers/bfi-pdf/importer.ts
@@ -243,6 +243,68 @@ async function finalizeImportResult(
  * This is the main entry point for importing BFI screenings from PDFs
  * and programme changes.
  */
+/**
+ * Fetch + parse + merge BFI screenings WITHOUT saving. Use this when you
+ * want the screenings returned for processing through the standard scraper
+ * pipeline (e.g. from `BFIScraper.scrape()` so the unified /scrape records
+ * the correct screening_count per cinema in `scraper_runs`).
+ *
+ * For the standalone CLI path (`npm run scrape:bfi-pdf`), use `runBFIImport`
+ * which calls this and then saves + persists a run record.
+ */
+export async function loadBFIScreenings(): Promise<{
+  screenings: RawScreening[];
+  pdfInfo: { label: string; contentHash: string } | undefined;
+  sourceStatus: { pdf: SourceStatus; programmeChanges: SourceStatus };
+}> {
+  const sourceStatus: { pdf: SourceStatus; programmeChanges: SourceStatus } = {
+    pdf: "empty",
+    programmeChanges: "empty",
+  };
+
+  let pdfResult: ParseResult | null = null;
+  let changesResult: ProgrammeChangesResult | null = null;
+  let fetchedPdf: FetchedPDF | null = null;
+
+  console.log("[BFI-Load] Fetching latest PDF...");
+  try {
+    fetchedPdf = await fetchLatestPDF();
+    if (fetchedPdf) {
+      pdfResult = await parsePDF(fetchedPdf);
+      sourceStatus.pdf = pdfResult.screenings.length > 0 ? "success" : "empty";
+      console.log(`[BFI-Load] PDF parsed: ${pdfResult.screenings.length} screenings from ${pdfResult.films.length} films`);
+    } else {
+      sourceStatus.pdf = "failed";
+    }
+  } catch (error) {
+    sourceStatus.pdf = "failed";
+    console.error(`[BFI-Load] PDF fetch/parse failed:`, error);
+  }
+
+  console.log("[BFI-Load] Fetching programme changes...");
+  try {
+    changesResult = await fetchProgrammeChanges();
+    sourceStatus.programmeChanges = changesResult.screenings.length > 0 ? "success" : "empty";
+    console.log(`[BFI-Load] Changes parsed: ${changesResult.screenings.length} screenings from ${changesResult.changes.length} changes`);
+  } catch (error) {
+    sourceStatus.programmeChanges = "failed";
+    console.error(`[BFI-Load] Programme changes fetch failed:`, error);
+  }
+
+  const screenings = mergeScreenings(
+    pdfResult?.screenings || [],
+    changesResult?.screenings || []
+  );
+
+  return {
+    screenings,
+    pdfInfo: fetchedPdf
+      ? { label: fetchedPdf.info.label, contentHash: fetchedPdf.contentHash }
+      : undefined,
+    sourceStatus,
+  };
+}
+
 export async function runBFIImport(context?: ImportContext): Promise<ImportResult> {
   const startedAt = new Date();
   const startTime = Date.now();
@@ -487,13 +549,16 @@ function isImaxBookingUrl(bookingUrl: string | undefined): boolean {
   }
 }
 
-function getVenueKey(screening: RawScreening): "bfi-southbank" | "bfi-imax" {
+export function getBFIVenueKey(screening: RawScreening): "bfi-southbank" | "bfi-imax" {
   const screen = screening.screen?.toUpperCase() || "";
   if (screen.includes("IMAX") || isImaxBookingUrl(screening.bookingUrl)) {
     return "bfi-imax";
   }
   return "bfi-southbank";
 }
+
+// Internal alias preserved for legacy call-sites inside this file.
+const getVenueKey = getBFIVenueKey;
 
 /**
  * Create a unique key for a screening based on venue, film, datetime, and screen.

--- a/src/scrapers/bfi-pdf/index.ts
+++ b/src/scrapers/bfi-pdf/index.ts
@@ -17,7 +17,7 @@ export type { ParsedFilm, ParsedScreening, ParseResult } from "./pdf-parser";
 export { fetchProgrammeChanges, parseChangesPage } from "./programme-changes-parser";
 export type { ProgrammeChange, ParsedChangeScreening, ProgrammeChangesResult } from "./programme-changes-parser";
 
-export { runBFIImport, runProgrammeChangesImport, scrape } from "./importer";
+export { runBFIImport, runProgrammeChangesImport, scrape, loadBFIScreenings, getBFIVenueKey } from "./importer";
 export type { ImportResult } from "./importer";
 
 export { runBFICleanup } from "./cleanup";

--- a/src/scrapers/cinemas/bfi.ts
+++ b/src/scrapers/cinemas/bfi.ts
@@ -10,7 +10,7 @@ import { createPersistentPage, waitForCloudflare } from "../utils/browser";
 import type { BrowserContext, Page } from "rebrowser-playwright";
 import { parseFilmMetadata } from "../utils/metadata-parser";
 import { FestivalDetector } from "../festivals/festival-detector";
-import { runBFIImport } from "../bfi-pdf";
+import { loadBFIScreenings, getBFIVenueKey } from "../bfi-pdf";
 
 interface BFIVenueConfig {
   id: "bfi-southbank" | "bfi-imax";
@@ -53,30 +53,28 @@ export class BFIScraper {
     // every internal navigation triggers a fresh challenge that doesn't clear
     // locally. Verified 2026-05-14: it produces 0 screenings for both venues.
     //
-    // Route to the PDF importer instead, which is the playbook-preferred path
-    // anyway. runBFIImport handles BOTH bfi-southbank and bfi-imax in one pass:
-    // - Fetches the monthly PDF guide (via persistent Playwright context to
-    //   bypass Cloudflare on the discovery page)
-    // - Parses screenings for both venues
-    // - Saves directly via the standard `saveScreenings` pipeline
+    // Route through the PDF importer's loader instead. `loadBFIScreenings()`
+    // fetches the monthly PDF (using the persistent Playwright context as a
+    // Cloudflare fallback for the discovery page) and parses screenings for
+    // BOTH venues at once. We cache the promise so both venue instances share
+    // one fetch + parse; the second invocation just filters the cached array.
     //
-    // We dedupe across the two venue instances with `bfiImportRunPromise`
-    // so the PDF is fetched + parsed once per /scrape session. The second
-    // venue instance shares the cached promise and the importer's per-venue
-    // save side-effects are already complete.
-    //
-    // Returning [] is correct here: runBFIImport has already persisted both
-    // venues' screenings. The unified pipeline will report "0 added, 0 updated"
-    // for each BFI venue in its per-cinema summary, but the DB state is right.
+    // Returning the venue-filtered screenings lets the unified pipeline save
+    // them through its standard path AND record the correct `screening_count`
+    // per cinema in `scraper_runs` — without that, the silent-breaker detector
+    // quarantines BFI as a Prowlarr-pattern zero-yield cinema.
     console.log(`[${this.config.cinemaId}] Routing to PDF importer (Playwright click-flow is Cloudflare-blocked)...`);
     try {
-      await getOrRunBFIImport();
+      const allScreenings = await getOrLoadBFIScreenings();
+      const venueScreenings = allScreenings.filter(s => getBFIVenueKey(s) === this.config.cinemaId);
+      console.log(`[${this.config.cinemaId}] PDF returned ${venueScreenings.length} screenings (${allScreenings.length} total across both BFI venues)`);
+      return venueScreenings;
     } catch (error) {
-      console.error(`[${this.config.cinemaId}] PDF importer failed:`, error);
+      console.error(`[${this.config.cinemaId}] PDF loader failed:`, error);
       // Fall through with [] — better to underreport than to throw and abort
       // the rest of the /scrape wave.
+      return [];
     }
-    return [];
   }
 
   /**
@@ -537,24 +535,24 @@ export function createBFIScraper(venueId: "bfi-southbank" | "bfi-imax"): BFIScra
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Module-scope cache so the PDF import runs ONCE per process even when the
- * unified scrape calls `createBFIScraper("bfi-southbank").scrape()` and
- * `createBFIScraper("bfi-imax").scrape()` in succession (or in parallel).
+ * Module-scope cache so the PDF fetch + parse runs ONCE per process even when
+ * the unified scrape calls `createBFIScraper("bfi-southbank").scrape()` and
+ * `createBFIScraper("bfi-imax").scrape()` in succession.
  *
- * runBFIImport saves screenings for BOTH venues in a single call, so the
- * second invocation would just re-fetch and re-save the same data. Caching
- * the promise lets the second caller await the first one's result.
+ * `loadBFIScreenings` returns screenings for BOTH venues (each tagged with
+ * its `cinemaId`). The second invocation reuses the cached promise and
+ * filters for its own venue.
  *
- * Reset each session by re-importing the module; the cache lives in memory
- * only for one Node process.
+ * Cache lives in memory only for one Node process.
  */
-let bfiImportRunPromise: Promise<void> | null = null;
+let bfiLoadPromise: Promise<RawScreening[]> | null = null;
 
-async function getOrRunBFIImport(): Promise<void> {
-  if (!bfiImportRunPromise) {
-    bfiImportRunPromise = (async () => {
-      await runBFIImport();
+async function getOrLoadBFIScreenings(): Promise<RawScreening[]> {
+  if (!bfiLoadPromise) {
+    bfiLoadPromise = (async () => {
+      const { screenings } = await loadBFIScreenings();
+      return screenings;
     })();
   }
-  return bfiImportRunPromise;
+  return bfiLoadPromise;
 }


### PR DESCRIPTION
## Summary
Follow-up to #489. That PR routed BFI through the working PDF importer path, but \`scrape()\` returned \`[]\` because \`runBFIImport\` saved directly. Result: \`scraper_runs.screening_count=0\` for every BFI run → silent-breaker detector quarantined both BFI venues.

**Before**: BFI Southbank/IMAX → \`screening_count=0\` per run → silent-breaker flag
**After**: BFI Southbank → 94 screenings tracked correctly per run

## Changes
- New \`loadBFIScreenings()\` export in \`bfi-pdf/importer.ts\` — does fetch + parse + merge without saving
- Promoted \`getVenueKey\` to public \`getBFIVenueKey\`
- \`BFIScraper.scrape()\` calls \`loadBFIScreenings\` (cached), filters by venue, returns slice
- Unified pipeline saves through standard path → \`scraper_runs.screening_count\` reflects reality

## Trade-off
Double-write if both \`/scrape\` AND \`npm run scrape:bfi-pdf\` run in the same session — but \`saveScreenings\` is idempotent (UPSERT) so the second write is a no-op. Safe.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 910/910 pass
- [x] \`npm run scrape:bfi\` — 94 screenings returned to pipeline, scraper_runs records \`screening_count=94\`
- [ ] Next \`/scrape\` will clear the silent-breaker flag for BFI Southbank

## Known follow-up
BFI IMAX still returns 0 — PDF parser uses title-first ordering, IMAX section uses screening-first. Separate parser issue; 63 prior IMAX screenings preserved (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)