### PR TITLE
feat(frontend): multi-day rolling calendar — always show upcoming films

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-05-14: Multi-day rolling calendar — always show upcoming films
+**PR**: TBD | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`, `frontend/src/lib/components/calendar/DayMasthead.svelte`, `frontend/test-all.spec.ts`, `frontend/tests/mobile.spec.ts`
+- Homepage no longer goes blank late at night when today's screenings are all past. The default view now shows a rolling window: today + as many upcoming days as needed to fill at least ~24 films (capped at 7 days).
+- Each day is its own `<section>` with a day header ("Today · Thursday, the fourteenth", "Tomorrow · Friday, the fifteenth", or just "Saturday, the sixteenth" for later days). Films within each day stay sorted by Letterboxd rating (the existing `compareFilmsByCalendarPriority` ordering), but the sort **resets per day**.
+- `buildFilmMap` default range changed from `[today, today]` to `[today, ∞)`. The DayMasthead day-strip buttons now anchor the window from the clicked day onwards (one-sided range) instead of collapsing to a single day. Date-picker / filter-sidebar single-day presets still set both ends.
+- Desktop's old `hybridFilms` flat-grid is replaced with day-grouped sections. Mobile's global `.mobile-date-label` is replaced with per-section headers.
+
+---
+
 ## 2026-05-14: BFI IMAX parser — handle screening-before-title layout + fix segmenter over-firing
 **PR**: TBD | **Files**: `src/scrapers/bfi-pdf/pdf-parser.ts`
 - Follow-up to #490. BFI IMAX was returning 0 screenings because the IMAX section of the PDF uses **screening-first** ordering (screening line before the film's title), opposite to BFI Southbank's title-first format.

--- a/changelogs/2026-05-14-multi-day-rolling-calendar.md
+++ b/changelogs/2026-05-14-multi-day-rolling-calendar.md
@@ -1,0 +1,41 @@
+# Multi-day rolling calendar — always show upcoming films
+
+**PR**: TBD
+**Date**: 2026-05-14
+
+## Problem
+
+The homepage at `pictures.london` defaulted to a single-day view (today's screenings only). The `buildFilmMap` helper in `frontend/src/lib/calendar-filter.ts` defaulted both `effectiveFrom` and `effectiveTo` to `today` when no date filter was set. After ~11pm, when all of today's screenings had already started (`dtMs <= now` excluded them), the page rendered zero films and showed the "No screenings found" empty state — a dead-end for users browsing late at night.
+
+## Changes
+
+### `frontend/src/lib/calendar-filter.ts`
+- Default `effectiveTo` is now `'9999-12-31'` (unbounded forward) when `filters.dateTo` is null, instead of `today`. The behavioural-contract docstring is updated accordingly.
+- The dev-only one-sided-range warning is relaxed: a `dateFrom`-only range is now valid (it's how the day strip anchors the rolling window). The warning only fires when `dateTo` is set without `dateFrom` — an unusual configuration no current UI surface produces.
+
+### `frontend/src/routes/+page.svelte`
+- New `visibleDayGroups` derived value that slices the full `dayGroups` array until total film count ≥ 24 (`MIN_FILMS_VISIBLE`), capped at 7 days (`MAX_DAYS_VISIBLE`). This produces a rolling window that auto-extends in sparse periods (late night) and collapses to roughly one day during peak hours.
+- Desktop layout: the flat `hybridFilms` grid is replaced with per-day `<section class="desktop-day">` blocks. Each day renders a `dayHeader` snippet followed by `DesktopHybridCard`s. The `hybridFilms` derivation is removed.
+- Mobile layout: the global `.mobile-date-label` block at the top of the mobile header is removed. Each `<section class="mobile-day">` now renders its own `dayHeader` snippet inside.
+- New `{#snippet dayHeader(iso: string)}` shared between desktop and mobile. Labels the day with "Today" / "Tomorrow" + weekday + ordinal (e.g. "Tomorrow · Friday, the fifteenth"). Reads from `todayStore` so it advances at the midnight rollover.
+- New `.desktop-day` and `.day-header` styles. Desktop day-header is 28px serif italic with a bottom border; mobile is 22px.
+
+### `frontend/src/lib/components/calendar/DayMasthead.svelte`
+- `selectDate(iso)` now sets `filters.dateFrom = iso` and leaves `filters.dateTo = null` (anchors the rolling window from that day forward) instead of setting both ends to `iso`. Clicking "Today" still clears both, restoring the default rolling window.
+
+### Tests
+- `frontend/test-all.spec.ts`: the "listings default to today" test is rewritten as "listings default to a rolling multi-day window from today onwards". The invariant now asserts no past screenings leak (rather than no future-day screenings appearing) and that clicking the next-day strip moves the earliest visible date forward (rather than narrowing to one day).
+- `frontend/tests/mobile.spec.ts`: the "day label renders" test now reads from the first `section.mobile-day h2.day-header` since the global `.mobile-date-label` no longer exists.
+
+## Impact
+
+- **Users**: Late-night visitors (after ~11pm London) now see tomorrow's screenings underneath the masthead instead of an empty state. Day-by-day browsing is more discoverable; the day strip now extends the window forward rather than narrowing it.
+- **Letterboxd-rating sort**: still applied within each day. Films users will recognise (highly-rated) appear first per day, just as they did in the old flat grid.
+- **Performance**: no additional network calls — the server-side load already fetches a 14-day window. The slice is purely client-side derived state.
+- **Behavioural contract**: `buildFilmMap`'s default range is now `[today, ∞)` instead of `[today, today]`. Any future caller relying on the old single-day default must explicitly set `dateTo`.
+
+## Verification
+
+- Type-check (`npx svelte-check`): clean for all modified files; pre-existing errors in `src/routes/letterboxd/+page.svelte` are untouched.
+- Playwright (`npx playwright test --project=chromium`): the two homepage tests this change touches pass. Remaining 9 chromium failures are pre-existing dev-environment issues (film detail pages return 404 in local dev; mobile-iPhone tests need webkit installed) — confirmed unrelated by reproducing on main.
+- Manual browser verification (Playwright automation): desktop 1440px, mobile iPhone 12 Pro 390x844, late-night `page.clock` simulation, day-strip navigation, empty-state filtering. Screenshots in `/tmp/multiday-screenshots/` during development.

--- a/frontend/src/lib/calendar-filter.ts
+++ b/frontend/src/lib/calendar-filter.ts
@@ -61,11 +61,14 @@ let lastOneSidedRangeWarnKey = '';
 /**
  * Group upcoming screenings by film, applying the active filters.
  *
- * Behavioural contract (locked in by tests + the lock-in Playwright assert):
+ * Behavioural contract:
  * - Excludes screenings whose `datetime` is at or before `now`.
  * - Excludes screenings without a `film`.
- * - Date range defaults to `[today, today]` when neither end is set on the
- *   snapshot (matches the masthead's single-day framing on the homepage).
+ * - Date range defaults to `[today, ∞)` when neither end is set on the
+ *   snapshot — the homepage shows a rolling multi-day window and slices the
+ *   visible days downstream in `+page.svelte`.
+ * - A `dateFrom`-only range (no `dateTo`) is valid: it anchors the rolling
+ *   window from that date forward.
  * - All date comparisons use London civil dates, never UTC ISO slices.
  * - Screenings are bucketed by `film.id` in insertion order; the caller is
  *   responsible for any ordering.
@@ -77,22 +80,23 @@ export function buildFilmMap<S extends CalendarScreening>(
 ): Map<string, FilmGroup<S>> {
 	const map = new Map<string, FilmGroup<S>>();
 	const effectiveFrom = filters.dateFrom ?? today;
-	const effectiveTo = filters.dateTo ?? today;
+	// '9999-12-31' is string-compare-safe since YYYY-MM-DD sorts lexicographically;
+	// any real screening date is strictly less.
+	const effectiveTo = filters.dateTo ?? '9999-12-31';
 	const searchQuery = filters.filmSearch ? filters.filmSearch.toLowerCase() : '';
 
-	// Every current caller (setDatePreset in `filters.svelte.ts`,
-	// `DayMasthead.selectDate`) assigns dateFrom and dateTo together, but
-	// `set dateFrom` / `set dateTo` on the store are public — if a future
-	// caller sets only one, we silently default the other to today. The
-	// dev-only warning below surfaces that drift instead of swallowing it.
+	// A `dateTo`-only range (with no `dateFrom`) is unusual — every UI surface
+	// that exposes a single-day filter sets both ends. Warn in dev so a drifting
+	// caller surfaces instead of silently defaulting `dateFrom` to today.
 	if (
 		import.meta.env.DEV &&
-		(filters.dateFrom === null) !== (filters.dateTo === null)
+		filters.dateFrom === null &&
+		filters.dateTo !== null
 	) {
 		const key = `${filters.dateFrom}|${filters.dateTo}`;
 		if (lastOneSidedRangeWarnKey !== key) {
 			lastOneSidedRangeWarnKey = key;
-			console.warn('buildFilmMap: one-sided date range — invariant broken', {
+			console.warn('buildFilmMap: dateTo set without dateFrom', {
 				dateFrom: filters.dateFrom,
 				dateTo: filters.dateTo
 			});

--- a/frontend/src/lib/components/calendar/DayMasthead.svelte
+++ b/frontend/src/lib/components/calendar/DayMasthead.svelte
@@ -59,8 +59,10 @@
 			filters.dateFrom = null;
 			filters.dateTo = null;
 		} else {
+			// Anchor the rolling multi-day window — leave `dateTo` open so the
+			// homepage's `visibleDayGroups` slice extends forward from `iso`.
 			filters.dateFrom = iso;
-			filters.dateTo = iso;
+			filters.dateTo = null;
 		}
 	}
 

--- a/frontend/src/lib/components/filters/ActiveFilterChips.svelte
+++ b/frontend/src/lib/components/filters/ActiveFilterChips.svelte
@@ -12,9 +12,16 @@
 		const c: Chip[] = [];
 
 		if (filters.dateFrom || filters.dateTo) {
-			const label = filters.dateFrom === filters.dateTo
-				? filters.dateFrom ?? ''
-				: `${filters.dateFrom ?? '…'} – ${filters.dateTo ?? '…'}`;
+			let label: string;
+			if (filters.dateFrom === filters.dateTo) {
+				label = filters.dateFrom ?? '';
+			} else if (filters.dateFrom && !filters.dateTo) {
+				// One-sided range: anchors the rolling multi-day window from this
+				// day forward (set by `DayMasthead.selectDate`).
+				label = `From ${filters.dateFrom}`;
+			} else {
+				label = `${filters.dateFrom ?? '…'} – ${filters.dateTo ?? '…'}`;
+			}
 			c.push({ key: 'date', label, onRemove: () => { filters.dateFrom = null; filters.dateTo = null; } });
 		}
 

--- a/frontend/src/lib/components/filters/DateTimePicker.svelte
+++ b/frontend/src/lib/components/filters/DateTimePicker.svelte
@@ -28,6 +28,10 @@
 			} else if (filters.dateTo) {
 				const dTo = new Date(filters.dateTo + 'T00:00:00');
 				parts.push(`${d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })} – ${dTo.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}`);
+			} else {
+				// One-sided range — the rolling-window anchor set by the day strip
+				// (`DayMasthead.selectDate` clears `dateTo`).
+				parts.push(`From ${d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })}`);
 			}
 		}
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -78,19 +78,40 @@
 			});
 	});
 
-	// Flat list of unique films for the desktop hybrid grid, sorted by calendar priority.
-	const hybridFilms = $derived.by(() => {
-		return [...filmMap.values()]
-			.map(({ film, screenings }) => ({
-				film,
-				screenings: screenings.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
-			}))
-			.sort(compareFilmsByCalendarPriority);
+	// Rolling-window slice: take days from the start of `dayGroups` until we've
+	// accumulated enough films to fill the viewport. Late at night today is
+	// usually empty (all past), so the window naturally extends to tomorrow /
+	// the day after without the page going blank.
+	const MIN_FILMS_VISIBLE = 24;
+	const MAX_DAYS_VISIBLE = 7;
+	const visibleDayGroups = $derived.by(() => {
+		const out: typeof dayGroups = [];
+		let filmCount = 0;
+		for (const day of dayGroups) {
+			out.push(day);
+			filmCount += day.films.length;
+			if (out.length >= MAX_DAYS_VISIBLE) break;
+			if (filmCount >= MIN_FILMS_VISIBLE) break;
+		}
+		return out;
 	});
 
+	// Visible counts (across the rolling-window slice, not the full filter set).
+	// `filmMap.size` would count every unique film within the entire date range
+	// up to 14 days — much larger than what the user actually sees in the
+	// sliced view. Same film playing multiple days is counted once here.
+	const visibleFilmCount = $derived.by(() => {
+		const ids = new Set<string>();
+		for (const day of visibleDayGroups) {
+			for (const { film } of day.films) ids.add(film.id);
+		}
+		return ids.size;
+	});
 	const screeningCount = $derived.by(() => {
 		let n = 0;
-		for (const { screenings } of filmMap.values()) n += screenings.length;
+		for (const day of visibleDayGroups) {
+			for (const { screenings } of day.films) n += screenings.length;
+		}
 		return n;
 	});
 
@@ -119,6 +140,19 @@
 <div class="sr-only" aria-live="polite" role="status">
 	{#if dayGroups.length === 0}No screenings found{:else}{filmMap.size} films showing{/if}
 </div>
+
+{#snippet dayHeader(iso: string)}
+	{@const d = new Date(iso + 'T12:00:00Z')}
+	{@const weekday = new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' }).format(d)}
+	{@const dayNum = Number(new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' }).format(d))}
+	{@const ordinals = {1:'first',2:'second',3:'third',4:'fourth',5:'fifth',6:'sixth',7:'seventh',8:'eighth',9:'ninth',10:'tenth',11:'eleventh',12:'twelfth',13:'thirteenth',14:'fourteenth',15:'fifteenth',16:'sixteenth',17:'seventeenth',18:'eighteenth',19:'nineteenth',20:'twentieth',21:'twenty-first',22:'twenty-second',23:'twenty-third',24:'twenty-fourth',25:'twenty-fifth',26:'twenty-sixth',27:'twenty-seventh',28:'twenty-eighth',29:'twenty-ninth',30:'thirtieth',31:'thirty-first'} as Record<number, string>}
+	{@const todayIso = todayStore.value}
+	{@const tomorrowIso = (() => { const t = new Date(todayIso + 'T12:00:00Z'); t.setUTCDate(t.getUTCDate() + 1); return t.toISOString().split('T')[0]; })()}
+	{@const relative = iso === todayIso ? 'Today' : iso === tomorrowIso ? 'Tomorrow' : null}
+	<h2 class="day-header">
+		{#if relative}<span class="day-header-relative">{relative}</span><span class="day-header-sep"> · </span>{/if}<span class="day-header-weekday">{weekday}</span><span class="italic-comma">,</span> <span class="day-header-ordinal">the {ordinals[dayNum] ?? `${dayNum}th`}</span>
+	</h2>
+{/snippet}
 
 <JsonLd data={webSiteSchema()} />
 <JsonLd data={faqSchema([
@@ -168,37 +202,42 @@
 			<div class="desktop-toolbar">
 				<FilmTypeFilter />
 				<span class="count-line">
-					<span class="count-num">{filmMap.size}</span> films ·
+					<span class="count-num">{visibleFilmCount}</span> films ·
 					<span class="count-num">{screeningCount}</span> screenings
 				</span>
 			</div>
 
-			{#if filmMap.size === 0}
+			{#if visibleDayGroups.length === 0}
 				<EmptyState title="No screenings found" description="Try adjusting your filters or check back later." />
 			{:else}
-				<div class="desktop-film-grid">
-					{#each hybridFilms as { film, screenings }, hi (film.id)}
-						<DesktopHybridCard
-							film={{
-								id: film.id,
-								title: film.title,
-								year: film.year,
-								director: film.director ?? null,
-								runtime: film.runtime,
-								posterUrl: film.posterUrl
-							}}
-							screenings={screenings.map((s) => ({
-								id: s.id,
-								datetime: s.datetime,
-								cinemaName: s.cinema?.name ?? 'Unknown',
-								cinemaSlug: s.cinema?.id ?? '',
-								format: s.format,
-								bookingUrl: s.bookingUrl
-							}))}
-							priority={hi < 4}
-						/>
-					{/each}
-				</div>
+				{#each visibleDayGroups as { date, films }, di (date)}
+					<section class="desktop-day">
+						{@render dayHeader(date)}
+						<div class="desktop-film-grid">
+							{#each films as { film, screenings }, fi (film.id)}
+								<DesktopHybridCard
+									film={{
+										id: film.id,
+										title: film.title,
+										year: film.year,
+										director: film.director ?? null,
+										runtime: film.runtime,
+										posterUrl: film.posterUrl
+									}}
+									screenings={screenings.map((s) => ({
+										id: s.id,
+										datetime: s.datetime,
+										cinemaName: s.cinema?.name ?? 'Unknown',
+										cinemaSlug: s.cinema?.id ?? '',
+										format: s.format,
+										bookingUrl: s.bookingUrl
+									}))}
+									priority={di === 0 && fi < 4}
+								/>
+							{/each}
+						</div>
+					</section>
+				{/each}
 			{/if}
 		</main>
 	</div>
@@ -207,18 +246,6 @@
 <!-- ── MOBILE LAYOUT (< 1024px) ── -->
 <div class="mobile-shell">
 	<div class="mobile-header">
-		<div class="mobile-date-label">
-			{#if dayGroups.length > 0}
-				{@const d = new Date(dayGroups[0].date + 'T12:00:00Z')}
-				{@const weekday = new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' }).format(d)}
-				{@const dayNum = Number(new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' }).format(d))}
-				{@const ordinals = {1:'first',2:'second',3:'third',4:'fourth',5:'fifth',6:'sixth',7:'seventh',8:'eighth',9:'ninth',10:'tenth',11:'eleventh',12:'twelfth',13:'thirteenth',14:'fourteenth',15:'fifteenth',16:'sixteenth',17:'seventeenth',18:'eighteenth',19:'nineteenth',20:'twentieth',21:'twenty-first',22:'twenty-second',23:'twenty-third',24:'twenty-fourth',25:'twenty-fifth',26:'twenty-sixth',27:'twenty-seventh',28:'twenty-eighth',29:'twenty-ninth',30:'thirtieth',31:'thirty-first'} as Record<number, string>}
-				{weekday}<span class="italic-comma">,</span> the {ordinals[dayNum] ?? `${dayNum}th`}
-			{:else}
-				No films
-			{/if}
-		</div>
-
 		<div class="mobile-search-row">
 			<div class="mobile-search">
 				<svg width="11" height="11" viewBox="0 0 14 14" aria-hidden="true">
@@ -245,12 +272,13 @@
 		</div>
 	</div>
 
-	{#if dayGroups.length === 0}
+	{#if visibleDayGroups.length === 0}
 		<EmptyState title="No screenings found" description="Try adjusting your filters or check back later." />
 	{:else}
 		<div class="mobile-list">
-			{#each dayGroups as { date, films }, di (date)}
+			{#each visibleDayGroups as { date, films }, di (date)}
 				<section class="mobile-day">
+					{@render dayHeader(date)}
 					{#each films as { film, screenings }, fi (film.id)}
 						<MobileFilmRow
 							film={{
@@ -384,6 +412,16 @@
 	}
 	.count-line .count-num { color: var(--color-text-secondary); }
 
+	.desktop-day {
+		display: flex;
+		flex-direction: column;
+		margin-bottom: 48px;
+	}
+
+	.desktop-day:last-child {
+		margin-bottom: 0;
+	}
+
 	.desktop-film-grid {
 		display: grid;
 		grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -405,6 +443,40 @@
 		}
 	}
 
+	/* ---------- Day headers (shared mobile + desktop) ---------- */
+	.day-header {
+		font-family: var(--font-serif-italic);
+		font-style: italic;
+		font-weight: 400;
+		letter-spacing: -0.01em;
+		color: var(--color-text);
+		margin: 0;
+	}
+
+	.day-header .italic-comma { color: var(--color-text-tertiary); }
+	.day-header .day-header-relative { font-style: normal; font-family: var(--font-serif); color: var(--color-text); }
+	.day-header .day-header-sep { color: var(--color-text-tertiary); font-style: normal; }
+	.day-header .day-header-ordinal { color: var(--color-text-secondary); }
+
+	@media (min-width: 1024px) {
+		.day-header {
+			font-size: 28px;
+			line-height: 1;
+			padding: 0 0 18px;
+			border-bottom: 1px solid var(--color-border);
+			margin-bottom: 22px;
+		}
+	}
+
+	@media (max-width: 1023px) {
+		.day-header {
+			font-size: 22px;
+			line-height: 1;
+			padding: 14px 0 12px;
+			border-bottom: 1px solid var(--color-border);
+		}
+	}
+
 	/* ---------- Mobile ---------- */
 	.mobile-shell {
 		display: block;
@@ -421,20 +493,6 @@
 		padding: 12px 0 0;
 		border-bottom: 1px solid var(--color-border-subtle);
 	}
-
-	.mobile-date-label {
-		font-family: var(--font-serif-italic);
-		font-style: italic;
-		font-size: 22px;
-		font-weight: 400;
-		line-height: 1;
-		color: var(--color-text);
-		letter-spacing: -0.01em;
-		padding: 4px 0 14px;
-		border-bottom: 1px solid var(--color-border);
-	}
-
-	.mobile-date-label .italic-comma { font-style: italic; color: var(--color-text-tertiary); }
 
 	.mobile-search-row {
 		display: flex;

--- a/frontend/test-all.spec.ts
+++ b/frontend/test-all.spec.ts
@@ -53,14 +53,14 @@ test.describe('Pictures London — SvelteKit Frontend', () => {
 			await expect(today).toBeVisible();
 		});
 
-		test('listings under each poster default to today and follow the day strip', async ({ page }) => {
-			// Locks in PR #445: filmMap previously skipped its date predicate
-			// when no range was set, leaking the full 30-day payload into every
-			// poster. It also compared `s.datetime.split('T')[0]` (UTC date)
-			// against London-time filter values, so late-night BST screenings
-			// landed on the wrong calendar day. This single assertion catches
-			// both halves: a leaked future-day or a UTC-vs-London mismatch
-			// produces a `datetime` that resolves to a London date != today.
+		test('listings default to a rolling multi-day window from today onwards', async ({ page }) => {
+			// Contract since the multi-day rolling-calendar change: the homepage
+			// shows today + the next few days (until ~24 films are visible), each
+			// in its own `<section>` with a day header. The lock-in invariant is
+			// that NO visible screening can resolve to a London date < today —
+			// a leaked past screening or a UTC-vs-London comparison bug would
+			// produce a `datetime` that resolves to a London date strictly before
+			// today.
 			const londonDate = (iso: string) =>
 				new Date(iso).toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
 			const today = londonDate(new Date().toISOString());
@@ -81,24 +81,26 @@ test.describe('Pictures London — SvelteKit Frontend', () => {
 
 			const initial = await collectDates();
 			expect(initial.length, 'expected at least one screening on the homepage').toBeGreaterThan(0);
-			const offToday = initial.filter((d) => londonDate(d) !== today);
+			const beforeToday = initial.filter((d) => londonDate(d) < today);
 			expect(
-				offToday,
-				`expected every visible screening to be on ${today} (London); ${offToday.length} were on other days: ${offToday.slice(0, 3).join(', ')}`
+				beforeToday,
+				`expected no screening before ${today} (London); ${beforeToday.length} leaked: ${beforeToday.slice(0, 3).join(', ')}`
 			).toEqual([]);
 
-			// Click the next-day strip button — listings should narrow to that day.
+			// Click the next-day strip button — window now anchors from that day
+			// forward. Every visible screening must resolve to a London date >=
+			// the clicked day (no past leakage, but multiple days are allowed).
 			const stripButtons = page.locator('.day-strip .strip-btn:not(.strip-arrow)');
 			await stripButtons.nth(1).click(); // index 0 = Today, 1 = +1 day
-			await page.waitForTimeout(300);
+			await page.waitForTimeout(400);
 			const after = await collectDates();
 			if (after.length > 0) {
-				const uniqueDays = new Set(after.map(londonDate));
+				const dates = after.map(londonDate);
+				const earliest = [...dates].sort()[0];
 				expect(
-					uniqueDays.size,
-					`expected screenings to narrow to a single day after strip click, got ${[...uniqueDays].join(', ')}`
-				).toBe(1);
-				expect([...uniqueDays][0]).not.toBe(today);
+					earliest > today,
+					`after clicking next-day strip, earliest visible date should be > today (${today}), got ${earliest}`
+				).toBe(true);
 			}
 		});
 

--- a/frontend/tests/mobile.spec.ts
+++ b/frontend/tests/mobile.spec.ts
@@ -69,11 +69,14 @@ test.describe('Mobile Responsive — iPhone 12 Pro (390x844)', () => {
 	// ═══════════════════════════════════════════════
 
 	test.describe('Mobile Homepage', () => {
-		test('day label renders with weekday + ordinal', async ({ page }) => {
+		test('day header renders with weekday + ordinal in first mobile section', async ({ page }) => {
 			await page.goto(BASE);
-			const label = page.locator('.mobile-date-label');
-			await expect(label).toBeVisible();
-			const text = (await label.textContent())?.toLowerCase() ?? '';
+			// First mobile-day section now carries its own h2.day-header — the
+			// global `.mobile-date-label` was removed when the homepage moved to a
+			// multi-day rolling layout.
+			const firstHeader = page.locator('section.mobile-day h2.day-header').first();
+			await expect(firstHeader).toBeVisible();
+			const text = (await firstHeader.textContent())?.toLowerCase() ?? '';
 			expect(text).toMatch(/monday|tuesday|wednesday|thursday|friday|saturday|sunday/);
 		});
 


### PR DESCRIPTION
## Summary
- Homepage no longer goes blank late at night when today's screenings are all past — defaults to a rolling window of today + upcoming days, auto-extending until ~24 films are visible (capped at 7 days).
- Each day is its own `<section>` with a header (e.g. "Today · Thursday, the fourteenth", "Tomorrow · Friday, the fifteenth"). Letterboxd-rating sort still applies, but **resets per day**.
- Day-strip clicks (Today / Fri / Sat / Sun / Mon) anchor the rolling window from the clicked day onwards instead of collapsing to a single day.

## Key changes
- `buildFilmMap` default range: `[today, today]` → `[today, ∞)`
- `DayMasthead.selectDate(iso)`: sets `dateFrom = iso, dateTo = null` (one-sided range anchoring the rolling window) instead of `dateFrom = dateTo = iso`
- Desktop: flat `hybridFilms` grid → day-grouped `<section class="desktop-day">` blocks
- Mobile: global `.mobile-date-label` → per-section `h2.day-header`
- `ActiveFilterChips` + `DateTimePicker` handle the new one-sided range shape ("From <date>")
- Visible film/screening counts in the toolbar now reflect the sliced view

## Test plan
- [x] `cd frontend && npx playwright test --project=chromium -g "rolling multi-day|day header"` passes
- [x] Type-check (`npx svelte-check`) clean for all modified files
- [x] Manual Playwright automation: desktop 1440px, mobile iPhone 12 Pro, late-night `page.clock` simulation, day-strip navigation, empty-state filtering, console error check
- [x] Code-reviewer agent run — all blockers addressed (chip/picker labels for one-sided range; count text reflects visible window)
- [ ] Vercel preview deploys and renders correctly

## Notes
- The remaining `[chromium]` Playwright failures on this branch are pre-existing dev-environment issues unrelated to this PR (film detail pages return 404 in local dev; mobile-small iPhone tests need webkit installed) — reproduce on `main` baseline.
- A repertory film playing multiple days now appears as a card in each day section it screens. This is intentional and aligns with the per-day grouping; the toolbar count reflects unique films visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)