### PR TITLE
fix(scrape): dedup 1,065 screening rows + prevent recurrence

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,15 @@
+## 2026-05-15: Dedup screenings + prevent recurrence in /scrape (BST shifts, film-id flips, BFI cluster bug)
+**PR**: TBD | **Files**: `src/scrapers/utils/screening-classification.ts`, `src/scrapers/pipeline.ts`, `src/scrapers/bfi-pdf/programme-changes-parser.ts`, `src/db/migrations/0011_screenings_cinema_source_unique.sql`, plus cleanup scripts + tests
+- Removed **1,065 bogus screening rows** in three classes:
+  - **710 (cinema_id, source_id) duplicates** in upcoming screenings — same source resolved to different films (e.g. Hard Boiled @ The Nickel, 135 same-datetime) OR BST off-by-one regressions producing datetime+1h dupes (e.g. Wake in Fright @ The Gate, Shrek @ Everyman Maida Vale — 409 of these). For same-datetime: latest scrape wins. For BST-shift: earlier datetime always wins (the +1h variant is always the bug).
+  - **254 (cinema_id, source_id) duplicates** across past dates (so the unique-index migration could be applied).
+  - **351 BFI Southbank "many films at same datetime" rows** — the programme-changes-parser's `getFollowingText` was grabbing the full parent paragraph's text, so 6+ films sharing one `<p>` each got matched against every sibling's screening times.
+- **Pipeline prevention**: `processScreenings` now uses `(cinema_id, source_id)` as conflict target when sourceId is set, so a re-scrape with a corrected datetime UPDATEs the existing row in place. `checkForDuplicate` Layer 0 dropped the datetime filter to match.
+- **DB enforcement**: new partial unique index `idx_screenings_cinema_source ON screenings (cinema_id, source_id) WHERE source_id IS NOT NULL` makes the invariant non-negotiable.
+- **BFI parser fix**: `getFollowingText` now walks DOM siblings and stops at the next `<b>`/`<strong>`, with a fallback that slices parent text correctly when only text nodes follow. Regression test added in `programme-changes-parser.test.ts`.
+
+---
+
 ## 2026-05-14: Multi-day rolling calendar — always show upcoming films
 **PR**: TBD | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`, `frontend/src/lib/components/calendar/DayMasthead.svelte`, `frontend/test-all.spec.ts`, `frontend/tests/mobile.spec.ts`
 - Homepage no longer goes blank late at night when today's screenings are all past. The default view now shows a rolling window: today + as many upcoming days as needed to fill at least ~24 films (capped at 7 days).

--- a/changelogs/2026-05-15-dedup-screenings.md
+++ b/changelogs/2026-05-15-dedup-screenings.md
@@ -1,0 +1,71 @@
+# Dedup screenings + prevent recurrence in /scrape
+
+**PR**: TBD
+**Date**: 2026-05-15
+
+## Problem
+
+The homepage was showing duplicate screenings across multiple cinemas, in three distinct shapes:
+
+1. **Same datetime, different `film_id`** — e.g. Hard Boiled @ The Nickel showing two 16:15 rows. Caused by duplicate rows in the `films` table being resolved as different `film_id`s across scrape runs.
+2. **Different datetime ~60min apart (BST off-by-one)** — e.g. Wake in Fright @ The Gate (15:30 + 16:30), Shrek @ Everyman Maida Vale (10:30 + 11:30). Same `source_id`, but an earlier (correct) scrape and a later (regressed) scrape both inserted rows. The recent BST fixes (#484, #485, #486) prevented FUTURE regressions but didn't reconcile the pre-existing rows.
+3. **BFI Southbank "many films at same datetime"** — 6–10 unrelated films (Rose of Nevada, Surviving Earth, The Christophers, ...) all stored at the same UTC time (e.g. `2026-05-15 11:50:00+00`), each with a correct individual `source_id`. Different shape from (1) and (2): a parser bug, not a dedup constraint gap.
+
+### Root causes
+
+- The screenings unique index was `(film_id, cinema_id, datetime)` and the upsert in `processScreenings` used the same conflict target — neither included `source_id`. Two scrape runs that mapped the same `(cinema_id, source_id)` to a different `film_id` or `datetime` both succeeded as inserts.
+- `checkForDuplicate` Layer 0 (in `src/scrapers/utils/screening-classification.ts`) matched on `(cinemaId, sourceId, datetime)`. The `datetime` predicate meant a re-scrape with a corrected datetime missed the existing row entirely.
+- `getFollowingText` in `src/scrapers/bfi-pdf/programme-changes-parser.ts` called `$el.parent().text()`, which returns the parent's full text including sibling `<b>` element children. Every film in a multi-film paragraph saw every sibling's screening times in its regex pool.
+
+## Changes
+
+### Data cleanup (one-shot)
+
+- **`scripts/cleanup-cinema-source-dupes.ts`** (new) — collapses `(cinema_id, source_id)` groups with >1 row.
+  - Same-datetime groups: keep the row with the latest `scraped_at`.
+  - Different-datetime groups: keep the **earlier datetime** (the BST regression always adds +1 h, so the earlier UTC value is the BST-correct one).
+  - Default dry-run; `--apply` commits. Refuses to exit 0 if any (cinema, source_id) dups remain after apply — protects the unique-index migration.
+- **`scripts/cleanup-bfi-cluster-bug.ts`** (new) — deletes BFI Southbank rows where ≥3 distinct films share a single `datetime` and all have `bfi-changes-*` source_ids. These were the parser-bug propagation rows; future BFI scrapes (with the fixed parser) will re-populate correct rows.
+
+Run results on prod:
+- Cleanup pass 1 (upcoming only): 710 rows deleted, 544 groups resolved.
+- Cleanup pass 2 (all dates, after extending scope to satisfy unique-index migration): 254 additional rows deleted.
+- BFI cluster cleanup: 351 rows deleted across 48 datetime clusters.
+- Total: **1,315 bogus rows removed**.
+
+### Pipeline prevention
+
+- **`src/scrapers/utils/screening-classification.ts`** — `checkForDuplicate` Layer 0 now matches on `(cinemaId, sourceId)` only (dropped the `datetime` predicate). A re-scrape with corrected datetime now finds the existing row and updates it.
+- **`src/scrapers/pipeline.ts`** —
+  - The duplicate-found update path now sets `datetime: screening.datetime` so a BST-corrected re-scrape heals the existing row instead of leaving the old wrong-hour value.
+  - The insert path's `onConflictDoUpdate` is now branched: when `sourceId` is present, the conflict target is `[cinemaId, sourceId]` (matching the new partial unique index) and the SET clause updates `filmId`, `datetime`, `scrapedAt`, `bookingUrl`. When `sourceId` is null, the legacy `[filmId, cinemaId, datetime]` target is preserved for the handful of scrapers that don't emit `source_id`.
+
+### DB constraint
+
+- **`src/db/migrations/0011_screenings_cinema_source_unique.sql`** — new partial unique index `idx_screenings_cinema_source ON screenings (cinema_id, source_id) WHERE source_id IS NOT NULL`. Enforces the invariant at the database level so any future scraper bug surfaces as a `23505` error rather than silently duplicating rows.
+
+### BFI parser fix
+
+- **`src/scrapers/bfi-pdf/programme-changes-parser.ts`** — `getFollowingText` rewritten to walk DOM siblings starting from the current `<b>` element, stopping at the next `<b>`/`<strong>`. A fallback handles the case where the screening times are direct text nodes inside the parent (cheerio's `nextAll()` skips text nodes): slices the parent's text from the end of this `<b>` up to the next bold sibling's text.
+- **`src/scrapers/bfi-pdf/programme-changes-parser.test.ts`** (new) — two regression tests:
+  - Two films sharing one `<p>` produce exactly one screening (the first film's), not two.
+  - Two films across separate `<p>`s each keep their own screening.
+
+## Impact
+
+- **Users**: duplicated screenings disappear immediately for the four reported cases (Hard Boiled, Shrek, Wake in Fright, São Paulo) and ~544 other affected screenings across 46 cinemas. BFI Southbank's fake-time rows for Rose of Nevada / Surviving Earth / The Christophers / Mother Mary / etc. are gone until the next BFI scrape repopulates correct times.
+- **Future scrapes**: re-running `/scrape` will UPSERT in place. Any BST regression that ever re-appears in a scraper now self-heals on the next run instead of leaving a wrong-hour row behind. The DB constraint guarantees this even if a future code path forgets to use the upsert.
+- **Past data**: cleanup was bounded to whatever was duplicated; legitimate historical data was preserved.
+
+## Verification
+
+- Type-check (`npx tsc --noEmit`) clean for all modified files.
+- Lint (`npm run lint`) clean (0 errors; existing warnings unchanged).
+- Vitest (`npm run test:run`): 912 / 912 pass, including the new BFI parser regression test.
+- Audit (`scripts/audit-screening-duplicates.ts`) reports `dup_triples: 0` post-cleanup.
+- Migration verified via direct query on `pg_indexes`: `idx_screenings_cinema_source` present with the partial `WHERE (source_id IS NOT NULL)` clause.
+
+## Follow-ups (out of scope)
+
+- The underlying duplicate **films** table rows (separate from screenings) are still a source of the same-datetime dup class. `scripts/cleanup-duplicate-films.ts` exists; left alone in this PR because it touches enrichment + posters.
+- A small number of legitimate "two films at same BFI time on different screens" pairs may still appear once BFI scrapes resume. They'll be allowed by the new constraint (different `source_id`s) and only flagged if the count exceeds the threshold in `cleanup-bfi-cluster-bug.ts`.

--- a/scripts/cleanup-bfi-cluster-bug.ts
+++ b/scripts/cleanup-bfi-cluster-bug.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env tsx
+/**
+ * Clean up BFI Southbank "many films at same datetime" bogus rows.
+ *
+ * Root cause: the programme-changes-parser's `getFollowingText` previously
+ * grabbed the entire parent paragraph's text, so when 6+ film entries shared
+ * one `<p>`, each film's regex pool contained every sibling's screening
+ * times. Result: every film got rows for every sibling's time. Fixed in
+ * `src/scrapers/bfi-pdf/programme-changes-parser.ts`.
+ *
+ * This script deletes the resulting bogus rows: any (cinema_id='bfi-southbank',
+ * datetime) bucket with ≥3 distinct films whose source_ids all start with
+ * `bfi-changes-`. Legitimate concurrent screenings at BFI Southbank can have
+ * 2 films at the same time (NFT1+NFT2); 3+ is the parser bug.
+ *
+ * Future scrapes (with the fixed parser) will re-populate the correct rows.
+ *
+ * Usage:
+ *   npx dotenv -e .env.local -- npx tsx scripts/cleanup-bfi-cluster-bug.ts
+ *   add --apply to commit deletions
+ */
+import { db } from "@/db";
+import { screenings } from "@/db/schema";
+import { inArray, sql } from "drizzle-orm";
+
+const APPLY = process.argv.includes("--apply");
+
+async function main() {
+  console.log(`BFI Southbank cluster cleanup — ${APPLY ? "APPLY" : "DRY RUN"} mode`);
+
+  // Find every (datetime) cluster with ≥3 distinct bfi-changes films.
+  const clusters = await db.execute(sql`
+    WITH suspicious AS (
+      SELECT s.datetime, COUNT(DISTINCT s.film_id) AS distinct_films
+      FROM screenings s
+      WHERE s.cinema_id = 'bfi-southbank'
+        AND s.source_id LIKE 'bfi-changes-%'
+      GROUP BY s.datetime
+      HAVING COUNT(DISTINCT s.film_id) >= 3
+    )
+    SELECT s.id, s.datetime::text AS datetime, s.source_id, f.title AS film_title
+    FROM screenings s
+    JOIN suspicious sus ON sus.datetime = s.datetime
+    JOIN films f ON f.id = s.film_id
+    WHERE s.cinema_id = 'bfi-southbank' AND s.source_id LIKE 'bfi-changes-%'
+    ORDER BY s.datetime, s.source_id
+  `);
+
+  const rows = clusters as unknown as Array<{
+    id: string;
+    datetime: string;
+    source_id: string;
+    film_title: string;
+  }>;
+
+  // Group for reporting
+  const byDatetime = new Map<string, typeof rows>();
+  for (const r of rows) {
+    const list = byDatetime.get(r.datetime) ?? [];
+    list.push(r);
+    byDatetime.set(r.datetime, list);
+  }
+
+  console.log(`\nFound ${byDatetime.size} suspicious datetime clusters, ${rows.length} rows total.\n`);
+  let i = 0;
+  for (const [dt, group] of byDatetime) {
+    if (i++ < 5) {
+      console.log(`  ${dt} — ${group.length} films:`);
+      for (const r of group) {
+        console.log(`    ${r.id.slice(0, 8)}  ${r.film_title}`);
+      }
+    }
+  }
+  if (byDatetime.size > 5) console.log(`  … and ${byDatetime.size - 5} more clusters.`);
+
+  if (!APPLY) {
+    console.log(`\n[DRY RUN] Pass --apply to delete ${rows.length} bogus rows.`);
+    process.exit(0);
+  }
+
+  if (rows.length === 0) {
+    console.log(`\nNothing to delete. ✅`);
+    process.exit(0);
+  }
+
+  console.log(`\nDeleting ${rows.length} BFI cluster rows…`);
+  const ids = rows.map((r) => r.id);
+  const batchSize = 200;
+  let deleted = 0;
+  for (let j = 0; j < ids.length; j += batchSize) {
+    const batch = ids.slice(j, j + batchSize);
+    const result = await db
+      .delete(screenings)
+      .where(inArray(screenings.id, batch))
+      .returning({ id: screenings.id });
+    deleted += result.length;
+    console.log(`  batch ${Math.floor(j / batchSize) + 1}: deleted ${result.length} rows`);
+  }
+  console.log(`✅ Deleted ${deleted} rows. Run BFI /scrape to re-populate with the fixed parser.`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/cleanup-cinema-source-dupes.ts
+++ b/scripts/cleanup-cinema-source-dupes.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env tsx
+/**
+ * Deduplicate screenings that share (cinema_id, source_id) — collapsing across
+ * BOTH datetime variants (BST off-by-one rescrapes) AND film_id variants
+ * (same source resolved to different films across runs).
+ *
+ * Why a second cleanup script when `dedupe-screening-source-id-duplicates.ts`
+ * already exists:
+ *   - That script keys on (cinema_id, source_id, datetime) → catches same-time
+ *     dupes (e.g. Hard Boiled @ Nickel) but does NOT catch BST-shift dupes
+ *     where the same source_id has rows at datetime + datetime+1h (e.g. Wake
+ *     in Fright @ The Gate: 14:30+00 and 15:30+00 with source_id
+ *     `picturehouse-gate-notting-hill-18642`).
+ *   - This script collapses on (cinema_id, source_id) only — last-scrape wins.
+ *
+ * Winner selection:
+ *   - Same-datetime groups (class 1: film_id mismatch): latest `scraped_at`
+ *     wins. Newer scrape usually has the better film resolution.
+ *   - Different-datetime groups (class 2: BST off-by-one): the EARLIER
+ *     `datetime` wins. The regression always adds +1h to the UTC value, so
+ *     the earlier of any near-60min-apart pair is the BST-correct row. This
+ *     was verified by spot-checking Wake in Fright @ The Gate and Shrek @
+ *     Everyman Maida Vale against the cinemas' upstream listings.
+ *
+ * Loser rows are deleted (and their festival_screenings rows first).
+ *
+ * Scope: ALL rows. We bound to no datetime filter because the companion
+ * migration adds a unique index across the full table; leaving past-dated
+ * dupes in would block the index creation. Past dupes are harmless for the
+ * user experience but the constraint still has to be satisfiable.
+ *
+ * Usage:
+ *   npx dotenv -e .env.local -- npx tsx scripts/cleanup-cinema-source-dupes.ts
+ *   npx dotenv -e .env.local -- npx tsx scripts/cleanup-cinema-source-dupes.ts --apply
+ *   add --verbose to print every group's decision
+ */
+import { db } from "@/db";
+import { screenings } from "@/db/schema";
+import { inArray, sql } from "drizzle-orm";
+
+const APPLY = process.argv.includes("--apply");
+const VERBOSE = process.argv.includes("--verbose");
+
+interface DupRow {
+  id: string;
+  cinema_id: string;
+  source_id: string;
+  datetime: string;
+  film_id: string;
+  film_title: string | null;
+  scraped_at: string;
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `Screenings (cinema_id, source_id) dedup — ${APPLY ? "APPLY" : "DRY RUN"} mode`
+  );
+
+  // Pull every row that's part of a (cinema_id, source_id) group with >1
+  // upcoming row, in a single query. `INNER JOIN` on a CTE of dup keys.
+  const raw = await db.execute(sql`
+    WITH dup_keys AS (
+      SELECT cinema_id, source_id
+      FROM screenings
+      WHERE source_id IS NOT NULL
+      GROUP BY cinema_id, source_id
+      HAVING COUNT(*) > 1
+    )
+    SELECT
+      s.id, s.cinema_id, s.source_id, s.datetime::text AS datetime,
+      s.film_id, f.title AS film_title, s.scraped_at::text AS scraped_at
+    FROM screenings s
+    JOIN dup_keys d ON d.cinema_id = s.cinema_id AND d.source_id = s.source_id
+    LEFT JOIN films f ON f.id = s.film_id
+    ORDER BY s.cinema_id, s.source_id, s.scraped_at DESC
+  `);
+
+  const rows = raw as unknown as DupRow[];
+
+  // Group by (cinema_id, source_id).
+  const groups = new Map<string, DupRow[]>();
+  for (const r of rows) {
+    const key = `${r.cinema_id}|${r.source_id}`;
+    let g = groups.get(key);
+    if (!g) {
+      g = [];
+      groups.set(key, g);
+    }
+    g.push(r);
+  }
+
+  console.log(
+    `\nFound ${groups.size} (cinema_id, source_id) groups covering ${rows.length} rows.\n`
+  );
+
+  // Break down by shape: same-datetime vs different-datetime.
+  let sameDatetimeGroups = 0;
+  let diffDatetimeGroups = 0;
+  const idsToDelete: string[] = [];
+
+  for (const [, g] of groups) {
+    const datetimes = new Set(g.map((r) => r.datetime));
+    if (datetimes.size === 1) sameDatetimeGroups++;
+    else diffDatetimeGroups++;
+
+    // Winner selection — branches on whether all rows share a datetime.
+    //   class 1 (same datetime, dup film_id): latest scraped_at wins
+    //   class 2 (different datetime ~60min apart): earliest datetime wins
+    //                                              (the BST regression always
+    //                                              adds +1h to the UTC value)
+    //
+    // SAFETY: only apply the BST heuristic when the spread is exactly within
+    // [55, 65] minutes. Otherwise the gap is too large to be a BST shift —
+    // could be a legitimate schedule change at the cinema OR a non-BST clock
+    // bug. Fall back to "latest scraped_at wins" in that case rather than
+    // silently picking an arbitrary "earlier" row.
+    const epochs = g.map((r) => new Date(r.datetime).getTime());
+    const spreadMs = Math.max(...epochs) - Math.min(...epochs);
+    const spreadMin = spreadMs / 60_000;
+    const isBstShift = datetimes.size > 1 && spreadMin >= 55 && spreadMin <= 65;
+    g.sort((a, b) => {
+      if (isBstShift && a.datetime !== b.datetime) {
+        return a.datetime.localeCompare(b.datetime); // earlier first
+      }
+      if (b.scraped_at !== a.scraped_at) return b.scraped_at.localeCompare(a.scraped_at);
+      return b.id.localeCompare(a.id);
+    });
+    const winner = g[0];
+    const losers = g.slice(1);
+    for (const l of losers) idsToDelete.push(l.id);
+
+    if (VERBOSE) {
+      console.log(
+        `${g[0].cinema_id} | ${g[0].source_id.slice(0, 70)}${g[0].source_id.length > 70 ? "…" : ""}`
+      );
+      console.log(
+        `  WINNER  ${winner.id.slice(0, 8)} datetime=${winner.datetime.slice(0, 19)} scraped=${winner.scraped_at.slice(0, 19)} film="${winner.film_title}"`
+      );
+      for (const l of losers) {
+        console.log(
+          `   loser  ${l.id.slice(0, 8)} datetime=${l.datetime.slice(0, 19)} scraped=${l.scraped_at.slice(0, 19)} film="${l.film_title}"`
+        );
+      }
+    }
+  }
+
+  console.log(`Same-datetime dup groups (true dupes):       ${sameDatetimeGroups}`);
+  console.log(`Different-datetime dup groups (BST shifts):  ${diffDatetimeGroups}`);
+  console.log(`Rows to delete:                              ${idsToDelete.length}\n`);
+
+  if (!APPLY) {
+    console.log(`[DRY RUN] Re-run with --apply to commit deletions.`);
+    process.exit(0);
+  }
+
+  if (idsToDelete.length === 0) {
+    console.log(`Nothing to delete. ✅`);
+    process.exit(0);
+  }
+
+  // festival_screenings has ON DELETE CASCADE on screening_id, so the join
+  // rows go automatically. Delete screenings in batches.
+  const batchSize = 200;
+  let deleted = 0;
+  for (let i = 0; i < idsToDelete.length; i += batchSize) {
+    const batch = idsToDelete.slice(i, i + batchSize);
+    const result = await db
+      .delete(screenings)
+      .where(inArray(screenings.id, batch))
+      .returning({ id: screenings.id });
+    deleted += result.length;
+    console.log(
+      `  batch ${Math.floor(i / batchSize) + 1}: deleted ${result.length} screenings`
+    );
+  }
+  console.log(`✅ Deleted ${deleted} screening rows.`);
+
+  // Post-apply verification: any remaining (cinema_id, source_id) dups?
+  const remaining = await db.execute(sql`
+    SELECT COUNT(*)::int AS dup_groups
+    FROM (
+      SELECT 1 FROM screenings
+      WHERE source_id IS NOT NULL
+      GROUP BY cinema_id, source_id
+      HAVING COUNT(*) > 1
+    ) t
+  `);
+  console.log(`\nPost-apply remaining (cinema_id, source_id) dup groups:`, remaining);
+  const remainingRows = remaining as unknown as Array<{ dup_groups: number }>;
+  const remainingCount = remainingRows[0]?.dup_groups ?? 0;
+  if (remainingCount > 0) {
+    console.error(
+      `❌ ${remainingCount} groups still duplicated. Unique-index migration will FAIL.`
+    );
+    process.exit(1);
+  }
+  console.log(`✅ No remaining duplicates. Safe to add the unique index.`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("ERR:", e);
+  process.exit(1);
+});

--- a/src/db/migrations/0011_screenings_cinema_source_unique.sql
+++ b/src/db/migrations/0011_screenings_cinema_source_unique.sql
@@ -1,0 +1,19 @@
+-- Prevent (cinema_id, source_id) duplicate rows on `screenings`.
+--
+-- Why: the existing unique index is on (film_id, cinema_id, datetime) which
+-- doesn't catch two scrapes mapping the same (cinema_id, source_id) to
+-- different rows — either via different film_id resolutions (e.g. Hard Boiled
+-- @ The Nickel) or via BST off-by-one regressions producing datetime+1h
+-- duplicates (e.g. Wake in Fright @ The Gate, Shrek @ Everyman Maida Vale).
+--
+-- The partial WHERE clause excludes rows without a source_id; some legacy
+-- scrapers may still emit null source_ids, and we still want them to insert.
+--
+-- Companion change: the upsert in `processScreenings` (src/scrapers/pipeline.ts)
+-- now uses (cinema_id, source_id) as conflict target when source_id is set,
+-- so a re-scrape with corrected datetime UPDATEs in place instead of inserting
+-- a new row.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_screenings_cinema_source
+  ON screenings (cinema_id, source_id)
+  WHERE source_id IS NOT NULL;

--- a/src/scrapers/bfi-pdf/programme-changes-parser.test.ts
+++ b/src/scrapers/bfi-pdf/programme-changes-parser.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { parseChangesPage } from "./programme-changes-parser";
+
+describe("parseChangesPage — film text isolation", () => {
+  it("does NOT propagate one film's screening times to sibling films in the same paragraph", () => {
+    // Reproduces the production bug observed 2026-05-15: six unrelated films
+    // (Rose of Nevada, Surviving Earth, The Christophers, ...) all stored at
+    // 2026-05-15 11:50:00+00 because `getFollowingText` previously grabbed the
+    // entire parent's text via `$el.parent().text()`.
+    //
+    // Fixture: two films share the same <p>. Only the FIRST has a screening
+    // time. The SECOND should produce zero screenings.
+    const futureYear = new Date().getFullYear() + 1;
+    const html = `
+      <html><body><main>
+        <p>
+          <b>Rose of Nevada</b> A short description. Fri 9 Aug 11:50 NFT4 p10 — extra screening added.
+          <b>Surviving Earth</b> A different film with no times listed yet.
+        </p>
+      </main></body></html>
+    `.replace(/Aug/g, monthAbbrev(futureYear - new Date().getFullYear() > 0 ? 8 : new Date().getMonth() + 1));
+
+    const result = parseChangesPage(html);
+    const titles = result.changes.map((c) => c.filmTitle);
+    expect(titles).toContain("Rose of Nevada");
+
+    // Lock-in invariant: total emitted screenings across the page is exactly 1
+    // (Rose of Nevada's 11:50). Pre-fix, this was 2 — Surviving Earth had also
+    // inherited the same time via shared parent text. Under the new
+    // `getFollowingText`, Surviving Earth has zero screenings and is filtered
+    // out by `parseChangesPage` (no screenings → not added to `changes`).
+    expect(result.screenings.length).toBe(1);
+    expect(titles).not.toContain("Surviving Earth");
+  });
+
+  it("keeps multiple times for a single film when each has a day-name prefix", () => {
+    // The regex requires a day-name prefix on every match — pre-existing parser
+    // limitation. Lock in current behaviour: each "Day DD Mon HH:MM Venue"
+    // tuple becomes a screening; bare "and HH:MM Venue" continuations on the
+    // same line do NOT (known gap, tracked separately). The walker fix must
+    // not regress past the regex coverage.
+    const html = `
+      <html><body><main>
+        <p><b>Cabaret</b> Fri 9 Aug 11:50 NFT4 p10; Sat 10 Aug 20:30 NFT4 p10</p>
+      </main></body></html>
+    `;
+    const result = parseChangesPage(html);
+    const cabaret = result.changes.find((c) => c.filmTitle === "Cabaret");
+    expect(cabaret).toBeDefined();
+    expect(cabaret?.screenings.length).toBe(2);
+  });
+
+  it("isolates films across separate paragraphs", () => {
+    const html = `
+      <html><body><main>
+        <p><b>Film A</b> Sat 30 Aug 14:00 NFT2 p20</p>
+        <p><b>Film B</b> Sun 31 Aug 18:30 NFT3 p21</p>
+      </main></body></html>
+    `;
+
+    const result = parseChangesPage(html);
+    const filmA = result.changes.find((c) => c.filmTitle === "Film A");
+    const filmB = result.changes.find((c) => c.filmTitle === "Film B");
+
+    // Each film keeps only its own screening — A at 14:00, B at 18:30.
+    const aTimes = (filmA?.screenings ?? []).map((s) => s.datetime.getUTCHours());
+    const bTimes = (filmB?.screenings ?? []).map((s) => s.datetime.getUTCHours());
+    expect(aTimes.length).toBe(1);
+    expect(bTimes.length).toBe(1);
+    // 14:00 BST = 13:00 UTC; 18:30 BST = 17:30 UTC (August is BST).
+    expect(aTimes[0]).toBe(13);
+    expect(bTimes[0]).toBe(17);
+  });
+});
+
+// August is BST in the UK. The fixture year is the next August relative to
+// "today" so screenings aren't filtered as past by `parseScreeningsFromText`.
+function monthAbbrev(monthNum1Based: number): string {
+  const m = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return m[monthNum1Based - 1];
+}

--- a/src/scrapers/bfi-pdf/programme-changes-parser.ts
+++ b/src/scrapers/bfi-pdf/programme-changes-parser.ts
@@ -18,7 +18,7 @@
 
 import * as cheerio from "cheerio";
 import type { RawScreening } from "../types";
-import type { CheerioSelection } from "../utils/cheerio-types";
+import type { CheerioAPI, CheerioSelection } from "../utils/cheerio-types";
 import { fetchWithRetry } from "../utils/fetch-with-retry";
 import { CHROME_USER_AGENT_FULL } from "../constants";
 import { buildBFISearchUrl } from "./url-builder";
@@ -177,7 +177,7 @@ export function parseChangesPage(html: string): ProgrammeChangesResult {
 
     // Get the following text for screening info and notes
     const parentText = $el.parent().text();
-    const nextText = getFollowingText($el);
+    const nextText = getFollowingText($, $el);
 
     // Determine change type
     let changeType: ProgrammeChange["changeType"] = "other";
@@ -229,29 +229,93 @@ export function parseChangesPage(html: string): ProgrammeChangesResult {
 }
 
 /**
- * Get text following a bold element
+ * Get text following a bold element — bounded by the NEXT bold element so
+ * each film entry only sees its own screening times.
+ *
+ * The previous implementation called `$el.parent().text()` which returned the
+ * full parent text including every sibling `<b>` and its screening lines.
+ * Result: every film in a multi-film paragraph was matched against the SAME
+ * pool of times, producing rows like "Rose of Nevada / Surviving Earth /
+ * The Christophers all at 2026-05-15 11:50" — one real screening propagated
+ * to six unrelated films. See `programme-changes-parser.test.ts` for the
+ * fixture that reproduces the bug.
+ *
+ * The fixed walk:
+ *   1. Collect text from the current `<b>`'s sibling nodes until the next
+ *      `<b>`/`<strong>` at the same DOM level is reached.
+ *   2. If the paragraph ends without exhausting siblings, continue into
+ *      subsequent block-level siblings (paragraphs, divs) up to a small
+ *      cap, stopping at any element that contains a bold tag.
  */
-function getFollowingText($el: CheerioSelection): string {
+function getFollowingText($: CheerioAPI, $el: CheerioSelection): string {
   const parts: string[] = [];
 
-  // Get text from same parent
-  const parentText = $el.parent().text();
-  parts.push(parentText);
+  // 1. Walk through sibling nodes AFTER this <b> within its parent. Stop the
+  //    moment we hit another <b>/<strong> — that's the next film entry.
+  let hitNextBold = false;
+  let $sib = $el.next();
+  while ($sib.length) {
+    const tag = ($sib.get(0) as { tagName?: string }).tagName?.toLowerCase();
+    if (tag === "b" || tag === "strong") {
+      hitNextBold = true;
+      break;
+    }
+    parts.push($sib.text());
+    $sib = $sib.next();
+  }
 
-  // Get next siblings' text
-  let $next = $el.parent().next();
-  let count = 0;
-  while ($next.length && count < 10) {
-    const text = $next.text().trim();
-    if (text) {
-      // Stop if we hit another film title (bold text at start)
-      if ($next.find("b, strong").length && $next.find("b, strong").first().text().trim() === $next.text().trim()) {
+  // Cheerio's `nextAll()`/`.next()` skips raw text nodes. If our scan returned
+  // nothing, the parent likely has the screening times as direct text content.
+  // Fall back to slicing the parent's text between THIS <b>'s text and the
+  // next sibling <b>'s text.
+  if (parts.length === 0) {
+    const parentText = $el.parent().text();
+    const ownText = $el.text();
+    const startIdx = parentText.indexOf(ownText);
+    if (startIdx >= 0) {
+      let slice = parentText.slice(startIdx + ownText.length);
+      // Truncate at the next bold sibling's text, if any.
+      $el
+        .parent()
+        .find("b, strong")
+        .each((_: number, b: unknown) => {
+          if (b === $el.get(0)) return;
+          const bText = $(b as Parameters<typeof $>[0]).text();
+          const pos = slice.indexOf(bText);
+          if (pos > 0) {
+            slice = slice.slice(0, pos);
+            return false;
+          }
+          return undefined;
+        });
+      parts.push(slice);
+    }
+  }
+
+  // 2. If we didn't hit a bold sibling in this parent, continue into the
+  //    next block-level siblings (paragraphs/divs). Stop at the first one
+  //    whose first bold element marks the next film.
+  if (!hitNextBold) {
+    let $nextBlock = $el.parent().next();
+    let walked = 0;
+    while ($nextBlock.length && walked < 6) {
+      const $firstBold = $nextBlock.find("b, strong").first();
+      if ($firstBold.length) {
+        const blockText = $nextBlock.text();
+        const boldText = $firstBold.text().trim();
+        if (boldText === blockText.trim()) {
+          // Whole block is the next film title — stop entirely.
+          break;
+        }
+        // Bold appears mid-block. Take only text before it, then stop.
+        const idx = blockText.indexOf(boldText);
+        if (idx > 0) parts.push(blockText.slice(0, idx));
         break;
       }
-      parts.push(text);
+      parts.push($nextBlock.text());
+      $nextBlock = $nextBlock.next();
+      walked++;
     }
-    $next = $next.next();
-    count++;
   }
 
   return parts.join(" ");

--- a/src/scrapers/pipeline.ts
+++ b/src/scrapers/pipeline.ts
@@ -528,6 +528,11 @@ async function insertScreening(
         .update(screeningsTable)
         .set({
           filmId,
+          // Always update datetime — a re-scrape may correct a BST-shift bug
+          // (Layer 0 of checkForDuplicate now matches on cinemaId+sourceId only,
+          // so we can land here with a different `duplicate.datetime`). Setting
+          // it unconditionally heals the row instead of leaving the old value.
+          datetime: screening.datetime,
           format: metadata.format,
           screen: screening.screen,
           isSpecialEvent: metadata.isSpecialEvent,
@@ -570,9 +575,16 @@ async function insertScreening(
     return false; // Updated, not added
   }
 
-  // Insert new screening with conflict handling for race conditions
+  // Insert new screening with conflict handling for race conditions.
+  //
+  // Conflict target depends on whether sourceId is present:
+  //   - With sourceId: use the (cinema_id, source_id) partial unique index.
+  //     This catches BST-shift dupes — a concurrent scrape inserting the same
+  //     source at a different datetime updates the existing row in place.
+  //   - Without sourceId: fall back to the legacy (film_id, cinema_id, datetime)
+  //     unique index for the handful of scrapers that don't emit source_ids.
   const now = new Date();
-  await db.insert(screeningsTable).values({
+  const baseValues = {
     id: uuidv4(),
     filmId,
     cinemaId,
@@ -591,19 +603,32 @@ async function insertScreening(
     bookingUrl: screening.bookingUrl,
     sourceId: screening.sourceId,
     scrapedAt: now,
-    // Set festival flag
     isFestivalScreening: !!screening.festivalSlug,
-    // Availability status from scraper
     availabilityStatus: screening.availabilityStatus ?? null,
     availabilityCheckedAt: screening.availabilityStatus ? now : null,
-  }).onConflictDoUpdate({
-    target: [screeningsTable.filmId, screeningsTable.cinemaId, screeningsTable.datetime],
-    set: {
-      scrapedAt: now,
-      bookingUrl: screening.bookingUrl,
-      updatedAt: now,
-    },
-  });
+  };
+
+  if (screening.sourceId) {
+    await db.insert(screeningsTable).values(baseValues).onConflictDoUpdate({
+      target: [screeningsTable.cinemaId, screeningsTable.sourceId],
+      set: {
+        filmId,
+        datetime: screening.datetime,
+        scrapedAt: now,
+        bookingUrl: screening.bookingUrl,
+        updatedAt: now,
+      },
+    });
+  } else {
+    await db.insert(screeningsTable).values(baseValues).onConflictDoUpdate({
+      target: [screeningsTable.filmId, screeningsTable.cinemaId, screeningsTable.datetime],
+      set: {
+        scrapedAt: now,
+        bookingUrl: screening.bookingUrl,
+        updatedAt: now,
+      },
+    });
+  }
 
   // Handle festival linking
   if (screening.festivalSlug) {

--- a/src/scrapers/utils/screening-classification.ts
+++ b/src/scrapers/utils/screening-classification.ts
@@ -136,7 +136,14 @@ export async function checkForDuplicate(
   normalizeTitle: (title: string) => string,
   sourceId?: string
 ): Promise<DuplicateCheckResult> {
-  // Layer 0: same (cinemaId, sourceId, datetime) regardless of filmId.
+  // Layer 0: same (cinemaId, sourceId) regardless of filmId or datetime.
+  //
+  // Datetime is intentionally NOT in the WHERE clause — if it were, a re-scrape
+  // with a corrected datetime (e.g. after a BST timezone-conversion regression
+  // is fixed) would miss the existing row and insert a fresh one, leaving the
+  // old (wrong-hour) row stranded. Without the datetime filter, the caller can
+  // UPDATE the existing row's datetime in place. The companion unique index
+  // `idx_screenings_cinema_source` enforces this invariant at the DB level.
   if (sourceId) {
     const [bySource] = await db
       .select()
@@ -144,8 +151,7 @@ export async function checkForDuplicate(
       .where(
         and(
           eq(screeningsTable.cinemaId, cinemaId),
-          eq(screeningsTable.sourceId, sourceId),
-          eq(screeningsTable.datetime, datetime)
+          eq(screeningsTable.sourceId, sourceId)
         )
       )
       .limit(1);


### PR DESCRIPTION
## Summary
- Cleans up **1,065 duplicate/bogus screening rows** across three distinct bugs (BST off-by-one rescrapes, film-id flips, BFI parser cluster bug).
- Adds a **partial unique index** `(cinema_id, source_id) WHERE source_id IS NOT NULL` to make recurrence impossible at the DB level.
- Branches `processScreenings` upsert: `(cinema_id, source_id)` when sourceId is set, else legacy target. `checkForDuplicate` Layer 0 drops the `datetime` predicate so a BST-corrected re-scrape heals the existing row in place.
- Fixes the BFI programme-changes parser's `getFollowingText` to stop at the next `<b>`/`<strong>` instead of grabbing the whole parent paragraph.

## Root causes
| Class | Example | Cause |
|---|---|---|
| Same datetime, different film_id | Hard Boiled @ The Nickel, 16:15 × 2 | Duplicate rows in `films` table resolved as different `film_id`s across runs. Existing unique index `(film_id, cinema_id, datetime)` lets them both insert. |
| Different datetime ~60min apart | Wake in Fright @ The Gate (15:30 + 16:30), Shrek @ Everyman Maida Vale (10:30 + 11:30) | BST regression rescrape produces datetime+1h. `checkForDuplicate` Layer 0 required matching datetime so it missed the existing row. |
| Many films at same datetime | BFI Southbank: Rose of Nevada, Surviving Earth, The Christophers, Mother Mary all at 11:50 | `getFollowingText` returned `$el.parent().text()` — every film in a multi-film paragraph saw every sibling's screening times. |

## Test plan
- [x] `npx tsc --noEmit` clean for modified files
- [x] `npm run lint` clean (0 errors)
- [x] `npm run test:run` → 912 / 912 pass, including 3 new BFI parser regression tests
- [x] `scripts/audit-screening-duplicates.ts` reports `dup_triples: 0` post-cleanup
- [x] Migration verified in `pg_indexes`: `idx_screenings_cinema_source` present with partial `WHERE (source_id IS NOT NULL)` clause
- [x] PCC source_id uniqueness verified (611 rows / 611 distinct sources) — no data-loss risk from the new constraint

## Cleanup applied to prod
- 710 (cinema_id, source_id) dupes in upcoming screenings
- 254 (cinema_id, source_id) dupes in past screenings (needed to satisfy the new unique index)
- 351 BFI Southbank cluster rows
- **Total: 1,315 rows deleted**

🤖 Generated with [Claude Code](https://claude.com/claude-code)