### PR TITLE
fix(scrape): set is_repertory at TMDB UPDATE + filter stale by is_active

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-05-15: /scrape follow-ups — is_repertory at write time + stale-cinema is_active filter
+**PR**: TBD | **Files**: `src/scripts/cleanup-upcoming-films.ts`, `src/lib/scrape-quarantine.ts`
+- Closes the cycle-N+1 patrol dependency for `is_repertory`: the TMDB-match UPDATE path in `cleanup-upcoming-films.ts` now sets `isRepertory: isRepertoryFilm(release_date)` alongside `year`. The patrol caught 5 misflagged films in 5 consecutive cycles before this; now repertory films are tagged at write time using the same helper `film-matching.ts` already uses.
+- `detectStaleCinemas` now filters `WHERE c.is_active = true`, excluding 5 zombie cinemas (curzon-camden / curzon-richmond / curzon-wimbledon / everyman-walthamstow / nickel) that would otherwise appear as "never scraped" in every `/scrape` post-run report indefinitely.
+
+---
+
 ## 2026-05-15: Push recurring data-check fixes into /scrape (prefix/suffix sync + foreign-bracket + write guards + stale surfacing)
 **PR**: TBD | **Files**: `src/scrapers/utils/film-title-cleaner.ts`, `src/scrapers/utils/film-write-guards.ts` (new), `src/scrapers/pipeline.ts`, `src/scrapers/utils/film-matching.ts`, `src/scripts/cleanup-upcoming-films.ts`, `src/lib/scrape-quarantine.ts`, `src/scripts/run-scrape-and-enrich.ts`, plus tests
 - **Patrol-learned prefixes/suffixes feed the scraper**: `film-title-cleaner` now loads `.claude/data-check-learnings.json` at module init and appends `prefixesToStrip` (79) + `suffixesToStrip` (25) to its existing hand-curated lists. Gracefully degrades to empty arrays when the file isn't present (CI / fresh checkouts). Same patterns the patrol fixes after-the-fact now apply at scrape time.

--- a/changelogs/2026-05-15-scrape-improvements-followup.md
+++ b/changelogs/2026-05-15-scrape-improvements-followup.md
@@ -1,0 +1,42 @@
+# /scrape follow-ups — is_repertory at write time + stale-cinema is_active filter
+
+**PR**: TBD
+**Date**: 2026-05-15
+
+## Problem
+
+Post-mortem of `Pictures/Data Quality/patrol-2026-05-15-*.md` (cycles 19 + 20) surfaced two recurring patterns that the prior `/scrape` PRs didn't close:
+
+1. **`is_repertory` misflagged cycle-after-cycle.** 5 consecutive patrols (iter-91, iter-98, iter-103, iter-113, iter-115) each fixed exactly one `wrong_new_tag` issue — a repertory film (year < currentYear - 2) left at the default `is_repertory=false`. Patrol-1758's own diagnosis: *"100% catch rate for this specific class of follow-up. Compelling argument for adding `is_repertory = year < current_year - 2` directly to setTitleAndTmdb to eliminate the cycle-N+1 dependency."* Confirmed in DB: 8 films currently misflagged.
+   - **Root cause**: `src/scrapers/utils/film-matching.ts:239` already calls `isRepertoryFilm(release_date)` on INSERT, but `src/scripts/cleanup-upcoming-films.ts:250-279` (the TMDB-matched UPDATE path) wrote `year` without recomputing `is_repertory`. So a freshly-enriched repertory film kept the default until the patrol noticed.
+
+2. **`detectStaleCinemas` permanently lists inactive zombies.** The function shipped in PR #494 ignored `cinemas.is_active`. The next `/scrape` post-run report would have listed these 5 cinemas as "never scraped" forever: `curzon-camden`, `curzon-richmond`, `curzon-wimbledon`, `everyman-walthamstow`, `nickel` — all `is_active=false`, all have no scraper by design.
+
+## Changes
+
+### `src/scripts/cleanup-upcoming-films.ts`
+- New import: `isRepertoryFilm` from `@/lib/tmdb/match` (the same helper `film-matching.ts:239` and `:267` already use).
+- In the TMDB-match UPDATE around line 257, added `isRepertory: isRepertoryFilm(details.details.release_date)` alongside the existing `year: sanitizeYear(tmdbMatch.year)`.
+
+### `src/lib/scrape-quarantine.ts::detectStaleCinemas`
+- Added `WHERE c.is_active = true` to the SQL between `LEFT JOIN scraper_runs` and `GROUP BY`.
+- Updated docstring (lines 109–120) to note that inactive cinemas are excluded with the rationale (zombie rows the user can't action).
+
+## Impact
+
+- **Patrols**: the recurring `wrong_new_tag` follow-up should drop to zero. Next 5 cycles should not see another iter-N+1 fix of this kind.
+- **`/scrape` report**: post-run output's "Stale cinemas" block now reflects only actionable cinemas. Users see the actual stale set, not noise from rows that haven't moved in months by design.
+- **Existing 8 misflagged rows**: will self-heal on the next `cleanup:upcoming` pass since the same script that left them broken now writes the flag correctly. No backfill needed.
+
+## Verification
+
+- Type-check (`npx tsc --noEmit`): clean.
+- Lint (`npm run lint`): 0 errors.
+- Vitest (`npm run test:run`): 931 / 931 pass.
+- Live DB check (`detectStaleCinemas()` against prod): inactive set reported as 0 (was 5 pre-change).
+- Patrol regression: next `/data-check` after a `/scrape` should report 0 `wrong_new_tag` fixes.
+
+## Out of scope (deferred)
+- Tier 2 phantom-screening surfacing (needs auto-delete vs warn design decision).
+- Wave-by-wave failure detail in the report (separate observability PR).
+- Booking-URL verifier rework.

--- a/src/lib/scrape-quarantine.ts
+++ b/src/lib/scrape-quarantine.ts
@@ -117,14 +117,20 @@ export interface StaleCinema {
  *
  * Used in the /scrape post-run report to surface cinemas the user should
  * investigate. Read-only.
+ *
+ * Inactive cinemas (`is_active = false`) are excluded — they have no scraper
+ * by design (e.g. permanently-closed Everyman Walthamstow, orphan `nickel`
+ * row superseded by `the-nickel`, defunct Curzon Camden/Richmond/Wimbledon).
+ * Including them would mean every /scrape run reports the same 5 "never
+ * scraped" zombies indefinitely.
  */
 export async function detectStaleCinemas(options?: {
   thresholdHours?: number;
 }): Promise<StaleCinema[]> {
   const thresholdHours = options?.thresholdHours ?? 24;
 
-  // For each cinema, get the most recent run's startedAt and compute hours
-  // since. Done in a single query rather than N+1.
+  // For each ACTIVE cinema, get the most recent run's startedAt and compute
+  // hours since. Done in a single query rather than N+1.
   const rows = await db.execute(sql`
     SELECT
       c.id AS cinema_id,
@@ -132,6 +138,7 @@ export async function detectStaleCinemas(options?: {
       EXTRACT(EPOCH FROM (NOW() - MAX(r.started_at))) / 3600.0 AS hours_since
     FROM cinemas c
     LEFT JOIN scraper_runs r ON r.cinema_id = c.id
+    WHERE c.is_active = true
     GROUP BY c.id, c.name
     HAVING (MAX(r.started_at) IS NULL OR EXTRACT(EPOCH FROM (NOW() - MAX(r.started_at))) / 3600.0 > ${thresholdHours})
     -- NULLS FIRST: never-scraped cinemas are the most urgent case and must

--- a/src/scripts/cleanup-upcoming-films.ts
+++ b/src/scripts/cleanup-upcoming-films.ts
@@ -18,6 +18,7 @@ import { db } from "@/db";
 import { films, screenings } from "@/db/schema";
 import { eq, isNull, gte, and } from "drizzle-orm";
 import { matchFilmToTMDB, getTMDBClient } from "@/lib/tmdb";
+import { isRepertoryFilm } from "@/lib/tmdb/match";
 import { extractFilmTitle } from "@/lib/title-extraction";
 import { cleanFilmTitle } from "@/scrapers/pipeline";
 import { decodeHtmlEntities } from "@/scripts/enrich-upcoming-films";
@@ -256,6 +257,10 @@ async function phase2TMDBMatching(upcomingFilms: FilmRow[]): Promise<{ matched: 
           title: details.details.title,
           originalTitle: details.details.original_title,
           year: sanitizeYear(tmdbMatch.year),
+          // Compute is_repertory at write time so the cycle-N+1 patrol fix
+          // (5+ patrols in a row caught films left at the default false here)
+          // becomes unnecessary. Same predicate as film-matching.ts:239.
+          isRepertory: isRepertoryFilm(details.details.release_date),
           runtime: details.details.runtime || null,
           directors: sanitizeDirectors(
             details.directors.length > 0 ? details.directors : film.directors,


### PR DESCRIPTION
## Summary
Two small follow-ups from today's patrol-log audit (cycles 19+20).

### 1. `is_repertory` at TMDB-match UPDATE write site
- `cleanup-upcoming-films.ts:257` now calls `isRepertoryFilm(release_date)` — same helper `film-matching.ts:239` already uses on INSERT.
- Closes the cycle-N+1 dependency where the patrol caught `wrong_new_tag` fixes **5 cycles in a row** (iter-91, -98, -103, -113, -115). From patrol-1758: *"100% catch rate for this specific class of follow-up."*
- DB currently has 8 misflagged films; they self-heal on the next `cleanup:upcoming` pass.

### 2. `detectStaleCinemas` filters `is_active=true`
- Stops the `/scrape` post-run report from permanently listing 5 zombie cinemas as "never scraped": `curzon-camden`, `curzon-richmond`, `curzon-wimbledon`, `everyman-walthamstow`, `nickel`. All have `is_active=false` by design.

## Test plan
- [x] Type-check clean
- [x] Lint clean (0 errors)
- [x] Vitest: 931/931 pass
- [x] Live DB check: `detectStaleCinemas()` now reports 0 inactive cinemas (was 5)
- [ ] Patrol regression: next `/data-check` after a `/scrape` should report 0 `wrong_new_tag` fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)