### PR TITLE
feat(goal): terminal goal-driven loop with measurable end conditions

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-05-15: /goal command — terminal goal-driven loop with measurable end conditions
+**PR**: TBD | **Files**: `tasks/goal.md`, `scripts/goal-check-{coverage,silent-breakers,booking-links,lighthouse,axe,posthog-funnel,dqs}.ts`, `scripts/goal-status.ts`, `changelogs/2026-05-15-goal-command.md`
+- New `/goal` slash command (local in `.claude/commands/`): unlike `/kaizen` and `/posthog-optimize` (perpetual), this one declares an explicit finish line and exits when crossed. Reads `tasks/goal.md`, runs all measurement scripts, picks the highest-leverage failing condition, fixes one sub-task per invocation, holds merge behind the existing `ship it` deployment gate.
+- Goal: "Pictures.london v1 — complete, fast, accessible, trustworthy". Seven end conditions: London independents covered, no silent breakers, zero broken booking links, Lighthouse mobile ≥90, axe-core clean, PostHog `booking_click` proof-of-life per cinema, DQS floor ≥85 across two consecutive `/data-check` runs.
+- Orchestrator (`scripts/goal-status.ts`) runs every check, prints status table, writes `.claude/goal-status.json` for the slash command to read. `--fast` skips lighthouse + axe for inner-loop iteration.
+- No new dependencies — lighthouse and axe-core invoked via `npx` on demand per CLAUDE.md dep-rule.
+
+---
+
 ## 2026-05-15: /scrape follow-ups — is_repertory at write time + stale-cinema is_active filter
 **PR**: TBD | **Files**: `src/scripts/cleanup-upcoming-films.ts`, `src/lib/scrape-quarantine.ts`
 - Closes the cycle-N+1 patrol dependency for `is_repertory`: the TMDB-match UPDATE path in `cleanup-upcoming-films.ts` now sets `isRepertory: isRepertoryFilm(release_date)` alongside `year`. The patrol caught 5 misflagged films in 5 consecutive cycles before this; now repertory films are tagged at write time using the same helper `film-matching.ts` already uses.

--- a/changelogs/2026-05-15-goal-command.md
+++ b/changelogs/2026-05-15-goal-command.md
@@ -1,0 +1,33 @@
+# /goal command — terminal goal-driven loop with measurable end conditions
+
+**PR**: TBD
+**Date**: 2026-05-15
+
+## Changes
+
+- Added `tasks/goal.md` — the single canonical goal definition file. Declares the project's current top-level goal ("Pictures.london v1 — complete, fast, accessible, trustworthy"), seven measurable end conditions, and a cursor block the slash command updates after each invocation.
+- Added `.claude/commands/goal.md` — the `/goal` slash command spec. Phase-by-phase: pre-flight gate → assess all conditions → achievement check (early exit if all pass) → pick the highest-leverage failing condition → pick or write one sub-task → implement on a feature branch → verify → ship behind the `ship it` deployment gate → update cursor → print summary.
+- Added seven end-condition measurement scripts under `scripts/`:
+  - `goal-check-coverage.ts` — parses the coverage-target list from `tasks/goal.md` and verifies each cinema slug is active in the DB and has a recent successful scrape.
+  - `goal-check-silent-breakers.ts` — wraps `detectSilentBreakers` (will tighten to require zero critical flakies when the ratio-based detector lands on main).
+  - `goal-check-booking-links.ts` — HEAD/GET probe of a 25-screening sample per active cinema. Passes when hard 404/410 rate is 0 AND non-2xx rate < 5%.
+  - `goal-check-lighthouse.ts` — shells out to `npx lighthouse@12` for mobile + desktop. Passes when both score ≥ 90 on perf/a11y/SEO.
+  - `goal-check-axe.ts` — shells out to `npx @axe-core/cli@4` for mobile + desktop viewports. Passes when zero `critical` or `serious` violations.
+  - `goal-check-posthog-funnel.ts` — HogQL query for `booking_click` events per `properties.cinema_id` in trailing 30d. Passes when every active cinema has ≥ 1 click recorded.
+  - `goal-check-dqs.ts` — reads the two most recent DQS scores from `.claude/data-check-learnings.json`. Passes when both are ≥ 85.
+- Added `scripts/goal-status.ts` — the orchestrator. Spawns every measurement script, prints a status table, writes a machine-readable summary to `.claude/goal-status.json` for the slash command to consume. Accepts `--fast` to skip the slow checks (lighthouse + axe).
+
+## Impact
+
+- **Who:** The project's autonomous-improvement system. `/goal` complements but does not replace the perpetual loops (`/kaizen`, `/posthog-optimize`, `/data-check`, `/spot-check`). Those keep running indefinitely; `/goal` declares "the project is done improving along this axis" and exits.
+- **Risk surface:** Zero on the backend scrape pipeline — none of the new scripts mutate data. Booking-link probes are pure HTTP HEAD/GET. PostHog query is read-only. The slash command's Phase 6 ("Ship") requires the user's `ship it` keyword, so no merges happen without explicit approval.
+- **Dependency posture:** No new packages added. Lighthouse and axe-core are run via `npx`, downloaded on first invocation, cached afterwards. This honors the CLAUDE.md "no new deps without asking" rule.
+- **Operational note:** End condition #6 (PostHog funnel) requires `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID` in `.env.local`. The other six conditions need only the existing `.env.local` (DB + `.claude/data-check-learnings.json`).
+- **First-run state (informational):** At the time of writing, the DQS floor is failing (76.62 / 77.42 vs. 85 target). The first `/goal` invocation will surface this as the targeted condition.
+
+## Verification
+
+- `npx tsc --noEmit` clean.
+- `npx eslint scripts/goal-*.ts` clean (one `let → const` fixup applied during build).
+- DQS check smoke-tested locally — returns valid JSON, correctly reports current state.
+- Goal-file regex parser smoke-tested — extracts all 7 coverage-target slugs.

--- a/scripts/goal-check-axe.ts
+++ b/scripts/goal-check-axe.ts
@@ -1,0 +1,112 @@
+/**
+ * End-condition #5: axe-core clean.
+ *
+ * Shells out to `npx @axe-core/cli` against pictures.london at mobile + desktop
+ * viewports. No dep added — npx fetches axe-core/cli on demand (cached after
+ * first run).
+ *
+ * Passes when there are zero violations at impact `critical` or `serious`
+ * across both viewport runs.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-axe.ts
+ */
+import { execFileSync } from "node:child_process";
+
+const TARGET_URL = process.env.GOAL_AXE_URL ?? "https://pictures.london/";
+
+interface AxeViolation {
+  id: string;
+  impact: "critical" | "serious" | "moderate" | "minor" | null;
+  help: string;
+  nodes: { html: string }[];
+}
+
+interface AxeResult {
+  violations: AxeViolation[];
+}
+
+function runAxe(viewport: "mobile" | "desktop"): AxeViolation[] {
+  // axe-core/cli supports --chromedriver-path, but we let it use Chromium
+  // bundled with Playwright. Pass viewport via `--browser`-args isn't directly
+  // supported; instead we use a Chrome window size flag via --chrome-options.
+  // The CLI's `--save` writes JSON to disk; we use stdout via --stdout.
+  const windowSize = viewport === "mobile" ? "390,844" : "1280,800";
+  const args = [
+    "-y",
+    "@axe-core/cli@4",
+    TARGET_URL,
+    "--stdout",
+    "--exit",
+    "--tags",
+    "wcag2a,wcag2aa,wcag21a,wcag21aa",
+    "--chrome-options",
+    `headless=new,window-size=${windowSize},no-sandbox`,
+  ];
+
+  let stdout = "";
+  try {
+    stdout = execFileSync("npx", args, {
+      encoding: "utf-8",
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err: unknown) {
+    // axe-core/cli exits non-zero when violations exist; that's expected.
+    const e = err as { stdout?: Buffer | string };
+    stdout = typeof e.stdout === "string" ? e.stdout : (e.stdout?.toString("utf-8") ?? "");
+  }
+
+  // The CLI emits a mix of human-readable and JSON. Find the JSON block.
+  const jsonStart = stdout.indexOf("[");
+  if (jsonStart < 0) {
+    throw new Error(`axe-core/cli produced no JSON output (got ${stdout.length} chars)`);
+  }
+  const arr = JSON.parse(stdout.slice(jsonStart)) as AxeResult[];
+  return arr.flatMap((r) => r.violations);
+}
+
+async function main() {
+  if (process.env.GOAL_SKIP_AXE === "1") {
+    console.log(JSON.stringify({ condition: "axe", pass: false, skipped: true, reason: "GOAL_SKIP_AXE=1" }, null, 2));
+    process.exit(1);
+  }
+
+  const mobile = runAxe("mobile");
+  const desktop = runAxe("desktop");
+  const combined = [...mobile, ...desktop];
+  const blockers = combined.filter((v) => v.impact === "critical" || v.impact === "serious");
+  const pass = blockers.length === 0;
+
+  const summarise = (vs: AxeViolation[]) => {
+    const by = new Map<string, { impact: string; help: string; count: number }>();
+    for (const v of vs) {
+      const cur = by.get(v.id) ?? { impact: v.impact ?? "unknown", help: v.help, count: 0 };
+      cur.count += v.nodes.length;
+      by.set(v.id, cur);
+    }
+    return Array.from(by.entries()).map(([id, b]) => ({ id, ...b }));
+  };
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "axe",
+        pass,
+        target: TARGET_URL,
+        blockerCount: blockers.length,
+        blockers: summarise(blockers).slice(0, 20),
+        mobileSummary: summarise(mobile).slice(0, 10),
+        desktopSummary: summarise(desktop).slice(0, 10),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ condition: "axe", pass: false, error: String(err).slice(0, 500) }));
+  process.exit(1);
+});

--- a/scripts/goal-check-axe.ts
+++ b/scripts/goal-check-axe.ts
@@ -107,6 +107,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(JSON.stringify({ condition: "axe", pass: false, error: String(err).slice(0, 500) }));
+  console.log(JSON.stringify({ condition: "axe", pass: false, error: String(err).slice(0, 500) }));
   process.exit(1);
 });

--- a/scripts/goal-check-booking-links.ts
+++ b/scripts/goal-check-booking-links.ts
@@ -1,0 +1,179 @@
+/**
+ * End-condition #3: Zero broken booking links.
+ *
+ * Samples up to N future screenings per active cinema and checks each
+ * `booking_url` over HTTP (HEAD, GET fallback). Reports per-cinema stats.
+ *
+ * Passes when:
+ *   - Hard 404/410 rate is 0% across the sample
+ *   - Total non-2xx rate is < 5%
+ *
+ * Cinemas in `bookingLinkExclusions` are skipped (e.g. SPAs that always
+ * 200 on a static shell — those should be verified by end-condition #6
+ * via PostHog booking_click data instead).
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-booking-links.ts
+ */
+import { and, eq, gte, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { cinemas } from "@/db/schema/cinemas";
+import { screenings } from "@/db/schema/screenings";
+
+const SAMPLE_PER_CINEMA = 25;
+const HARD_FAIL_STATUSES = new Set([404, 410]);
+const CONCURRENCY = 6;
+const REQUEST_TIMEOUT_MS = 8_000;
+const TOTAL_NON_2XX_BUDGET = 0.05; // 5%
+
+// Cinemas whose booking SPAs always return 200 — exclude from HTTP check.
+// Trust PostHog booking_click data (end-condition #6) instead.
+const bookingLinkExclusions = new Set<string>([
+  // Add slugs here if a cinema's booking page is provably SPA-200-always.
+]);
+
+interface Probe {
+  url: string;
+  status: number | "timeout" | "error";
+  cinemaId: string;
+}
+
+async function probeOne(url: string, cinemaId: string): Promise<Probe> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    let resp = await fetch(url, {
+      method: "HEAD",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "User-Agent": "pictures.london goal-check/1.0" },
+    });
+    // Some sites reject HEAD; retry with GET.
+    if (resp.status === 405 || resp.status === 501) {
+      resp = await fetch(url, {
+        method: "GET",
+        redirect: "follow",
+        signal: controller.signal,
+        headers: { "User-Agent": "pictures.london goal-check/1.0" },
+      });
+    }
+    return { url, status: resp.status, cinemaId };
+  } catch (err) {
+    const msg = String(err);
+    return { url, status: msg.includes("aborted") ? "timeout" : "error", cinemaId };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  worker: (item: T) => Promise<R>,
+  concurrency: number,
+): Promise<R[]> {
+  const results: R[] = [];
+  let i = 0;
+  const runners: Promise<void>[] = [];
+  for (let c = 0; c < concurrency; c++) {
+    runners.push(
+      (async () => {
+        while (i < items.length) {
+          const myIndex = i++;
+          results[myIndex] = await worker(items[myIndex]);
+        }
+      })(),
+    );
+  }
+  await Promise.all(runners);
+  return results;
+}
+
+async function main() {
+  const activeCinemas = await db
+    .select({ id: cinemas.id, name: cinemas.name })
+    .from(cinemas)
+    .where(eq(cinemas.isActive, true));
+
+  const now = new Date();
+  const probes: Probe[] = [];
+  const perCinemaCounts = new Map<string, { name: string; checked: number; nonOk: number; hardFail: number }>();
+
+  for (const c of activeCinemas) {
+    if (bookingLinkExclusions.has(c.id)) {
+      perCinemaCounts.set(c.id, { name: c.name, checked: 0, nonOk: 0, hardFail: 0 });
+      continue;
+    }
+
+    // Pull a sample of distinct future booking URLs for this cinema.
+    const rows = await db
+      .select({ url: screenings.bookingUrl })
+      .from(screenings)
+      .where(
+        and(
+          eq(screenings.cinemaId, c.id),
+          gte(screenings.datetime, now),
+        ),
+      )
+      .groupBy(screenings.bookingUrl)
+      .orderBy(sql`min(${screenings.datetime})`)
+      .limit(SAMPLE_PER_CINEMA);
+
+    const urls = rows.map((r) => r.url).filter((u): u is string => Boolean(u));
+    perCinemaCounts.set(c.id, { name: c.name, checked: urls.length, nonOk: 0, hardFail: 0 });
+
+    const cinemaProbes = await runWithConcurrency(
+      urls,
+      (url) => probeOne(url, c.id),
+      CONCURRENCY,
+    );
+    probes.push(...cinemaProbes);
+  }
+
+  let totalChecked = 0;
+  let totalNonOk = 0;
+  let totalHardFail = 0;
+  for (const p of probes) {
+    totalChecked++;
+    const ok = typeof p.status === "number" && p.status >= 200 && p.status < 400;
+    const hard = typeof p.status === "number" && HARD_FAIL_STATUSES.has(p.status);
+    if (!ok) totalNonOk++;
+    if (hard) totalHardFail++;
+    const counts = perCinemaCounts.get(p.cinemaId);
+    if (counts) {
+      if (!ok) counts.nonOk++;
+      if (hard) counts.hardFail++;
+    }
+  }
+
+  const nonOkRate = totalChecked === 0 ? 0 : totalNonOk / totalChecked;
+  const hardFailRate = totalChecked === 0 ? 0 : totalHardFail / totalChecked;
+  const pass = totalHardFail === 0 && nonOkRate < TOTAL_NON_2XX_BUDGET;
+
+  const worstCinemas = Array.from(perCinemaCounts.entries())
+    .map(([id, v]) => ({ id, ...v, nonOkRate: v.checked ? v.nonOk / v.checked : 0 }))
+    .filter((c) => c.hardFail > 0 || c.nonOkRate > 0.2)
+    .sort((a, b) => b.hardFail - a.hardFail || b.nonOkRate - a.nonOkRate);
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "booking-links",
+        pass,
+        totalChecked,
+        totalNonOk,
+        totalHardFail,
+        nonOkRate: Math.round(nonOkRate * 10000) / 100,
+        hardFailRate: Math.round(hardFailRate * 10000) / 100,
+        worstCinemas: worstCinemas.slice(0, 10),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ condition: "booking-links", pass: false, error: String(err) }));
+  process.exit(1);
+});

--- a/scripts/goal-check-booking-links.ts
+++ b/scripts/goal-check-booking-links.ts
@@ -38,32 +38,43 @@ interface Probe {
   cinemaId: string;
 }
 
-async function probeOne(url: string, cinemaId: string): Promise<Probe> {
+async function fetchWithTimeout(
+  url: string,
+  method: "HEAD" | "GET",
+): Promise<{ status: number } | { timeout: true } | { error: string }> {
+  // Fresh AbortController per request — sharing one across HEAD and a GET
+  // retry causes the retry to inherit an already-expired (or already-fired)
+  // signal whenever HEAD ran close to the deadline.
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   try {
-    let resp = await fetch(url, {
-      method: "HEAD",
+    const resp = await fetch(url, {
+      method,
       redirect: "follow",
       signal: controller.signal,
       headers: { "User-Agent": "pictures.london goal-check/1.0" },
     });
-    // Some sites reject HEAD; retry with GET.
-    if (resp.status === 405 || resp.status === 501) {
-      resp = await fetch(url, {
-        method: "GET",
-        redirect: "follow",
-        signal: controller.signal,
-        headers: { "User-Agent": "pictures.london goal-check/1.0" },
-      });
-    }
-    return { url, status: resp.status, cinemaId };
+    return { status: resp.status };
   } catch (err) {
     const msg = String(err);
-    return { url, status: msg.includes("aborted") ? "timeout" : "error", cinemaId };
+    return msg.includes("aborted") ? { timeout: true } : { error: msg };
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function probeOne(url: string, cinemaId: string): Promise<Probe> {
+  const first = await fetchWithTimeout(url, "HEAD");
+  // Some sites reject HEAD; retry with GET on its own fresh timeout budget.
+  if ("status" in first && (first.status === 405 || first.status === 501)) {
+    const second = await fetchWithTimeout(url, "GET");
+    if ("status" in second) return { url, status: second.status, cinemaId };
+    if ("timeout" in second) return { url, status: "timeout", cinemaId };
+    return { url, status: "error", cinemaId };
+  }
+  if ("status" in first) return { url, status: first.status, cinemaId };
+  if ("timeout" in first) return { url, status: "timeout", cinemaId };
+  return { url, status: "error", cinemaId };
 }
 
 async function runWithConcurrency<T, R>(
@@ -174,6 +185,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(JSON.stringify({ condition: "booking-links", pass: false, error: String(err) }));
+  console.log(JSON.stringify({ condition: "booking-links", pass: false, error: String(err) }));
   process.exit(1);
 });

--- a/scripts/goal-check-coverage.ts
+++ b/scripts/goal-check-coverage.ts
@@ -1,0 +1,113 @@
+/**
+ * End-condition #1: London independents covered.
+ *
+ * Reads the canonical target list from tasks/goal.md (the `coverage targets`
+ * bullet list under "End Conditions → 1. London independents covered"), then
+ * verifies each slug exists in `cinemas` with `is_active = true` AND has at
+ * least one successful scraper_run with screening_count > 0 in the last 7 days.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-coverage.ts
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { and, desc, eq, gt, gte } from "drizzle-orm";
+import { db } from "@/db";
+import { cinemas } from "@/db/schema/cinemas";
+import { scraperRuns } from "@/db/schema/admin";
+
+interface CinemaStatus {
+  slug: string;
+  exists: boolean;
+  isActive: boolean;
+  hasRecentSuccess: boolean;
+  lastSuccessAt: string | null;
+}
+
+function parseTargetsFromGoalFile(): string[] {
+  const path = resolve(process.cwd(), "tasks/goal.md");
+  const text = readFileSync(path, "utf-8");
+  // Section starts at "### 1. London independents covered" and we read the
+  // bullets under "**Coverage targets**" until the next blank line / sub-tasks.
+  const sectionMatch = text.match(
+    /### 1\. London independents covered[\s\S]*?\*\*Coverage targets\*\*[^\n]*\n([\s\S]*?)\n\s*- \*\*Sub-tasks:\*\*/,
+  );
+  if (!sectionMatch) {
+    throw new Error("Could not locate coverage-targets block in tasks/goal.md");
+  }
+  const block = sectionMatch[1];
+  const targets: string[] = [];
+  for (const line of block.split("\n")) {
+    // Match e.g. "  - `cinema-museum`" optionally followed by a parenthetical note
+    const m = line.match(/^\s*-\s+`([a-z0-9-]+)`/);
+    if (m) targets.push(m[1]);
+  }
+  return targets;
+}
+
+async function checkOne(slug: string): Promise<CinemaStatus> {
+  const cinemaRow = await db
+    .select({ id: cinemas.id, isActive: cinemas.isActive })
+    .from(cinemas)
+    .where(eq(cinemas.id, slug))
+    .limit(1);
+
+  if (cinemaRow.length === 0) {
+    return { slug, exists: false, isActive: false, hasRecentSuccess: false, lastSuccessAt: null };
+  }
+
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const recent = await db
+    .select({ startedAt: scraperRuns.startedAt })
+    .from(scraperRuns)
+    .where(
+      and(
+        eq(scraperRuns.cinemaId, slug),
+        eq(scraperRuns.status, "success"),
+        gt(scraperRuns.screeningCount, 0),
+        gte(scraperRuns.startedAt, sevenDaysAgo),
+      ),
+    )
+    .orderBy(desc(scraperRuns.startedAt))
+    .limit(1);
+
+  return {
+    slug,
+    exists: true,
+    isActive: cinemaRow[0].isActive,
+    hasRecentSuccess: recent.length > 0,
+    lastSuccessAt: recent[0]?.startedAt?.toISOString() ?? null,
+  };
+}
+
+async function main() {
+  const targets = parseTargetsFromGoalFile();
+  if (targets.length === 0) {
+    console.log(JSON.stringify({ condition: "coverage", pass: false, error: "no targets parsed from tasks/goal.md" }, null, 2));
+    process.exit(1);
+  }
+
+  const statuses = await Promise.all(targets.map(checkOne));
+  const missing = statuses.filter((s) => !s.exists);
+  const inactive = statuses.filter((s) => s.exists && !s.isActive);
+  const noRecent = statuses.filter((s) => s.exists && s.isActive && !s.hasRecentSuccess);
+  const pass = missing.length === 0 && inactive.length === 0 && noRecent.length === 0;
+
+  const payload = {
+    condition: "coverage",
+    pass,
+    targetsTotal: targets.length,
+    missing: missing.map((s) => s.slug),
+    inactive: inactive.map((s) => s.slug),
+    noRecentSuccess: noRecent.map((s) => s.slug),
+    details: statuses,
+  };
+
+  console.log(JSON.stringify(payload, null, 2));
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ condition: "coverage", pass: false, error: String(err) }));
+  process.exit(1);
+});

--- a/scripts/goal-check-coverage.ts
+++ b/scripts/goal-check-coverage.ts
@@ -29,8 +29,12 @@ function parseTargetsFromGoalFile(): string[] {
   const text = readFileSync(path, "utf-8");
   // Section starts at "### 1. London independents covered" and we read the
   // bullets under "**Coverage targets**" until the next blank line / sub-tasks.
+  // Match coverage-targets bullets until either the Sub-tasks line (the
+  // canonical terminator) or the next H3 heading (fallback if someone removes
+  // the Sub-tasks bullet). Either terminator keeps the parser non-greedy and
+  // localised to section 1.
   const sectionMatch = text.match(
-    /### 1\. London independents covered[\s\S]*?\*\*Coverage targets\*\*[^\n]*\n([\s\S]*?)\n\s*- \*\*Sub-tasks:\*\*/,
+    /### 1\. London independents covered[\s\S]*?\*\*Coverage targets\*\*[^\n]*\n([\s\S]*?)(?:\n\s*- \*\*Sub-tasks:\*\*|\n###\s)/,
   );
   if (!sectionMatch) {
     throw new Error("Could not locate coverage-targets block in tasks/goal.md");
@@ -108,6 +112,8 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(JSON.stringify({ condition: "coverage", pass: false, error: String(err) }));
+  // Emit result on stdout (success or failure) — stderr is reserved for
+  // unstructured diagnostic noise so the orchestrator can parse stdout cleanly.
+  console.log(JSON.stringify({ condition: "coverage", pass: false, error: String(err) }));
   process.exit(1);
 });

--- a/scripts/goal-check-dqs.ts
+++ b/scripts/goal-check-dqs.ts
@@ -1,0 +1,80 @@
+/**
+ * End-condition #7: Data quality floor.
+ *
+ * Reads `.claude/data-check-learnings.json` and checks the two most recent
+ * DQS scores recorded by /data-check. Both must be ≥ 85 composite for pass.
+ *
+ * Single high score is not enough — the floor must hold across two
+ * consecutive patrol runs to prove it's not a one-off.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-dqs.ts
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const FLOOR = 85;
+
+interface LearningsFile {
+  dqsHistory?: { timestamp: string; compositeScore: number }[];
+}
+
+function main() {
+  const path = resolve(process.cwd(), ".claude/data-check-learnings.json");
+  if (!existsSync(path)) {
+    console.log(
+      JSON.stringify(
+        {
+          condition: "dqs",
+          pass: false,
+          reason: "data-check-learnings.json not found — run /data-check first",
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(1);
+  }
+  const file = JSON.parse(readFileSync(path, "utf-8")) as LearningsFile;
+  const history = (file.dqsHistory ?? []).slice().sort((a, b) =>
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  );
+
+  if (history.length < 2) {
+    console.log(
+      JSON.stringify(
+        {
+          condition: "dqs",
+          pass: false,
+          reason: `Only ${history.length} DQS run(s) on record; need ≥2 above the floor`,
+          floor: FLOOR,
+          history,
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const [latest, prev] = history;
+  const pass = latest.compositeScore >= FLOOR && prev.compositeScore >= FLOOR;
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "dqs",
+        pass,
+        floor: FLOOR,
+        latest,
+        previous: prev,
+        runsConsidered: 2,
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main();

--- a/scripts/goal-check-lighthouse.ts
+++ b/scripts/goal-check-lighthouse.ts
@@ -96,6 +96,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(JSON.stringify({ condition: "lighthouse", pass: false, error: String(err).slice(0, 500) }));
+  console.log(JSON.stringify({ condition: "lighthouse", pass: false, error: String(err).slice(0, 500) }));
   process.exit(1);
 });

--- a/scripts/goal-check-lighthouse.ts
+++ b/scripts/goal-check-lighthouse.ts
@@ -1,0 +1,101 @@
+/**
+ * End-condition #4: Lighthouse mobile ≥ 90 (perf, a11y, SEO).
+ *
+ * Shells out to `npx lighthouse@12` for mobile + desktop presets against
+ * https://pictures.london/. No dep added — npx fetches lighthouse on demand
+ * (cached after first run).
+ *
+ * Passes when both runs score ≥ 90 on performance, accessibility, and SEO.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-lighthouse.ts
+ *
+ * NOTE: Lighthouse is slow (~30-60s per run × 2). The `/goal` orchestrator
+ * can call this less often than other checks. Skipped automatically with the
+ * `GOAL_SKIP_LIGHTHOUSE=1` env var if you need fast iterations.
+ */
+import { execFileSync } from "node:child_process";
+
+const TARGET_URL = process.env.GOAL_LIGHTHOUSE_URL ?? "https://pictures.london/";
+const THRESHOLD = 90;
+
+interface CategoryScore {
+  performance: number;
+  accessibility: number;
+  seo: number;
+}
+
+interface LighthouseJSON {
+  categories: {
+    performance: { score: number | null };
+    accessibility: { score: number | null };
+    seo: { score: number | null };
+  };
+}
+
+function runLighthouse(preset: "mobile" | "desktop"): CategoryScore {
+  const args = [
+    "-y",
+    "lighthouse@12",
+    TARGET_URL,
+    "--output=json",
+    "--quiet",
+    "--chrome-flags=--headless=new --no-sandbox",
+    `--preset=${preset === "desktop" ? "desktop" : "perf"}`,
+    "--only-categories=performance,accessibility,seo",
+  ];
+  // For mobile preset, lighthouse uses defaults (which is mobile). For desktop,
+  // --preset=desktop is the canonical flag.
+  if (preset === "mobile") {
+    // remove the `--preset=perf` we added above and let mobile be the default
+    const idx = args.indexOf("--preset=perf");
+    if (idx >= 0) args.splice(idx, 1);
+  }
+
+  const stdout = execFileSync("npx", args, {
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const parsed = JSON.parse(stdout) as LighthouseJSON;
+  return {
+    performance: Math.round((parsed.categories.performance.score ?? 0) * 100),
+    accessibility: Math.round((parsed.categories.accessibility.score ?? 0) * 100),
+    seo: Math.round((parsed.categories.seo.score ?? 0) * 100),
+  };
+}
+
+async function main() {
+  if (process.env.GOAL_SKIP_LIGHTHOUSE === "1") {
+    console.log(JSON.stringify({ condition: "lighthouse", pass: false, skipped: true, reason: "GOAL_SKIP_LIGHTHOUSE=1" }, null, 2));
+    process.exit(1);
+  }
+
+  const mobile = runLighthouse("mobile");
+  const desktop = runLighthouse("desktop");
+  const allScores = [mobile.performance, mobile.accessibility, mobile.seo, desktop.performance, desktop.accessibility, desktop.seo];
+  const pass = allScores.every((s) => s >= THRESHOLD);
+  const lowest = Math.min(...allScores);
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "lighthouse",
+        pass,
+        threshold: THRESHOLD,
+        lowest,
+        target: TARGET_URL,
+        mobile,
+        desktop,
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ condition: "lighthouse", pass: false, error: String(err).slice(0, 500) }));
+  process.exit(1);
+});

--- a/scripts/goal-check-posthog-funnel.ts
+++ b/scripts/goal-check-posthog-funnel.ts
@@ -1,0 +1,126 @@
+/**
+ * End-condition #6: PostHog booking funnel proof-of-life.
+ *
+ * For every active cinema, count `booking_click` events in the trailing 30
+ * days. Passes when every active cinema has ≥ 1 event recorded.
+ *
+ * A cinema with 0 events is a structural booking failure even if HTTP returns
+ * 200 — the URL exists but no real user has successfully clicked through it.
+ *
+ * Requires: POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID in .env.local.
+ * If either is missing the script skips with a non-fatal warning and pass=false.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-posthog-funnel.ts
+ */
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { cinemas } from "@/db/schema/cinemas";
+
+const POSTHOG_API_HOST = process.env.POSTHOG_API_HOST ?? "https://eu.posthog.com";
+
+interface HogQLResponse {
+  results: unknown[][];
+  columns: string[];
+}
+
+async function hogql(query: string): Promise<HogQLResponse> {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  if (!apiKey || !projectId) {
+    throw new Error("POSTHOG_PERSONAL_API_KEY or POSTHOG_PROJECT_ID missing");
+  }
+  const resp = await fetch(`${POSTHOG_API_HOST}/api/projects/${projectId}/query/`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`PostHog HogQL query failed (${resp.status}): ${text.slice(0, 300)}`);
+  }
+  return (await resp.json()) as HogQLResponse;
+}
+
+async function main() {
+  if (!process.env.POSTHOG_PERSONAL_API_KEY || !process.env.POSTHOG_PROJECT_ID) {
+    console.log(
+      JSON.stringify(
+        {
+          condition: "posthog-funnel",
+          pass: false,
+          skipped: true,
+          reason: "POSTHOG_PERSONAL_API_KEY or POSTHOG_PROJECT_ID not set in .env.local",
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const activeCinemas = await db
+    .select({ id: cinemas.id, name: cinemas.name })
+    .from(cinemas)
+    .where(eq(cinemas.isActive, true));
+
+  // HogQL: count distinct days the event fired per cinema_id property, last 30d.
+  // We use `properties.cinema_id` which is what trackBookingClick attaches.
+  const query = `
+    SELECT properties.cinema_id AS cinema_id, count() AS n
+    FROM events
+    WHERE event = 'booking_click'
+      AND timestamp >= now() - INTERVAL 30 DAY
+      AND properties.cinema_id IS NOT NULL
+    GROUP BY properties.cinema_id
+  `;
+  const counts = new Map<string, number>();
+  try {
+    const res = await hogql(query);
+    for (const row of res.results) {
+      const id = row[0] as string;
+      const n = Number(row[1]);
+      if (id) counts.set(id, n);
+    }
+  } catch (err) {
+    console.log(
+      JSON.stringify(
+        {
+          condition: "posthog-funnel",
+          pass: false,
+          error: String(err).slice(0, 500),
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const zeroCinemas = activeCinemas.filter((c) => !counts.has(c.id) || (counts.get(c.id) ?? 0) === 0);
+  const pass = zeroCinemas.length === 0;
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "posthog-funnel",
+        pass,
+        windowDays: 30,
+        activeCinemas: activeCinemas.length,
+        cinemasWithClicks: activeCinemas.length - zeroCinemas.length,
+        zeroClickCinemas: zeroCinemas.map((c) => ({ id: c.id, name: c.name })),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ condition: "posthog-funnel", pass: false, error: String(err).slice(0, 500) }));
+  process.exit(1);
+});

--- a/scripts/goal-check-posthog-funnel.ts
+++ b/scripts/goal-check-posthog-funnel.ts
@@ -67,12 +67,14 @@ async function main() {
     .from(cinemas)
     .where(eq(cinemas.isActive, true));
 
-  // HogQL: count distinct days the event fired per cinema_id property, last 30d.
-  // We use `properties.cinema_id` which is what trackBookingClick attaches.
+  // HogQL: count events per cinema_id over the last 30d. Event name and
+  // property name must match the frontend tracker — see
+  // frontend/src/lib/analytics/posthog.ts:128 (`booking_link_clicked` with
+  // `cinema_id`). If those change, this query must change too.
   const query = `
     SELECT properties.cinema_id AS cinema_id, count() AS n
     FROM events
-    WHERE event = 'booking_click'
+    WHERE event = 'booking_link_clicked'
       AND timestamp >= now() - INTERVAL 30 DAY
       AND properties.cinema_id IS NOT NULL
     GROUP BY properties.cinema_id
@@ -121,6 +123,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(JSON.stringify({ condition: "posthog-funnel", pass: false, error: String(err).slice(0, 500) }));
+  console.log(JSON.stringify({ condition: "posthog-funnel", pass: false, error: String(err).slice(0, 500) }));
   process.exit(1);
 });

--- a/scripts/goal-check-silent-breakers.ts
+++ b/scripts/goal-check-silent-breakers.ts
@@ -1,0 +1,40 @@
+/**
+ * End-condition #2: No silent breakers.
+ *
+ * Wraps `detectSilentBreakers` from `src/lib/scrape-quarantine.ts`.
+ *
+ * NOTE: When the ratio-based flaky-cinema detector lands on main, extend this
+ * script to require `detectFlakyCinemas().filter(f => f.severity === 'critical')`
+ * to also be empty. Until then we rely on the consecutive-zero detector only.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-silent-breakers.ts
+ */
+import { detectSilentBreakers } from "@/lib/scrape-quarantine";
+
+async function main() {
+  const silent = await detectSilentBreakers();
+  const pass = silent.length === 0;
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "silent-breakers",
+        pass,
+        silentBreakers: silent.map((s) => ({
+          name: s.cinemaName,
+          consecutiveZeroRuns: s.consecutiveZeroRuns,
+          lastGood: s.lastSuccessfulRunAt?.toISOString() ?? null,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ condition: "silent-breakers", pass: false, error: String(err) }));
+  process.exit(1);
+});

--- a/scripts/goal-check-silent-breakers.ts
+++ b/scripts/goal-check-silent-breakers.ts
@@ -35,6 +35,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(JSON.stringify({ condition: "silent-breakers", pass: false, error: String(err) }));
+  console.log(JSON.stringify({ condition: "silent-breakers", pass: false, error: String(err) }));
   process.exit(1);
 });

--- a/scripts/goal-status.ts
+++ b/scripts/goal-status.ts
@@ -42,16 +42,25 @@ function runOne(scriptPath: string): { pass: boolean; raw: unknown; durationMs: 
     { encoding: "utf-8", maxBuffer: 32 * 1024 * 1024 },
   );
   const durationMs = Date.now() - started;
-  // Each script prints JSON to stdout. Some prefix with progress so find the
-  // first '{' that opens valid JSON.
-  const out = (result.stdout ?? "") + (result.stderr ?? "");
-  const firstBrace = out.indexOf("{");
-  let raw: unknown = { pass: false, error: "no JSON output" };
+  // Contract: every measurement script emits its result JSON to stdout (even
+  // on failure — main().catch logs via console.log). Stderr is reserved for
+  // unstructured diagnostic noise (e.g. npx install banners, child-process
+  // stack traces) which can contain its own `{` characters and would
+  // otherwise corrupt the parse. Parse stdout only.
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  const firstBrace = stdout.indexOf("{");
+  let raw: unknown = { pass: false, error: "no JSON on stdout", stderrTail: stderr.slice(-500) };
   if (firstBrace >= 0) {
     try {
-      raw = JSON.parse(out.slice(firstBrace));
+      raw = JSON.parse(stdout.slice(firstBrace));
     } catch (err) {
-      raw = { pass: false, error: `Could not parse JSON from script: ${String(err).slice(0, 200)}`, rawOutput: out.slice(0, 500) };
+      raw = {
+        pass: false,
+        error: `Could not parse JSON from script stdout: ${String(err).slice(0, 200)}`,
+        stdoutHead: stdout.slice(0, 500),
+        stderrTail: stderr.slice(-500),
+      };
     }
   }
   const pass = (raw as { pass?: boolean }).pass === true;

--- a/scripts/goal-status.ts
+++ b/scripts/goal-status.ts
@@ -1,0 +1,123 @@
+/**
+ * Goal status orchestrator.
+ *
+ * Runs every measurement script declared in tasks/goal.md, prints a single
+ * status table to stdout, and writes a machine-readable summary to
+ * `.claude/goal-status.json`. Exit code 0 if all conditions pass, 1 otherwise.
+ *
+ * Lighthouse + axe are slow — pass `--fast` to skip them.
+ *
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-status.ts [--fast]
+ */
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ConditionResult {
+  id: string;
+  label: string;
+  pass: boolean;
+  skipped?: boolean;
+  rawJson: unknown;
+  durationMs: number;
+}
+
+const FAST = process.argv.includes("--fast");
+
+const CONDITIONS: { id: string; label: string; script: string; slow?: boolean }[] = [
+  { id: "coverage", label: "1. London independents covered", script: "scripts/goal-check-coverage.ts" },
+  { id: "silent-breakers", label: "2. No silent breakers / criticals", script: "scripts/goal-check-silent-breakers.ts" },
+  { id: "booking-links", label: "3. Zero broken booking links", script: "scripts/goal-check-booking-links.ts" },
+  { id: "lighthouse", label: "4. Lighthouse ≥ 90", script: "scripts/goal-check-lighthouse.ts", slow: true },
+  { id: "axe", label: "5. axe-core clean", script: "scripts/goal-check-axe.ts", slow: true },
+  { id: "posthog-funnel", label: "6. PostHog booking proof-of-life", script: "scripts/goal-check-posthog-funnel.ts" },
+  { id: "dqs", label: "7. DQS floor ≥ 85 × 2 runs", script: "scripts/goal-check-dqs.ts" },
+];
+
+function runOne(scriptPath: string): { pass: boolean; raw: unknown; durationMs: number } {
+  const started = Date.now();
+  const result = spawnSync(
+    "npx",
+    ["tsx", "--env-file=.env.local", "-r", "tsconfig-paths/register", scriptPath],
+    { encoding: "utf-8", maxBuffer: 32 * 1024 * 1024 },
+  );
+  const durationMs = Date.now() - started;
+  // Each script prints JSON to stdout. Some prefix with progress so find the
+  // first '{' that opens valid JSON.
+  const out = (result.stdout ?? "") + (result.stderr ?? "");
+  const firstBrace = out.indexOf("{");
+  let raw: unknown = { pass: false, error: "no JSON output" };
+  if (firstBrace >= 0) {
+    try {
+      raw = JSON.parse(out.slice(firstBrace));
+    } catch (err) {
+      raw = { pass: false, error: `Could not parse JSON from script: ${String(err).slice(0, 200)}`, rawOutput: out.slice(0, 500) };
+    }
+  }
+  const pass = (raw as { pass?: boolean }).pass === true;
+  return { pass, raw, durationMs };
+}
+
+function fmtRow(r: ConditionResult): string {
+  const tick = r.skipped ? "⏭ " : r.pass ? "✅" : "❌";
+  const dur = `${(r.durationMs / 1000).toFixed(1)}s`;
+  return `${tick}  ${r.label.padEnd(40)} (${dur})`;
+}
+
+function main() {
+  const results: ConditionResult[] = [];
+
+  for (const c of CONDITIONS) {
+    if (FAST && c.slow) {
+      results.push({
+        id: c.id,
+        label: c.label,
+        pass: false,
+        skipped: true,
+        rawJson: { skipped: true, reason: "--fast" },
+        durationMs: 0,
+      });
+      continue;
+    }
+    process.stdout.write(`Running ${c.id}...\n`);
+    const { pass, raw, durationMs } = runOne(c.script);
+    results.push({ id: c.id, label: c.label, pass, rawJson: raw, durationMs });
+  }
+
+  const nonSkipped = results.filter((r) => !r.skipped);
+  const allPass = nonSkipped.length > 0 && nonSkipped.every((r) => r.pass);
+
+  // Print human-readable table
+  console.log("\n──────────────────────────────────────────────────────────");
+  console.log("  Goal status — pictures.london v1");
+  console.log("──────────────────────────────────────────────────────────");
+  for (const r of results) console.log(fmtRow(r));
+  console.log("──────────────────────────────────────────────────────────");
+  const verdict = FAST
+    ? `${nonSkipped.filter((r) => r.pass).length}/${nonSkipped.length} measured (lighthouse + axe skipped via --fast)`
+    : allPass
+      ? "🎯 ALL CONDITIONS PASS — goal is ACHIEVED"
+      : `${nonSkipped.filter((r) => r.pass).length}/${nonSkipped.length} conditions passing`;
+  console.log(`  ${verdict}\n`);
+
+  // Write summary file for /goal slash command to read
+  const out = resolve(process.cwd(), ".claude/goal-status.json");
+  writeFileSync(
+    out,
+    JSON.stringify(
+      {
+        timestamp: new Date().toISOString(),
+        fastMode: FAST,
+        allPass: !FAST && allPass,
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`  Summary → ${out}\n`);
+
+  process.exit(allPass && !FAST ? 0 : 1);
+}
+
+main();

--- a/tasks/goal.md
+++ b/tasks/goal.md
@@ -1,0 +1,73 @@
+# Goal — Pictures.london v1: complete, fast, accessible, trustworthy
+
+**Set:** 2026-05-15
+**Status:** IN_PROGRESS
+**Owner:** /goal slash command (single canonical goal file — only one goal active at a time)
+
+## Objective
+
+Make pictures.london a complete, fast, accessible, and trustworthy London cinema calendar. When every end condition below is green for one consecutive `/goal` invocation, the goal is achieved and this file is rewritten with the next goal.
+
+## End Conditions
+
+Each condition declares the script that measures it. `/goal` runs every script every invocation; the goal is ACHIEVED only when all return `pass: true`.
+
+### 1. London independents covered
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-coverage.ts`
+- **Passes when:** every cinema slug in `coverageTargets` (below) exists in `cinemas` with `is_active = true` AND has ≥1 successful scraper_run with screening_count > 0 in the last 7 days.
+- **Coverage targets** (edit this list to redefine the bar — `/goal` will not change it):
+  - `cinema-museum`
+  - `catford-mews`
+  - `whirled-cinema`
+  - `bertha-dochouse`
+  - `hackney-cinematheque`
+  - `the-castle-cinema-stoke-newington`  *(only if separate from existing castle-cinema)*
+  - `chiswick-cinema`
+- **Sub-tasks:** (filled in by /goal as it works each cinema)
+
+### 2. No silent breakers, no critical flakies
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-silent-breakers.ts`
+- **Passes when:** `detectSilentBreakers()` returns `[]`. When the ratio-based `detectFlakyCinemas()` detector lands on `main`, tighten this condition to also require zero `critical` flakies and update the script accordingly.
+- **Sub-tasks:**
+
+### 3. Zero broken booking links
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-booking-links.ts`
+- **Passes when:** sampling 25 future screenings per active cinema, hard 404/410 rate is 0% AND total non-2xx rate is < 5%. Cinemas excluded from the live HTTP check: list any in the `bookingLinkExclusions` block of the script (e.g. SPAs that always 200).
+- **Sub-tasks:**
+
+### 4. Lighthouse mobile ≥ 90 (perf, a11y, SEO)
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-lighthouse.ts`
+- **Passes when:** running lighthouse mobile preset against `https://pictures.london/`, mobile + desktop both score ≥ 90 on performance, accessibility, and SEO.
+- **Sub-tasks:**
+
+### 5. axe-core clean
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-axe.ts`
+- **Passes when:** axe-core run against `https://pictures.london/` (mobile + desktop viewports) returns zero violations at impact `critical` or `serious`.
+- **Sub-tasks:**
+
+### 6. PostHog booking funnel proof-of-life
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-posthog-funnel.ts`
+- **Passes when:** in the trailing 30 days, every cinema with `is_active = true` has ≥ 1 PostHog `booking_click` event recorded. Cinemas with zero clicks indicate a structurally broken booking URL even if HTTP returns 200.
+- **Requires:** `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID` in `.env.local`.
+- **Sub-tasks:**
+
+### 7. Data quality floor
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-dqs.ts`
+- **Passes when:** the two most recent DQS scores recorded in `.claude/data-check-learnings.json` are both ≥ 85 composite. Single high score is not enough — the floor must hold across two consecutive `/data-check` runs.
+- **Sub-tasks:**
+
+## Cursor
+
+```yaml
+last_run: null
+last_run_at: null
+last_condition_targeted: null
+last_delta: null
+status: IN_PROGRESS
+achieved_at: null
+blocked_subtasks: []
+```
+
+## Achievement summary
+
+(Filled in by `/goal` when all conditions pass for one consecutive invocation. Copied to `Obsidian Vault/Pictures/Goals/pictures-london-v1-achieved.md` on completion.)


### PR DESCRIPTION
## Summary

Introduces `/goal` — a slash command that declares an explicit finish line for the project and exits when crossed. Unlike `/kaizen` and `/posthog-optimize` (perpetual), this loop terminates the moment all seven measurable end conditions pass.

The goal: **Pictures.london v1 — complete, fast, accessible, trustworthy**.

| # | End condition | How it's measured |
|---|---|---|
| 1 | London independents covered | DB has active, recently-scraping rows for every slug in `tasks/goal.md` |
| 2 | No silent breakers | `detectSilentBreakers()` returns `[]` |
| 3 | Zero broken booking links | Sample 25 URLs/cinema; 0 hard 404/410, <5% non-2xx |
| 4 | Lighthouse mobile + desktop ≥ 90 | `npx lighthouse@12` perf/a11y/SEO |
| 5 | axe-core clean | `npx @axe-core/cli@4` — zero `critical` / `serious` |
| 6 | PostHog `booking_link_clicked` proof-of-life | ≥1 event per active cinema in trailing 30d |
| 7 | DQS floor ≥ 85 | Two most recent `/data-check` runs in `.claude/data-check-learnings.json` |

## What this PR adds

- `tasks/goal.md` — single canonical goal file with the 7 conditions, coverage-target list, and cursor block.
- `scripts/goal-check-{coverage,silent-breakers,booking-links,lighthouse,axe,posthog-funnel,dqs}.ts` — one measurement script per condition.
- `scripts/goal-status.ts` — orchestrator. Runs all checks, prints status table, writes `.claude/goal-status.json`. Accepts `--fast` to skip the slow checks.
- `RECENT_CHANGES.md` + `changelogs/2026-05-15-goal-command.md` per the dual-changelog rule.

The slash command itself (`.claude/commands/goal.md`) lives in the gitignored `.claude/` directory — matches the project convention for local-only slash commands.

## What this PR doesn't add

- No new dependencies (lighthouse + axe-core invoked via `npx` on demand).
- No schema or migration changes.
- No frontend changes.
- No changes to the scrape pipeline.

## Code review

Ran `pr-review-toolkit:code-reviewer` agent on the diff before opening this PR. Three blocking findings, all fixed in commit `5a50d40`:

1. PostHog query used wrong event name (`booking_click` vs actual `booking_link_clicked`)
2. Orchestrator parsed stdout+stderr and could pick up `{` from npx banners
3. Booking-link probe reused one `AbortController` across HEAD→GET retry

Plus one non-blocker (goal-file regex now falls back to next H3 if `**Sub-tasks:**` line is missing).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint scripts/goal-*.ts` clean
- [x] DQS smoke-test runs and returns valid JSON
- [x] Goal-file regex parser extracts all 7 coverage targets
- [ ] Reviewer eyes-on this PR
- [ ] First real `/goal status --fast` run on `main` after merge — expect DQS condition to fail (76.62/77.42 vs 85 floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)