### PR TITLE
feat(scrape): yield-drop detector — closes third detection gap

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-05-15: /scrape detection — yield-drop detector (closes third detection gap)
+**PR**: TBD | **Files**: `src/lib/scrape-quarantine.ts`, `src/lib/scrape-quarantine.test.ts`, `src/scripts/run-scrape-and-enrich.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`, `.claude/commands/scrape.md`, `src/scrapers/chains/curzon.ts`
+- New `detectYieldDrop` + `analyzeYieldDrop` + `formatYieldDropReport`. Compares recent avg `screening_count` (last 5 successful runs) against a trailing baseline (next 20). Flags when `recentAvg / baselineAvg ≤ 0.5` (warn) or `≤ 0.3` (critical). Closes the third detection gap (silent breakers + flaky catch `success+0` / `failed`; yield-drop catches `success+low-but-non-zero` — e.g. PDF parser silently dropping one venue from a multi-venue scrape).
+- Single windowed SQL (ROW_NUMBER OVER PARTITION), filters to `status='success'` so failed/empty rows don't pollute the math. Live replay against production: 0 false positives in 461ms.
+- 10 new unit tests covering: window-size gate, healthy ratio, critical, warn, baseline-floor, BFI-style 200→30 regression, ASC input ordering, custom thresholds, formatter output.
+- Wired into both pre-flight and post-run health phases of `/scrape`.
+- Bonus: updated `curzon-camden`/`curzon-richmond`/`curzon-wimbledon` venue comments to note 2026-05-15 web search shows live public listings — left `active: false` pending verification with a prod-side JWT probe (API still 401s locally without Cloudflare bypass).
+
+---
+
 ## 2026-05-15: /scrape reliability — flaky-cinema detector, BFI yield gate, healthCheck retry
 **PR**: TBD | **Files**: `src/lib/scrape-quarantine.ts`, `src/scrapers/base.ts`, `src/scrapers/cinemas/bfi.ts`, `src/scripts/run-scrape-and-enrich.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`, plus tests
 - **New `detectFlakyCinemas`** in `src/lib/scrape-quarantine.ts`: ratio-based detector that surfaces cinemas with ≥30% empty-success or ≥30% failed runs across the last 10 attempts. Catches *alternating* failure patterns the consecutive-zero detector missed (BFI IMAX 60% empty success → critical, BFI Southbank 30% → warn, Close-Up 30% failed → warn). Pure analyzer (`analyzeRunsForFlakiness`) sorts inputs internally so callers can pass any order. Single windowed SQL (ROW_NUMBER OVER PARTITION) replaces 60 per-cinema queries; pre-flight dropped from ~2s to ~340ms.

--- a/changelogs/2026-05-15-yield-drop-detector.md
+++ b/changelogs/2026-05-15-yield-drop-detector.md
@@ -1,0 +1,71 @@
+# /scrape detection — yield-drop detector
+
+**PR**: TBD (stacks on top of `feat/scrape-reliability-flaky-detector-bfi-healthcheck`)
+**Date**: 2026-05-15
+
+## Context
+
+The two existing detectors leave a gap. `detectSilentBreakers` flags consecutive `success+0` runs (Prowlarr pattern). `detectFlakyCinemas` flags high `success+0` or `failed` ratios over a wider window. Both miss the "success + low-but-non-zero" case — a scraper that normally yields ~200 screenings and now consistently yields ~30 looks **healthy** to both detectors (the rows are `status=success` with `screening_count > 0`) even though the data is functionally broken.
+
+Real example the detector is built for: a BFI PDF parser regression that silently drops one of the two venues from each parse, halving the yield without surfacing any failure.
+
+## Changes
+
+### `src/lib/scrape-quarantine.ts`
+
+- `analyzeYieldDrop(rawRuns, thresholds)` — pure analyzer. Takes only successful runs, sorts by `startedAt` DESC internally, slices the most recent `recentWindow` runs as the "recent" sample and the next `baselineWindow` as the baseline. If `recentAvg / baselineAvg ≤ dropRatioCritical` → critical; `≤ dropRatioWarn` → warn; else null. Bails to null when baseline avg is below `minBaselineAvg` (avoids noise on small cinemas like BFI IMAX or Coldharbour Blue).
+- `detectYieldDrop(thresholds)` — DB walker using the same single windowed query pattern as `detectFlakyCinemas` (`ROW_NUMBER() OVER (PARTITION BY cinema_id ORDER BY started_at DESC) <= recentWindow + baselineWindow`). Filters to `status='success'` so failures/empties don't pollute the math.
+- `formatYieldDropReport(drops)` — slash-command-friendly output with 🔴 critical / 🟡 warn markers, percentage drop, and sample counts.
+- `DEFAULT_YIELD_DROP_THRESHOLDS = { recentWindow: 5, baselineWindow: 20, minBaselineAvg: 20, dropRatioWarn: 0.5, dropRatioCritical: 0.3 }`. Calibrated so a 50%+ drop on a baseline ≥ 20 fires warn, and a 70%+ drop fires critical.
+- Exports new types `YieldDropCinema`, `YieldDropSeverity`, `YieldDropThresholds`, `SuccessRunRecord`.
+
+### `src/scripts/run-scrape-and-enrich.ts`
+
+- Pre-flight phase now runs all three detectors in parallel (`detectSilentBreakers`, `detectFlakyCinemas`, `detectYieldDrop`) and reports a combined cinema-signal count.
+- Post-run health-check phase does the same.
+
+### `.claude/commands/scrape.md`
+
+- `/scrape health` argument-handler updated to call `detectYieldDrop` + `formatYieldDropReport` alongside the existing detectors.
+
+### `src/scrapers/SCRAPING_PLAYBOOK.md`
+
+- "Health & Flakiness Detection" section now documents all three detectors with their threshold defaults.
+
+### `src/scrapers/chains/curzon.ts`
+
+- Updated the `active: false` comments for `curzon-camden`, `curzon-richmond`, `curzon-wimbledon` to note that a 2026-05-15 web search shows live public listings on `www.curzon.com/venues/<slug>/`. The Vista API endpoint still 401s without a prod-side JWT (Cloudflare blocks the auth-token bootstrap locally). Left inactive pending verification — flipping these would re-enable the chain scraper for them automatically.
+
+### `src/lib/scrape-quarantine.test.ts`
+
+- 10 new tests against the pure analyzer + formatter:
+  - Returns null when below window-size requirement
+  - Returns null on healthy ratio
+  - Critical fires at ≤30%
+  - Warn fires between 30-50%
+  - Baseline-floor: small-cinema noise excluded
+  - BFI 200→30 pattern fires critical
+  - ASC input is sorted internally and produces correct recent/baseline split
+  - Custom thresholds (`dropRatioWarn=0.7`) override defaults correctly
+  - Formatter empty / non-empty cases
+  - Helper bug-fix: `makeSuccessRun` now uses Date arithmetic, not string interpolation (`2026-05-${15-24}` produces invalid dates)
+
+## Verification
+
+- `npx vitest run src/lib/scrape-quarantine.test.ts` — 20 / 20 pass (10 flaky from prior PR + 10 new yield-drop)
+- `npm run test:run` — 962 / 962 pass on the branch
+- `npx tsc --noEmit` — clean
+- `npx eslint <changed files>` — clean
+- **Live replay** against production scraper_runs: detector ran in 461 ms, returned 0 false positives (no cinema currently meets the drop threshold, which is the right answer given the production fleet is healthy on yield).
+
+## Impact
+
+- **Detection coverage now 3-of-3 failure modes**: consecutive zeros (silent breaker), alternating empty/failed (flaky), low-but-non-zero (yield drop). Future regressions of any of the three shapes surface in `/scrape` pre-flight before the user invests 30-60 min of scraping.
+- **Performance**: single windowed SQL, ~460 ms in live replay. Pre-flight cost is now ~1 s total for all three detectors combined.
+- **No data changes** — this is purely additive read-only observability.
+
+## Follow-ups
+
+- After a few weeks of production data, tune `minBaselineAvg=20` if it's masking regressions on legitimately-small cinemas, or raise it if it's noisy.
+- Verify the three inactive Curzon venues from a prod-side environment with a fresh JWT; flip `active: true` if the API actually returns dates.
+- Consider extending `detectSilentBreakers` to use the same single-windowed SQL pattern (pre-existing N+1 — flagged in the prior PR's code review).

--- a/src/lib/scrape-quarantine.test.ts
+++ b/src/lib/scrape-quarantine.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   analyzeRunsForFlakiness,
+  analyzeYieldDrop,
   DEFAULT_FLAKY_THRESHOLDS,
+  DEFAULT_YIELD_DROP_THRESHOLDS,
   formatFlakyReport,
+  formatYieldDropReport,
   type FlakyCinema,
   type RunRecord,
+  type SuccessRunRecord,
+  type YieldDropCinema,
 } from "./scrape-quarantine";
 
 function makeRun(
@@ -172,5 +177,127 @@ describe("formatFlakyReport", () => {
     expect(out).toContain("Flaky cinemas (2)");
     expect(out).toContain("🔴 critical BFI IMAX");
     expect(out).toContain("🟡 warn Close-Up");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Yield-drop detector
+// ─────────────────────────────────────────────────────────────────────────
+
+function makeSuccessRun(screeningCount: number, daysAgo: number): SuccessRunRecord {
+  // Compute via Date arithmetic so daysAgo > 14 doesn't produce "2026-05-(-9)"
+  const t = new Date("2026-05-15T01:00:00Z");
+  t.setUTCDate(t.getUTCDate() - daysAgo);
+  return { screeningCount, startedAt: t };
+}
+
+describe("analyzeYieldDrop", () => {
+  it("returns null when below the required window size", () => {
+    const runs = [makeSuccessRun(50, 0), makeSuccessRun(50, 1)];
+    expect(analyzeYieldDrop(runs)).toBeNull();
+  });
+
+  it("returns null when recent and baseline are similar (healthy)", () => {
+    const runs: SuccessRunRecord[] = [];
+    for (let i = 0; i < 25; i++) runs.push(makeSuccessRun(200 + (i % 10), i));
+    expect(analyzeYieldDrop(runs)).toBeNull();
+  });
+
+  it("flags critical when recent yield is <= 30% of baseline", () => {
+    const runs: SuccessRunRecord[] = [];
+    // 5 recent runs at 50 (~25% of baseline)
+    for (let i = 0; i < 5; i++) runs.push(makeSuccessRun(50, i));
+    // 20 baseline runs at 200
+    for (let i = 5; i < 25; i++) runs.push(makeSuccessRun(200, i));
+
+    const verdict = analyzeYieldDrop(runs);
+    expect(verdict).not.toBeNull();
+    expect(verdict!.severity).toBe("critical");
+    expect(verdict!.recentAvg).toBe(50);
+    expect(verdict!.baselineAvg).toBe(200);
+    expect(verdict!.dropRatio).toBeCloseTo(0.25, 2);
+  });
+
+  it("flags warn when recent yield is between 30% and 50% of baseline", () => {
+    const runs: SuccessRunRecord[] = [];
+    // recent 100, baseline 250 → ratio 0.4 → warn
+    for (let i = 0; i < 5; i++) runs.push(makeSuccessRun(100, i));
+    for (let i = 5; i < 25; i++) runs.push(makeSuccessRun(250, i));
+
+    const verdict = analyzeYieldDrop(runs);
+    expect(verdict).not.toBeNull();
+    expect(verdict!.severity).toBe("warn");
+  });
+
+  it("does NOT flag when baseline avg is below the floor (tiny cinemas excluded)", () => {
+    const runs: SuccessRunRecord[] = [];
+    // baseline avg = 10 (below minBaselineAvg=20), even a 90% drop must not fire
+    for (let i = 0; i < 5; i++) runs.push(makeSuccessRun(1, i));
+    for (let i = 5; i < 25; i++) runs.push(makeSuccessRun(10, i));
+
+    expect(analyzeYieldDrop(runs)).toBeNull();
+  });
+
+  it("simulates the BFI 'PDF parser regression' pattern (200 → 30 screenings)", () => {
+    // The exact failure mode the detector is built for: silent success+low
+    const runs: SuccessRunRecord[] = [];
+    for (let i = 0; i < 5; i++) runs.push(makeSuccessRun(30, i));
+    for (let i = 5; i < 25; i++) runs.push(makeSuccessRun(195 + (i % 10), i));
+
+    const verdict = analyzeYieldDrop(runs);
+    expect(verdict).not.toBeNull();
+    expect(verdict!.severity).toBe("critical"); // 30/199 ≈ 15% — well under critical
+  });
+
+  it("uses startedAt order from input (sorts internally) — pass ASC to verify", () => {
+    const ascending: SuccessRunRecord[] = [];
+    for (let i = 24; i >= 0; i--) ascending.push(makeSuccessRun(i < 5 ? 50 : 200, i));
+    const verdict = analyzeYieldDrop(ascending);
+    expect(verdict).not.toBeNull();
+    expect(verdict!.recentAvg).toBe(50);
+    expect(verdict!.baselineAvg).toBe(200);
+  });
+
+  it("respects custom thresholds", () => {
+    const runs: SuccessRunRecord[] = [];
+    // ratio 0.6 — under default warn (0.5), but if we set warn=0.7 it should fire
+    for (let i = 0; i < 5; i++) runs.push(makeSuccessRun(120, i));
+    for (let i = 5; i < 25; i++) runs.push(makeSuccessRun(200, i));
+
+    expect(analyzeYieldDrop(runs)).toBeNull();
+    const verdict = analyzeYieldDrop(runs, {
+      ...DEFAULT_YIELD_DROP_THRESHOLDS,
+      dropRatioWarn: 0.7,
+      dropRatioCritical: 0.4,
+    });
+    expect(verdict?.severity).toBe("warn");
+  });
+});
+
+describe("formatYieldDropReport", () => {
+  it("returns a clean message when nothing dropped", () => {
+    expect(formatYieldDropReport([])).toBe("No yield drops detected.");
+  });
+
+  it("renders entries with percentage drop + sample counts", () => {
+    const sample: YieldDropCinema[] = [
+      {
+        cinemaId: "bfi-southbank",
+        cinemaName: "BFI Southbank",
+        recentAvg: 30,
+        baselineAvg: 200,
+        dropRatio: 0.15,
+        recentSamples: 5,
+        baselineSamples: 20,
+        lastRunAt: new Date("2026-05-15T00:00:00Z"),
+        severity: "critical",
+      },
+    ];
+    const out = formatYieldDropReport(sample);
+    expect(out).toContain("Yield drops (1)");
+    expect(out).toContain("🔴 critical BFI Southbank");
+    expect(out).toContain("yield down 85%");
+    expect(out).toContain("recent avg 30 (last 5)");
+    expect(out).toContain("baseline avg 200 (prior 20)");
   });
 });

--- a/src/lib/scrape-quarantine.ts
+++ b/src/lib/scrape-quarantine.ts
@@ -336,6 +336,196 @@ export function formatFlakyReport(flaky: FlakyCinema[]): string {
   return `Flaky cinemas (${flaky.length}):\n${lines.join("\n")}`;
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Yield-drop detector
+// ─────────────────────────────────────────────────────────────────────────
+// Closes the third gap in detection alongside silent-breaker (success+0
+// repeating) and flaky (success+0 + failed ratio). Yield-drop catches the
+// silent "success+low-but-non-zero" case — a scraper that normally yields
+// ~200 screenings and now consistently yields ~20. The previous detectors
+// see this as healthy `status=success` with a non-zero count, but the data
+// is functionally broken. Example: a BFI PDF parser regression that only
+// extracts one venue's screenings instead of both.
+
+export type YieldDropSeverity = "warn" | "critical";
+
+export interface YieldDropCinema {
+  cinemaId: string;
+  cinemaName: string;
+  recentAvg: number;     // avg screening_count over the most recent successful runs
+  baselineAvg: number;   // avg over the trailing baseline window
+  dropRatio: number;     // recentAvg / baselineAvg (0..1; lower = worse)
+  recentSamples: number; // how many runs went into recentAvg
+  baselineSamples: number;
+  lastRunAt: Date;
+  severity: YieldDropSeverity;
+}
+
+export interface YieldDropThresholds {
+  /** Most recent N successful runs to compute recentAvg from. */
+  recentWindow: number;
+  /** Previous M successful runs (after the recent window) to compute baselineAvg from. */
+  baselineWindow: number;
+  /**
+   * Floor on baselineAvg below which we don't flag. Small cinemas
+   * (Coldharbour ≈ 9/run, BFI IMAX ≈ 2/run when broken) generate too much
+   * noise otherwise.
+   */
+  minBaselineAvg: number;
+  /** recentAvg / baselineAvg ≤ this → warn. */
+  dropRatioWarn: number;
+  /** recentAvg / baselineAvg ≤ this → critical. */
+  dropRatioCritical: number;
+}
+
+export const DEFAULT_YIELD_DROP_THRESHOLDS: YieldDropThresholds = {
+  recentWindow: 5,
+  baselineWindow: 20,
+  minBaselineAvg: 20,
+  dropRatioWarn: 0.5,
+  dropRatioCritical: 0.3,
+};
+
+/** Run shape consumed by the pure analyzer. */
+export interface SuccessRunRecord {
+  screeningCount: number | null;
+  startedAt: Date;
+}
+
+/**
+ * Pure analyzer for yield-drop detection. Takes only successful runs (the
+ * caller filters to `status=success`) so the math isn't polluted by failures
+ * or empty-success rows that already get caught by flaky/silent-breaker.
+ *
+ * Sorts the input internally by `startedAt` DESC so callers can pass any order.
+ * Returns `null` when there isn't enough data, when baseline is below the
+ * floor, or when the drop isn't large enough to fire.
+ */
+export function analyzeYieldDrop(
+  rawRuns: SuccessRunRecord[],
+  thresholds: YieldDropThresholds = DEFAULT_YIELD_DROP_THRESHOLDS,
+): Omit<YieldDropCinema, "cinemaId" | "cinemaName"> | null {
+  const needed = thresholds.recentWindow + thresholds.baselineWindow;
+  if (rawRuns.length < needed) return null;
+
+  const sorted = [...rawRuns].sort(
+    (a, b) => b.startedAt.getTime() - a.startedAt.getTime(),
+  );
+
+  const recent = sorted.slice(0, thresholds.recentWindow);
+  const baseline = sorted.slice(
+    thresholds.recentWindow,
+    thresholds.recentWindow + thresholds.baselineWindow,
+  );
+
+  const avg = (xs: SuccessRunRecord[]): number =>
+    xs.reduce((s, r) => s + (r.screeningCount ?? 0), 0) / xs.length;
+
+  const recentAvg = avg(recent);
+  const baselineAvg = avg(baseline);
+
+  if (baselineAvg < thresholds.minBaselineAvg) return null;
+
+  const dropRatio = recentAvg / baselineAvg;
+  let severity: YieldDropSeverity | null = null;
+  if (dropRatio <= thresholds.dropRatioCritical) severity = "critical";
+  else if (dropRatio <= thresholds.dropRatioWarn) severity = "warn";
+  if (severity === null) return null;
+
+  return {
+    recentAvg,
+    baselineAvg,
+    dropRatio,
+    recentSamples: recent.length,
+    baselineSamples: baseline.length,
+    lastRunAt: sorted[0].startedAt,
+    severity,
+  };
+}
+
+/**
+ * Walk every active cinema, pull its recent successful runs, and surface those
+ * whose recent yield has dropped significantly below baseline.
+ *
+ * Single windowed SQL — same shape as `detectFlakyCinemas`.
+ */
+export async function detectYieldDrop(
+  thresholds: YieldDropThresholds = DEFAULT_YIELD_DROP_THRESHOLDS,
+): Promise<YieldDropCinema[]> {
+  const totalNeeded = thresholds.recentWindow + thresholds.baselineWindow;
+
+  const rows = (await db.execute(sql`
+    WITH ranked AS (
+      SELECT
+        r.cinema_id,
+        r.screening_count,
+        r.started_at,
+        ROW_NUMBER() OVER (PARTITION BY r.cinema_id ORDER BY r.started_at DESC) AS rn
+      FROM scraper_runs r
+      JOIN cinemas c ON c.id = r.cinema_id
+      WHERE c.is_active = true
+        AND r.status = 'success'
+    )
+    SELECT
+      ranked.cinema_id,
+      cinemas.name AS cinema_name,
+      ranked.screening_count,
+      ranked.started_at
+    FROM ranked
+    JOIN cinemas ON cinemas.id = ranked.cinema_id
+    WHERE ranked.rn <= ${totalNeeded}
+    ORDER BY ranked.cinema_id, ranked.started_at DESC
+  `)) as unknown as Array<{
+    cinema_id: string;
+    cinema_name: string;
+    screening_count: number | null;
+    started_at: Date;
+  }>;
+
+  const byCinema = new Map<string, { name: string; runs: SuccessRunRecord[] }>();
+  for (const row of rows) {
+    const startedAt =
+      row.started_at instanceof Date ? row.started_at : new Date(row.started_at);
+    let entry = byCinema.get(row.cinema_id);
+    if (!entry) {
+      entry = { name: row.cinema_name, runs: [] };
+      byCinema.set(row.cinema_id, entry);
+    }
+    entry.runs.push({ screeningCount: row.screening_count, startedAt });
+  }
+
+  const yieldDrops: YieldDropCinema[] = [];
+  for (const [cinemaId, { name, runs }] of byCinema) {
+    const verdict = analyzeYieldDrop(runs, thresholds);
+    if (verdict !== null) {
+      yieldDrops.push({ cinemaId, cinemaName: name, ...verdict });
+    }
+  }
+
+  // critical first, then biggest drops first
+  return yieldDrops.sort((a, b) => {
+    if (a.severity !== b.severity) return a.severity === "critical" ? -1 : 1;
+    return a.dropRatio - b.dropRatio;
+  });
+}
+
+/** Format the yield-drop list for slash-command output. */
+export function formatYieldDropReport(drops: YieldDropCinema[]): string {
+  if (drops.length === 0) {
+    return "No yield drops detected.";
+  }
+  const lines = drops.map((d) => {
+    const tag = d.severity === "critical" ? "🔴 critical" : "🟡 warn";
+    const pct = Math.round((1 - d.dropRatio) * 100);
+    return (
+      `  • ${tag} ${d.cinemaName}: yield down ${pct}% — ` +
+      `recent avg ${d.recentAvg.toFixed(0)} (last ${d.recentSamples}) vs ` +
+      `baseline avg ${d.baselineAvg.toFixed(0)} (prior ${d.baselineSamples})`
+    );
+  });
+  return `Yield drops (${drops.length}):\n${lines.join("\n")}`;
+}
+
 export interface StaleCinema {
   cinemaId: string;
   cinemaName: string;

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -19,10 +19,11 @@ Update this playbook whenever you:
 - **`BaseScraper.healthCheck()` retries** (2026-05-15): 3 attempts, 10s timeout each, 4s backoff between attempts. Fast-fails on 4xx (contract issue), retries on 5xx + network errors. Subclasses can override for cheaper/different checks (e.g. Curzon HEADs the API endpoint with a 401-is-healthy contract). Background: Close-Up was failing 33% of runs at 03:17-03:21 UTC because of brief nightly-maintenance windows.
 
 ## Health & Flakiness Detection
-The `/scrape` slash command runs two read-only detectors against `scraper_runs`:
+The `/scrape` slash command runs three read-only detectors against `scraper_runs`:
 - **`detectSilentBreakers`** (`src/lib/scrape-quarantine.ts`) — Prowlarr-pattern: flags cinemas with ≥N *consecutive* `success+0` runs.
-- **`detectFlakyCinemas`** (same file, added 2026-05-15) — ratio-based: flags cinemas whose last `lookback` runs have ≥X% `success+0` or `failed`. Catches alternating empty/non-empty patterns that the consecutive detector misses. Default thresholds: `emptyRatioWarn=0.3, emptyRatioCritical=0.5, failedRatioWarn=0.3, failedRatioCritical=0.5, minRuns=4, lookback=10`. Implemented as a single windowed SQL (ROW_NUMBER OVER PARTITION) rather than per-cinema queries.
-- Pure analyzer: `analyzeRunsForFlakiness(runs, thresholds)` — DB-free, unit-testable, internally sorts by `startedAt` DESC so callers may pass any order.
+- **`detectFlakyCinemas`** (same file, added 2026-05-15) — ratio-based: flags cinemas whose last `lookback` runs have ≥X% `success+0` or `failed`. Catches alternating empty/non-empty patterns that the consecutive detector misses. Default thresholds: `emptyRatioWarn=0.3, emptyRatioCritical=0.5, failedRatioWarn=0.3, failedRatioCritical=0.5, minRuns=4, lookback=10`. Implemented as a single windowed SQL (ROW_NUMBER OVER PARTITION).
+- **`detectYieldDrop`** (same file, added 2026-05-15) — compares recent avg `screening_count` against a trailing baseline. Catches "success+low-but-non-zero" regressions that look healthy to the other two detectors (e.g. BFI PDF parser silently dropping one venue's screenings — 200 → 30). Default thresholds: `recentWindow=5, baselineWindow=20, minBaselineAvg=20, dropRatioWarn=0.5, dropRatioCritical=0.3`. Only considers `status='success'` rows so failures/empties don't pollute the math.
+- Pure analyzers: `analyzeRunsForFlakiness(runs, thresholds)` and `analyzeYieldDrop(successRuns, thresholds)` — DB-free, unit-testable, internally sort by `startedAt` DESC so callers may pass any order.
 
 ## Primary Entrypoints
 - Unified CLI: `src/scrapers/cli.ts` (`npm run scrape -- <slug>`)

--- a/src/scrapers/chains/curzon.ts
+++ b/src/scrapers/chains/curzon.ts
@@ -122,7 +122,7 @@ export const CURZON_VENUES: VenueConfig[] = [
     postcode: "TW9 1NE",
     address: "3 Water Lane",
     chainVenueId: "RIC1",
-    active: false, // Venue closed — no listings since Feb 2026
+    active: false, // Marked inactive Feb 2026 — no listings via Vista API. 2026-05-15 web search shows live programmes on www.curzon.com/venues/<slug>/ but API still 401s without prod-side auth token, so left inactive pending verification with a fresh JWT from a prod-environment probe.
   },
   {
     id: "curzon-wimbledon",
@@ -133,7 +133,7 @@ export const CURZON_VENUES: VenueConfig[] = [
     postcode: "SW19 8YA",
     address: "23 The Broadway",
     chainVenueId: "WIM01",
-    active: false, // Venue closed — no listings since Feb 2026
+    active: false, // Marked inactive Feb 2026 — no listings via Vista API. 2026-05-15 web search shows live programmes on www.curzon.com/venues/<slug>/ but API still 401s without prod-side auth token, so left inactive pending verification with a fresh JWT from a prod-environment probe.
   },
   {
     id: "curzon-camden",
@@ -144,7 +144,7 @@ export const CURZON_VENUES: VenueConfig[] = [
     postcode: "NW1 8QP",
     address: "Hawley Wharf",
     chainVenueId: "CAM1",
-    active: false, // Venue closed — no listings since Feb 2026
+    active: false, // Marked inactive Feb 2026 — no listings via Vista API. 2026-05-15 web search shows live programmes on www.curzon.com/venues/<slug>/ but API still 401s without prod-side auth token, so left inactive pending verification with a fresh JWT from a prod-environment probe.
   },
 ];
 

--- a/src/scripts/run-scrape-and-enrich.ts
+++ b/src/scripts/run-scrape-and-enrich.ts
@@ -26,6 +26,8 @@ import {
   formatQuarantineReport,
   detectFlakyCinemas,
   formatFlakyReport,
+  detectYieldDrop,
+  formatYieldDropReport,
   detectStaleCinemas,
   formatStaleCinemaReport,
   readRecentDqs,
@@ -95,23 +97,28 @@ async function main(): Promise<void> {
 
   // Phase 0: Pre-flight quarantine — read-only, ~1s. Tells the user which
   // cinemas have been silently broken BEFORE they sit through a 30-60 min
-  // /scrape that just re-runs them. Two signals:
+  // /scrape that just re-runs them. Three signals, fully orthogonal:
   //   1. Silent breakers — N consecutive `success+0` runs (Prowlarr pattern)
   //   2. Flaky cinemas   — high empty-success or failed ratio over wider window
-  // Both always run. Flaky catches alternating empty/non-empty patterns that
-  // evade the consecutive-zero detector (BFI IMAX, BFI Southbank in May 2026).
+  //   3. Yield drops     — recent avg yield << baseline avg (silent partial regressions)
+  // All always run. Flaky catches alternating empty/non-empty patterns that
+  // evade the consecutive-zero detector. Yield-drop catches "success+low" cases
+  // (e.g. PDF parser regression that returns 20 instead of 200 screenings)
+  // that look healthy to the other two detectors.
   phases.push(
-    await runPhase("Pre-flight (silent-breaker + flaky check)", async () => {
-      const [breakers, flaky] = await Promise.all([
+    await runPhase("Pre-flight (silent-breaker + flaky + yield-drop check)", async () => {
+      const [breakers, flaky, yieldDrops] = await Promise.all([
         detectSilentBreakers(),
         detectFlakyCinemas(),
+        detectYieldDrop(),
       ]);
-      if (breakers.length === 0 && flaky.length === 0) {
-        console.log("[pre-flight] No broken or flaky cinemas detected — proceeding.");
+      const total = breakers.length + flaky.length + yieldDrops.length;
+      if (total === 0) {
+        console.log("[pre-flight] No broken, flaky, or yield-dropping cinemas detected — proceeding.");
       } else {
         if (breakers.length > 0) console.log(formatQuarantineReport(breakers));
         if (flaky.length > 0) console.log(formatFlakyReport(flaky));
-        const total = breakers.length + flaky.length;
+        if (yieldDrops.length > 0) console.log(formatYieldDropReport(yieldDrops));
         console.log(
           `[pre-flight] ${total} cinema signal(s) above. Consider \`/scrape-one <slug>\` ` +
             "to investigate before starting a full run.",
@@ -119,7 +126,7 @@ async function main(): Promise<void> {
       }
       return {
         ok: true,
-        detail: `${breakers.length} broken, ${flaky.length} flaky`,
+        detail: `${breakers.length} broken, ${flaky.length} flaky, ${yieldDrops.length} yield-drop`,
       };
     }),
   );
@@ -155,19 +162,21 @@ async function main(): Promise<void> {
     console.log("[scrape-and-enrich] --skip-enrich: skipping enrichment phases");
   }
 
-  // Phase 4: Quarantine detection (always runs — read-only). Reports both
-  // silent breakers and flaky cinemas so post-run state is visible.
+  // Phase 4: Quarantine detection (always runs — read-only). Reports all
+  // three detectors so post-run state is fully visible.
   phases.push(
-    await runPhase("Health check (silent-breaker + flaky)", async () => {
-      const [breakers, flaky] = await Promise.all([
+    await runPhase("Health check (silent-breaker + flaky + yield-drop)", async () => {
+      const [breakers, flaky, yieldDrops] = await Promise.all([
         detectSilentBreakers(),
         detectFlakyCinemas(),
+        detectYieldDrop(),
       ]);
       console.log(formatQuarantineReport(breakers));
       console.log(formatFlakyReport(flaky));
+      console.log(formatYieldDropReport(yieldDrops));
       return {
         ok: true,
-        detail: `${breakers.length} broken, ${flaky.length} flaky`,
+        detail: `${breakers.length} broken, ${flaky.length} flaky, ${yieldDrops.length} yield-drop`,
       };
     }),
   );


### PR DESCRIPTION
> Stacks on top of #496 (`feat/scrape-reliability-flaky-detector-bfi-healthcheck`). Rebase to `main` after #496 merges.

## Summary

The two detectors shipped in #496 (silent-breaker + flaky) catch `success+0` and `failed` patterns. They both look at a scraper that returns success with a low-but-non-zero count and call it healthy. **Yield-drop** closes that gap by comparing the avg of recent successful runs against a trailing baseline.

## What it catches

The textbook case: a BFI PDF parser regression that silently drops one of the two venues, halving the yield from ~200 to ~30. To the existing detectors that's `status=success, screening_count=30` — healthy. To yield-drop it's `recentAvg / baselineAvg = 0.15` — 🔴 critical.

## Defaults (calibrated, not yet tuned against history)

| Threshold | Value | Why |
|---|---|---|
| `recentWindow` | 5 successful runs | Short enough to be reactive |
| `baselineWindow` | 20 successful runs | Long enough to be stable |
| `minBaselineAvg` | 20 | Small cinemas (Coldharbour ≈ 9) excluded — too noisy |
| `dropRatioWarn` | 0.5 | 50%+ drop warrants attention |
| `dropRatioCritical` | 0.3 | 70%+ drop is almost certainly a regression |

## Test plan

- [x] 10 new unit tests against pure analyzer + formatter (window-size gate, healthy, critical, warn, baseline-floor, BFI 200→30 pattern, ASC input ordering, custom thresholds)
- [x] `npm run test:run` — 962 / 962 pass on the branch
- [x] `npx tsc --noEmit` + `npx eslint` — clean
- [x] **Live replay** against production scraper_runs: 0 false positives in 461 ms. Correct — production fleet is healthy on yield; the detector is now armed.

## Bonus

Updated `curzon-camden`, `curzon-richmond`, `curzon-wimbledon` venue comments to note that a 2026-05-15 web search shows live public listings on `www.curzon.com/venues/<slug>/`. Left `active: false` pending verification with a prod-side JWT probe — the Curzon API still 401s locally without Cloudflare bypass, so I couldn't confirm via the same code path the scraper uses.

## Follow-ups

- After a few weeks of production data, tune `minBaselineAvg` if it's masking real regressions or noisy on edge cases
- Verify the 3 inactive Curzon venues from a prod-side environment with a fresh JWT
- Migrate `detectSilentBreakers` to the single windowed SQL pattern (pre-existing N+1, flagged in #496's code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)