### PR TITLE
fix(goal): defer condition #6 below traffic floor + regression guard + honest rollup

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -2,7 +2,8 @@
 **PR**: TBD | **Files**: `scripts/goal-check-posthog-funnel.ts`, `scripts/goal-status.ts`, `tasks/goal.md`, `changelogs/2026-05-15-goal-condition-6-traffic-floor.md`
 - Empirical probe found pictures.london emits 52 `booking_link_clicked` events / 30d across 56 active cinemas, all properly tagged with `cinema_id`. The "31 zero-click cinemas" surfaced in the first /goal run is a traffic-distribution artefact, not a tracking bug or product defect.
 - Condition #6 now defers when total monthly clicks < 500 (returns `pass: true, deferred: true`). Above the floor, the existing per-cinema check engages. This stops /goal from endlessly targeting an impossible-at-this-traffic condition while the goal file pins the upgrade path (Stagehand-based booking-URL verifier as a sub-task).
-- Orchestrator status table now shows `ℹ️ — deferred` instead of `✅` for deferred conditions so users don't misread the rollup as proof the underlying thing works.
+- Orchestrator status table now shows `ℹ️ — deferred` instead of `✅` for deferred conditions so users don't misread the rollup as proof the underlying thing works. The headline verdict ("🎯 ALL CONDITIONS PASS — goal is ACHIEVED") is now gated on `!anyDeferred` so the goal can't be falsely declared achieved while a condition is in deferred state.
+- Regression guard: persists prior `totalClicks` to `.claude/goal-posthog-funnel-last.json`. If the current window's total drops below 50% of a prior baseline that was above the floor, the condition fails loudly with a "volume regression" reason rather than silently flipping to deferred-pass. Catches analytics breakage (PostHog key rotated, frontend tracker removed, ad-blocker surge) instead of masking it.
 
 ---
 

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-05-15: /goal condition #6 — defer below 500-event traffic floor
+**PR**: TBD | **Files**: `scripts/goal-check-posthog-funnel.ts`, `scripts/goal-status.ts`, `tasks/goal.md`, `changelogs/2026-05-15-goal-condition-6-traffic-floor.md`
+- Empirical probe found pictures.london emits 52 `booking_link_clicked` events / 30d across 56 active cinemas, all properly tagged with `cinema_id`. The "31 zero-click cinemas" surfaced in the first /goal run is a traffic-distribution artefact, not a tracking bug or product defect.
+- Condition #6 now defers when total monthly clicks < 500 (returns `pass: true, deferred: true`). Above the floor, the existing per-cinema check engages. This stops /goal from endlessly targeting an impossible-at-this-traffic condition while the goal file pins the upgrade path (Stagehand-based booking-URL verifier as a sub-task).
+- Orchestrator status table now shows `ℹ️ — deferred` instead of `✅` for deferred conditions so users don't misread the rollup as proof the underlying thing works.
+
+---
+
 ## 2026-05-15: /goal command — terminal goal-driven loop with measurable end conditions
 **PR**: TBD | **Files**: `tasks/goal.md`, `scripts/goal-check-{coverage,silent-breakers,booking-links,lighthouse,axe,posthog-funnel,dqs}.ts`, `scripts/goal-status.ts`, `changelogs/2026-05-15-goal-command.md`
 - New `/goal` slash command (local in `.claude/commands/`): unlike `/kaizen` and `/posthog-optimize` (perpetual), this one declares an explicit finish line and exits when crossed. Reads `tasks/goal.md`, runs all measurement scripts, picks the highest-leverage failing condition, fixes one sub-task per invocation, holds merge behind the existing `ship it` deployment gate.

--- a/changelogs/2026-05-15-goal-condition-6-traffic-floor.md
+++ b/changelogs/2026-05-15-goal-condition-6-traffic-floor.md
@@ -1,0 +1,39 @@
+# /goal condition #6 — defer below 500-event traffic floor
+
+**PR**: TBD
+**Date**: 2026-05-15
+
+## Changes
+
+- `scripts/goal-check-posthog-funnel.ts`:
+  - Added a step-1 aggregate probe that counts total `booking_link_clicked` events in the trailing 30 days.
+  - When total < `MIN_CLICKS_FLOOR` (500), the script short-circuits with `pass: true, deferred: true` and reports the deferral reason. The per-cinema query never runs.
+  - Above the floor, the existing per-cinema check engages unchanged. Zero-click cinemas still fail the condition.
+  - Refactored result emission through a single `emit()` helper to make stdout-only-JSON contract impossible to violate from any exit path.
+- `scripts/goal-status.ts`: status table shows `ℹ️ — deferred` for deferred conditions instead of plain `✅`. Without this, a deferred condition looks identical to a fully-passing one in the summary, which would mislead the reader.
+- `tasks/goal.md`: condition #6's "Passes when" clause now documents the deferral path. Added a sub-task under condition #6 for the longer-term Stagehand-based booking-URL verifier — the traffic-independent replacement that activates the moment a `/goal` cycle targets condition #6 above the floor.
+
+## Why
+
+The first real `/goal status` run (2026-05-15) reported 31 of 56 active cinemas as zero-click, marking condition #6 as failing. An empirical probe (`scripts/_tmp_probe_posthog_booking.ts`, since deleted) revealed the underlying state:
+
+- 52 total `booking_link_clicked` events in trailing 30d
+- 0 of those events had a null `cinema_id` (instrumentation is healthy)
+- 25 distinct cinemas accounted for all 52 events
+- Distribution is power-law: ritzy-brixton 9, bfi-southbank 5, garden 4, prince-charles 4, long tail of 1-3
+
+With ~1.7 clicks/day spread across 56 cinemas, organic per-cinema verification is impossible regardless of whether booking links work. Condition #6 as originally written was a growth signal in quality-signal clothing — meeting it required user volume, not product quality. `/goal` would have endlessly targeted it.
+
+The volume floor reframes condition #6 honestly: it produces a meaningful signal only when the site has enough traffic for absent clicks to be evidence rather than noise.
+
+## Impact
+
+- **`/goal` cycles unblock**: condition #6 stops appearing in `/goal`'s "failing conditions to target" list at current traffic levels. The next `/goal` run will pick DQS (condition #7) or coverage (#1) instead.
+- **Stagehand path tracked**: the sub-task under condition #6 captures the agreed upgrade — when the site grows past the floor (or sooner if the user wants to flip the trigger), the Stagehand verifier replaces the deferral path with a real traffic-independent quality check.
+- **No regression risk**: the change is read-only against production data, the floor is conservative, and the per-cinema query is unchanged above the floor.
+
+## Verification
+
+- `npx tsc --noEmit` clean.
+- `npx eslint scripts/goal-check-posthog-funnel.ts scripts/goal-status.ts` clean.
+- Smoke run against live PostHog: returns `pass: true, deferred: true, totalClicks: 52, floor: 500, windowDays: 30` — exactly the expected behavior at current traffic.

--- a/changelogs/2026-05-15-goal-condition-6-traffic-floor.md
+++ b/changelogs/2026-05-15-goal-condition-6-traffic-floor.md
@@ -10,7 +10,11 @@
   - When total < `MIN_CLICKS_FLOOR` (500), the script short-circuits with `pass: true, deferred: true` and reports the deferral reason. The per-cinema query never runs.
   - Above the floor, the existing per-cinema check engages unchanged. Zero-click cinemas still fail the condition.
   - Refactored result emission through a single `emit()` helper to make stdout-only-JSON contract impossible to violate from any exit path.
-- `scripts/goal-status.ts`: status table shows `ℹ️ — deferred` for deferred conditions instead of plain `✅`. Without this, a deferred condition looks identical to a fully-passing one in the summary, which would mislead the reader.
+- `scripts/goal-status.ts`:
+  - Status table shows `ℹ️ — deferred` for deferred conditions instead of plain `✅`. Without this, a deferred condition looks identical to a fully-passing one in the summary, which would mislead the reader.
+  - Headline verdict is now gated on `!anyDeferred`. Previously the orchestrator could print "🎯 ALL CONDITIONS PASS — goal is ACHIEVED" even when a condition was silently deferred — a dishonest rollup. Now achievement requires every measured condition to be genuinely passing (not deferred).
+  - `.claude/goal-status.json` payload now includes `anyDeferred`, `deferredCount`, and a `deferred: boolean` on each result so the `/goal` slash command can read deferral state without re-parsing each script's raw JSON.
+- `scripts/goal-check-posthog-funnel.ts` regression guard: persists `totalClicks` after each run to `.claude/goal-posthog-funnel-last.json`. If the current window's total drops below 50% of a prior baseline that was above the 500-event floor, the condition fails with `reason: "Volume regression: …"` rather than silently flipping to deferred-pass. Catches analytics breakage (PostHog key rotated, frontend tracker removed, ad-blocker surge). The baseline is updated even on regression so a sustained drop doesn't fail forever — the user investigates the drop, then subsequent runs use the lowered baseline.
 - `tasks/goal.md`: condition #6's "Passes when" clause now documents the deferral path. Added a sub-task under condition #6 for the longer-term Stagehand-based booking-URL verifier — the traffic-independent replacement that activates the moment a `/goal` cycle targets condition #6 above the floor.
 
 ## Why
@@ -36,4 +40,17 @@ The volume floor reframes condition #6 honestly: it produces a meaningful signal
 
 - `npx tsc --noEmit` clean.
 - `npx eslint scripts/goal-check-posthog-funnel.ts scripts/goal-status.ts` clean.
-- Smoke run against live PostHog: returns `pass: true, deferred: true, totalClicks: 52, floor: 500, windowDays: 30` — exactly the expected behavior at current traffic.
+- Four-scenario smoke run against live PostHog:
+  - Cold start (no prior baseline): defers with `previousTotal: null`, baseline written.
+  - Regression simulated (prior baseline 1200, current 52): fails with "Volume regression" reason as expected.
+  - Normal-low (prior baseline 60, current 52): defers cleanly, regression guard does not trip.
+  - Full orchestrator run: status table shows `ℹ️ — deferred` and verdict reads `3/5 measured (lighthouse + axe skipped via --fast), 1 deferred` instead of falsely claiming achievement.
+
+## Code review
+
+Reviewed by `pr-review-toolkit:code-reviewer` agent. Two blocking findings caught and fixed in commit `(this PR head)`:
+
+1. `allPass` rollup was dishonest — would print "goal is ACHIEVED" while a condition was silently deferred. Fixed: rollup gated on `!anyDeferred`.
+2. Volume floor was one-sided — a drop from 1200 → 200 would silently flip to deferred-pass. Fixed: regression guard with persisted baseline.
+
+Both fixes verified by the four-scenario smoke run above.

--- a/scripts/goal-check-posthog-funnel.ts
+++ b/scripts/goal-check-posthog-funnel.ts
@@ -1,16 +1,28 @@
 /**
  * End-condition #6: PostHog booking funnel proof-of-life.
  *
- * For every active cinema, count `booking_click` events in the trailing 30
- * days. Passes when every active cinema has ≥ 1 event recorded.
+ * For every active cinema, count `booking_link_clicked` events in the trailing
+ * 30 days. Passes when every active cinema has ≥ 1 event recorded.
  *
- * A cinema with 0 events is a structural booking failure even if HTTP returns
- * 200 — the URL exists but no real user has successfully clicked through it.
+ * ── Volume floor ────────────────────────────────────────────────────────────
+ * At low traffic, "every cinema has ≥1 click" is a growth signal, not a
+ * quality one: with 50-ish clicks/month distributed power-law across 50+
+ * venues, the long-tail cinemas can have 0 clicks for reasons that have
+ * nothing to do with broken booking links. We confirmed this empirically on
+ * 2026-05-15 — 52 events / 30d, 0 with null `cinema_id`, 25 distinct cinemas.
+ *
+ * To stop /goal from chasing an impossible target, the condition is DEFERRED
+ * (returns `pass: true` with `deferred: true`) when total monthly volume is
+ * below `MIN_CLICKS_FLOOR`. At that point, end-condition #6 produces no
+ * actionable signal — the next ratchet is the Stagehand-based booking-URL
+ * verifier (tracked as a sub-task in tasks/goal.md).
+ *
+ * When traffic crosses the floor, the per-cinema check engages and reports
+ * zero-click cinemas as failures the way it always did.
  *
  * Requires: POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID in .env.local.
- * If either is missing the script skips with a non-fatal warning and pass=false.
  *
- * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Output: JSON to stdout. Exit code 0 if pass (incl. deferred), 1 if fail.
  * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-posthog-funnel.ts
  */
 import { eq } from "drizzle-orm";
@@ -18,6 +30,8 @@ import { db } from "@/db";
 import { cinemas } from "@/db/schema/cinemas";
 
 const POSTHOG_API_HOST = process.env.POSTHOG_API_HOST ?? "https://eu.posthog.com";
+const MIN_CLICKS_FLOOR = 500;
+const WINDOW_DAYS = 30;
 
 interface HogQLResponse {
   results: unknown[][];
@@ -45,81 +59,115 @@ async function hogql(query: string): Promise<HogQLResponse> {
   return (await resp.json()) as HogQLResponse;
 }
 
+function emit(payload: Record<string, unknown>, exitCode: number): never {
+  console.log(JSON.stringify(payload, null, 2));
+  process.exit(exitCode);
+}
+
 async function main() {
   if (!process.env.POSTHOG_PERSONAL_API_KEY || !process.env.POSTHOG_PROJECT_ID) {
-    console.log(
-      JSON.stringify(
-        {
-          condition: "posthog-funnel",
-          pass: false,
-          skipped: true,
-          reason: "POSTHOG_PERSONAL_API_KEY or POSTHOG_PROJECT_ID not set in .env.local",
-        },
-        null,
-        2,
-      ),
+    emit(
+      {
+        condition: "posthog-funnel",
+        pass: false,
+        skipped: true,
+        reason: "POSTHOG_PERSONAL_API_KEY or POSTHOG_PROJECT_ID not set in .env.local",
+      },
+      1,
     );
-    process.exit(1);
   }
 
+  // Step 1 — volume floor probe. Cheaper than the per-cinema query and lets
+  // us short-circuit before walking the DB if traffic is insufficient.
+  // Event name + property name must match the frontend tracker — see
+  // frontend/src/lib/analytics/posthog.ts:128. If those change, change here.
+  let totalClicks = 0;
+  try {
+    const totalRes = await hogql(`
+      SELECT count() AS n
+      FROM events
+      WHERE event = 'booking_link_clicked'
+        AND timestamp >= now() - INTERVAL ${WINDOW_DAYS} DAY
+    `);
+    totalClicks = Number(totalRes.results?.[0]?.[0] ?? 0);
+  } catch (err) {
+    emit(
+      {
+        condition: "posthog-funnel",
+        pass: false,
+        error: String(err).slice(0, 500),
+      },
+      1,
+    );
+  }
+
+  if (totalClicks < MIN_CLICKS_FLOOR) {
+    // Defer: no measurable signal at this traffic level. Treat as pass so
+    // /goal moves on to a condition it can actually act on.
+    emit(
+      {
+        condition: "posthog-funnel",
+        pass: true,
+        deferred: true,
+        reason: `Total ${WINDOW_DAYS}d clicks (${totalClicks}) below ${MIN_CLICKS_FLOOR}-event floor — condition can't produce a quality signal until traffic grows. The Stagehand-based booking-URL verifier (see tasks/goal.md sub-tasks) is the path to a traffic-independent check.`,
+        totalClicks,
+        floor: MIN_CLICKS_FLOOR,
+        windowDays: WINDOW_DAYS,
+      },
+      0,
+    );
+  }
+
+  // Step 2 — per-cinema check. Only runs when traffic is high enough that a
+  // zero-click cinema is meaningful evidence of a structural problem rather
+  // than a sampling artefact.
   const activeCinemas = await db
     .select({ id: cinemas.id, name: cinemas.name })
     .from(cinemas)
     .where(eq(cinemas.isActive, true));
 
-  // HogQL: count events per cinema_id over the last 30d. Event name and
-  // property name must match the frontend tracker — see
-  // frontend/src/lib/analytics/posthog.ts:128 (`booking_link_clicked` with
-  // `cinema_id`). If those change, this query must change too.
-  const query = `
-    SELECT properties.cinema_id AS cinema_id, count() AS n
-    FROM events
-    WHERE event = 'booking_link_clicked'
-      AND timestamp >= now() - INTERVAL 30 DAY
-      AND properties.cinema_id IS NOT NULL
-    GROUP BY properties.cinema_id
-  `;
   const counts = new Map<string, number>();
   try {
-    const res = await hogql(query);
+    const res = await hogql(`
+      SELECT properties.cinema_id AS cinema_id, count() AS n
+      FROM events
+      WHERE event = 'booking_link_clicked'
+        AND timestamp >= now() - INTERVAL ${WINDOW_DAYS} DAY
+        AND properties.cinema_id IS NOT NULL
+      GROUP BY properties.cinema_id
+    `);
     for (const row of res.results) {
       const id = row[0] as string;
       const n = Number(row[1]);
       if (id) counts.set(id, n);
     }
   } catch (err) {
-    console.log(
-      JSON.stringify(
-        {
-          condition: "posthog-funnel",
-          pass: false,
-          error: String(err).slice(0, 500),
-        },
-        null,
-        2,
-      ),
+    emit(
+      {
+        condition: "posthog-funnel",
+        pass: false,
+        error: String(err).slice(0, 500),
+      },
+      1,
     );
-    process.exit(1);
   }
 
   const zeroCinemas = activeCinemas.filter((c) => !counts.has(c.id) || (counts.get(c.id) ?? 0) === 0);
   const pass = zeroCinemas.length === 0;
 
-  console.log(
-    JSON.stringify(
-      {
-        condition: "posthog-funnel",
-        pass,
-        windowDays: 30,
-        activeCinemas: activeCinemas.length,
-        cinemasWithClicks: activeCinemas.length - zeroCinemas.length,
-        zeroClickCinemas: zeroCinemas.map((c) => ({ id: c.id, name: c.name })),
-      },
-      null,
-      2,
-    ),
+  emit(
+    {
+      condition: "posthog-funnel",
+      pass,
+      windowDays: WINDOW_DAYS,
+      totalClicks,
+      floor: MIN_CLICKS_FLOOR,
+      activeCinemas: activeCinemas.length,
+      cinemasWithClicks: activeCinemas.length - zeroCinemas.length,
+      zeroClickCinemas: zeroCinemas.map((c) => ({ id: c.id, name: c.name })),
+    },
+    pass ? 0 : 1,
   );
-  process.exit(pass ? 0 : 1);
 }
 
 main().catch((err) => {

--- a/scripts/goal-check-posthog-funnel.ts
+++ b/scripts/goal-check-posthog-funnel.ts
@@ -25,6 +25,8 @@
  * Output: JSON to stdout. Exit code 0 if pass (incl. deferred), 1 if fail.
  * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-posthog-funnel.ts
  */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { cinemas } from "@/db/schema/cinemas";
@@ -32,6 +34,46 @@ import { cinemas } from "@/db/schema/cinemas";
 const POSTHOG_API_HOST = process.env.POSTHOG_API_HOST ?? "https://eu.posthog.com";
 const MIN_CLICKS_FLOOR = 500;
 const WINDOW_DAYS = 30;
+// Regression guard: if the current window has < 50% of the previously-recorded
+// total AND the previous total was above the floor, treat that as a likely
+// analytics breakage (PostHog key rotated, frontend tracker removed, ad-blocker
+// surge, etc.) and fail loudly rather than silently flipping to deferred-pass.
+const REGRESSION_RATIO = 0.5;
+const LAST_RUN_PATH = resolve(process.cwd(), ".claude/goal-posthog-funnel-last.json");
+
+interface LastRunState {
+  timestamp: string;
+  totalClicks: number;
+  windowDays: number;
+}
+
+function readLastRun(): LastRunState | null {
+  try {
+    if (!existsSync(LAST_RUN_PATH)) return null;
+    const raw = JSON.parse(readFileSync(LAST_RUN_PATH, "utf-8")) as LastRunState;
+    if (typeof raw.totalClicks !== "number") return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastRun(totalClicks: number): void {
+  try {
+    mkdirSync(dirname(LAST_RUN_PATH), { recursive: true });
+    writeFileSync(
+      LAST_RUN_PATH,
+      JSON.stringify(
+        { timestamp: new Date().toISOString(), totalClicks, windowDays: WINDOW_DAYS },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    // Non-fatal — the regression guard degrades to "no prior baseline" on
+    // the next run if the write fails.
+  }
+}
 
 interface HogQLResponse {
   results: unknown[][];
@@ -101,6 +143,40 @@ async function main() {
     );
   }
 
+  // Step 1b — regression guard. A floor-only check would silently mask a
+  // collapse from real-traffic to no-traffic (e.g. analytics breaks). If we
+  // have a prior baseline that was above the floor, require that the current
+  // total stays within REGRESSION_RATIO of it before we trust either branch.
+  const lastRun = readLastRun();
+  if (
+    lastRun !== null &&
+    lastRun.totalClicks >= MIN_CLICKS_FLOOR &&
+    totalClicks < lastRun.totalClicks * REGRESSION_RATIO
+  ) {
+    // Persist the new value so subsequent runs use the lowered baseline.
+    // Without this, a sustained drop would keep failing forever, which is
+    // worse than letting the user see the drop, investigate, and move on.
+    writeLastRun(totalClicks);
+    emit(
+      {
+        condition: "posthog-funnel",
+        pass: false,
+        reason: `Volume regression: total ${WINDOW_DAYS}d clicks dropped from ${lastRun.totalClicks} (previous run on ${lastRun.timestamp.slice(0, 10)}) to ${totalClicks} — below ${Math.round(REGRESSION_RATIO * 100)}% of prior. Likely cause: analytics break (PostHog key rotated, frontend tracker removed, ad-blocker surge). Investigate before re-running.`,
+        totalClicks,
+        previousTotal: lastRun.totalClicks,
+        previousAt: lastRun.timestamp,
+        regressionRatio: REGRESSION_RATIO,
+        floor: MIN_CLICKS_FLOOR,
+        windowDays: WINDOW_DAYS,
+      },
+      1,
+    );
+  }
+
+  // Update the baseline before any further short-circuit so the next run sees
+  // the current state regardless of whether this one passes/defers/fails.
+  writeLastRun(totalClicks);
+
   if (totalClicks < MIN_CLICKS_FLOOR) {
     // Defer: no measurable signal at this traffic level. Treat as pass so
     // /goal moves on to a condition it can actually act on.
@@ -111,6 +187,7 @@ async function main() {
         deferred: true,
         reason: `Total ${WINDOW_DAYS}d clicks (${totalClicks}) below ${MIN_CLICKS_FLOOR}-event floor — condition can't produce a quality signal until traffic grows. The Stagehand-based booking-URL verifier (see tasks/goal.md sub-tasks) is the path to a traffic-independent check.`,
         totalClicks,
+        previousTotal: lastRun?.totalClicks ?? null,
         floor: MIN_CLICKS_FLOOR,
         windowDays: WINDOW_DAYS,
       },

--- a/scripts/goal-status.ts
+++ b/scripts/goal-status.ts
@@ -98,20 +98,38 @@ function main() {
     results.push({ id: c.id, label: c.label, pass, rawJson: raw, durationMs });
   }
 
-  const nonSkipped = results.filter((r) => !r.skipped);
+  const isDeferred = (r: ConditionResult): boolean =>
+    (r.rawJson as { deferred?: boolean })?.deferred === true;
+
+  // Annotate each result with its deferred state so the JSON payload reflects
+  // it for the /goal slash command's consumption.
+  const annotated = results.map((r) => ({ ...r, deferred: isDeferred(r) }));
+
+  const nonSkipped = annotated.filter((r) => !r.skipped);
   const allPass = nonSkipped.length > 0 && nonSkipped.every((r) => r.pass);
+  const deferredCount = nonSkipped.filter((r) => r.deferred).length;
+  const anyDeferred = deferredCount > 0;
+  // A deferred condition is not producing a quality signal — even if every
+  // condition technically passes, we MUST NOT print "goal is ACHIEVED" while
+  // any deferral is in effect. That would be a dishonest rollup.
+  const trulyAchieved = allPass && !anyDeferred && !FAST;
 
   // Print human-readable table
   console.log("\n──────────────────────────────────────────────────────────");
   console.log("  Goal status — pictures.london v1");
   console.log("──────────────────────────────────────────────────────────");
-  for (const r of results) console.log(fmtRow(r));
+  for (const r of annotated) console.log(fmtRow(r));
   console.log("──────────────────────────────────────────────────────────");
+  const passing = nonSkipped.filter((r) => r.pass && !r.deferred).length;
   const verdict = FAST
-    ? `${nonSkipped.filter((r) => r.pass).length}/${nonSkipped.length} measured (lighthouse + axe skipped via --fast)`
-    : allPass
+    ? `${nonSkipped.filter((r) => r.pass).length}/${nonSkipped.length} measured (lighthouse + axe skipped via --fast)` +
+      (anyDeferred ? `, ${deferredCount} deferred` : "")
+    : trulyAchieved
       ? "🎯 ALL CONDITIONS PASS — goal is ACHIEVED"
-      : `${nonSkipped.filter((r) => r.pass).length}/${nonSkipped.length} conditions passing`;
+      : allPass && anyDeferred
+        ? `${passing}/${nonSkipped.length} passing, ${deferredCount} deferred — not yet achieved (deferred conditions don't count toward achievement)`
+        : `${nonSkipped.filter((r) => r.pass).length}/${nonSkipped.length} conditions passing` +
+          (anyDeferred ? ` (${deferredCount} of those deferred)` : "");
   console.log(`  ${verdict}\n`);
 
   // Write summary file for /goal slash command to read
@@ -122,8 +140,10 @@ function main() {
       {
         timestamp: new Date().toISOString(),
         fastMode: FAST,
-        allPass: !FAST && allPass,
-        results,
+        allPass: trulyAchieved,
+        anyDeferred,
+        deferredCount,
+        results: annotated,
       },
       null,
       2,
@@ -131,7 +151,7 @@ function main() {
   );
   console.log(`  Summary → ${out}\n`);
 
-  process.exit(allPass && !FAST ? 0 : 1);
+  process.exit(trulyAchieved ? 0 : 1);
 }
 
 main();

--- a/scripts/goal-status.ts
+++ b/scripts/goal-status.ts
@@ -68,9 +68,14 @@ function runOne(scriptPath: string): { pass: boolean; raw: unknown; durationMs: 
 }
 
 function fmtRow(r: ConditionResult): string {
-  const tick = r.skipped ? "⏭ " : r.pass ? "✅" : "❌";
+  // A "deferred" condition passes the rollup but isn't producing a real
+  // quality signal — surface it distinctly so users don't read the ✅ as
+  // proof the underlying thing works. See goal-check-posthog-funnel.ts.
+  const deferred = (r.rawJson as { deferred?: boolean })?.deferred === true;
+  const tick = r.skipped ? "⏭ " : deferred ? "ℹ️ " : r.pass ? "✅" : "❌";
   const dur = `${(r.durationMs / 1000).toFixed(1)}s`;
-  return `${tick}  ${r.label.padEnd(40)} (${dur})`;
+  const suffix = deferred ? " — deferred" : "";
+  return `${tick}  ${r.label.padEnd(40)} (${dur})${suffix}`;
 }
 
 function main() {

--- a/tasks/goal.md
+++ b/tasks/goal.md
@@ -47,9 +47,11 @@ Each condition declares the script that measures it. `/goal` runs every script e
 
 ### 6. PostHog booking funnel proof-of-life
 - **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-posthog-funnel.ts`
-- **Passes when:** in the trailing 30 days, every cinema with `is_active = true` has ≥ 1 PostHog `booking_click` event recorded. Cinemas with zero clicks indicate a structurally broken booking URL even if HTTP returns 200.
+- **Passes when:** EITHER (a) every cinema with `is_active = true` has ≥ 1 PostHog `booking_link_clicked` event in the trailing 30 days, OR (b) total site-wide clicks in that window are below the 500-event volume floor (the condition is deferred — see below).
+- **Volume floor rationale:** at low traffic, per-cinema zero-click counts are a growth signal not a quality one. Confirmed empirically on 2026-05-15: 52 total events / 30d across 56 cinemas means the long tail will have zeros regardless of whether booking links work. The condition defers until the site has enough volume to make the metric meaningful.
 - **Requires:** `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID` in `.env.local`.
 - **Sub-tasks:**
+  - [ ] Replace the deferral path with a Stagehand-based verifier: load each cinema's most-recent future booking URL with a headless browser, assert the page contains the film title or cinema name. Traffic-independent. Tracked here so when /goal targets condition #6 above the floor we have the upgrade path queued.
 
 ### 7. Data quality floor
 - **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-dqs.ts`


### PR DESCRIPTION
## Summary

The first real `/goal` run flagged 31 of 56 active cinemas as zero-click for condition #6 (PostHog `booking_link_clicked` proof-of-life). Investigation showed this is a *traffic* problem, not a *quality* problem — pictures.london emits only 52 events in 30d, all properly attributed, power-law distributed. Condition #6 as originally written was a growth signal, not a quality signal.

This PR:

1. **Defers condition #6 below a 500-event volume floor.** Below the floor, the script returns `pass: true, deferred: true` and `/goal` moves on. Above the floor, the existing per-cinema check engages unchanged.
2. **Adds a regression guard.** Persists `totalClicks` after each run. If current < 50% of a prior baseline that was above the floor, the condition fails with `"Volume regression: …"` rather than silently flipping to deferred-pass. Catches analytics breakage.
3. **Makes the orchestrator rollup honest.** Headline verdict is gated on `!anyDeferred` so the goal can't be falsely declared achieved while a condition is in deferred state. Status table shows `ℹ️ — deferred` instead of `✅`.
4. **Queues the Stagehand-based booking-URL verifier** as a sub-task under condition #6 in `tasks/goal.md` — the traffic-independent replacement that activates when the site grows past the floor.

## Code review

Ran `pr-review-toolkit:code-reviewer` agent on initial commit. Two blocking findings, both fixed in commit `5ad3c40`:

1. Dishonest rollup — `allPass` was computed from `r.pass` alone, so a deferred condition counted as a real pass. The orchestrator could declare "goal is ACHIEVED" while a condition was silently deferred.
2. One-sided volume floor — a drop from 1200 → 200 would silently flip to deferred-pass, masking analytics breakage.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint scripts/goal-*.ts` clean
- [x] Four-scenario smoke run against live PostHog:
  - Cold start → defers cleanly, baseline written
  - Simulated regression (prior 1200 → current 52) → fails with "Volume regression" reason
  - Normal-low (prior 60 → current 52) → defers, regression guard does not trip
  - Full orchestrator run → verdict reads "3/5 measured, 1 deferred" not "ALL CONDITIONS PASS"
- [ ] CI green
- [ ] Reviewer eyes-on

🤖 Generated with [Claude Code](https://claude.com/claude-code)