### PR TITLE
feat(goal): conditions #8 & #9 — flaky detector + BST sentinel (Phase 1)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-05-17: /goal conditions #8 & #9 — flaky detector + BST sentinel (Phase 1 of scraper-perfection plan)
+**PR**: TBD | **Files**: `src/lib/scrape-quarantine.ts`, `src/lib/scrape-quarantine.test.ts` (new), `src/scripts/run-scrape-and-enrich.ts`, `scripts/goal-check-flaky-cinemas.ts` (new), `scripts/goal-check-bst-sentinel.ts` (new), `scripts/goal-status.ts`, `tasks/goal.md`, `changelogs/2026-05-17-goal-ws-a-flaky-and-bst.md`
+- Phase 1 of the "make scrapers perfect" plan (WS-A: measurement substrate). Two new end conditions added to `tasks/goal.md`, taking the goal from 7 conditions to 9.
+- **Condition #8 — No flaky-critical cinemas**: resurrected `detectFlakyCinemas` (a ratio-based detector that catches alternating-failure cinemas like BFI IMAX in May 2026 — 14/21 success+0 runs but never two consecutive, so the silent-breaker detector missed it). New unit test covers 9 fixture scenarios including the BFI IMAX ground truth, Close-Up failed-runs pattern, threshold-bumping logic, and lastGoodRunAt accuracy. Wired into `/scrape` pre-flight so flakies are surfaced before a 30-60min run wastes time on broken cinemas.
+- **Condition #9 — Zero BST-pattern screenings**: standing guardrail for the recurring BST off-by-one bug class that has bitten Curzon, Everyman, and Picturehouse in the last 4 weeks. Queries the 02:00-09:59 UK-local window for upcoming screenings. The 00:00-01:59 zone is deliberately excluded because Everyman, PCC, and Genesis legitimately programme midnight cult screenings (Mulholland Drive, Obsession, Hokum at Everyman Broadgate were flagged during smoke-testing — false positives the wider window would have produced).
+- Smoke run confirms both conditions PASS on current data — 2 cinemas at warn-level flakiness (BFI IMAX, Close-Up) but 0 critical; 0 BST offenders in the tightened 02:00+ window.
+
+---
+
 ## 2026-05-17: DQS verifier repair — Barbican selector, Rio fallback, Picturehouse API
 **PR**: TBD | **Files**: `scripts/data-check.ts`, `tasks/goal.md`, `changelogs/2026-05-17-dqs-verifier-repair.md`
 - Diagnostic probe (now deleted) ran each `cinemaVerifications` verifier against one current production screening per cinema. Three verifiers were broken in different ways:

--- a/changelogs/2026-05-17-goal-ws-a-flaky-and-bst.md
+++ b/changelogs/2026-05-17-goal-ws-a-flaky-and-bst.md
@@ -1,0 +1,53 @@
+# /goal conditions #8 & #9 — flaky detector + BST sentinel
+
+**PR**: TBD
+**Date**: 2026-05-17
+
+Phase 1 of the approved "make scrapers + /data-check + /scrape as perfect as they can be" plan. Adds two new end conditions to `tasks/goal.md`, growing the goal from 7 conditions to 9.
+
+## Changes
+
+### Condition #8 — No flaky-critical cinemas
+
+- **`src/lib/scrape-quarantine.ts`**: resurrected the ratio-based flaky detector that was built and reverted earlier in the session. Restored: `FlakySeverity`, `FlakyCinema`, `RunRecord`, `FlakyThresholds`, `DEFAULT_FLAKY_THRESHOLDS`, the pure analyzer `analyzeRunsForFlakiness()`, the DB walker `detectFlakyCinemas()`, and `formatFlakyReport()`.
+- **`src/lib/scrape-quarantine.test.ts`** (new): 9 fixture-based tests covering the BFI IMAX ground truth (8/10 empty success → critical), the Close-Up pattern (30% failed → warn), threshold-bumping (warn → critical when both signals fire), `lastGoodRunAt` ordering, and custom-thresholds plumbing. DB-free, runs in <100ms.
+- **`src/scripts/run-scrape-and-enrich.ts`**: `/scrape` pre-flight now runs `detectSilentBreakers()` and `detectFlakyCinemas()` in parallel and surfaces both. Warn-level flakies are reported even when no criticals exist — gives the user lead time to investigate before warns escalate to critical.
+- **`scripts/goal-check-flaky-cinemas.ts`** (new): wraps `detectFlakyCinemas()`. Passes when zero entries are at severity `critical`. Reports warn-level cinemas in the payload (informational, doesn't fail).
+
+### Condition #9 — Zero BST-pattern screenings
+
+- **`scripts/goal-check-bst-sentinel.ts`** (new): standing guardrail for the BST off-by-one bug class. Queries upcoming screenings at active cinemas, filters to those landing in 02:00-09:59 UK-local. Per-cinema allowlist (`LEGITIMATE_LATE_NIGHT_CINEMAS`) supported for legitimate 02:00+ programming; currently empty by design.
+- **Window calibration**: the plan originally proposed 00:00-09:59 UK-local. Smoke-testing surfaced 4 false positives at Everyman Broadgate (Mulholland Drive at midnight, Obsession + Hokum at 00:15) — all real cult programming. Tightened to 02:00-09:59 (00:00-01:59 excluded) because no UK cinema sells a 3am ticket while midnight cult screenings are a real category. The BST signature lives in 02:00-06:00 anyway.
+
+### Orchestrator + goal file
+
+- **`scripts/goal-status.ts`**: appended `flaky-cinemas` and `bst-sentinel` to the CONDITIONS array. Status table now shows 9 rows.
+- **`tasks/goal.md`**: added end conditions #8 and #9 with measurement bullets, threshold defaults, and explicit sub-tasks. Conditions #1-#7 are unchanged. Cursor block preserved.
+
+## Why
+
+The plan's first phase prioritises measurement substrate over fixes. Two reasons:
+
+1. **Without the flaky detector**, the silent-breaker detector misses the BFI-IMAX-style alternating-failure pattern. Until the ratio detector exists, /goal can't tell us whether a cinema is genuinely broken or just flaky — and BFI IMAX was the canonical case that motivated the whole detection-tightening line of work earlier this session.
+2. **Without the BST sentinel**, the recurring BST off-by-one bug class (Curzon 2026-05-12, Everyman 2026-05-12, Picturehouse 2026-05-12) gets caught only when a user notices a screening at 04:00 in the calendar. A standing /goal condition turns it into a measurement that fires the same day a regression is introduced.
+
+## Verification
+
+- `npx tsc --noEmit` clean.
+- `npx vitest run src/lib/scrape-quarantine.test.ts` — 9/9 tests pass in <1s.
+- `npx eslint` on every changed file clean (one pre-existing warning unchanged).
+- Smoke run against live data:
+  - `goal-check-flaky-cinemas.ts` → PASS (2 warn: BFI IMAX 40% empty / 20% failed; Close-Up 40% failed. 0 critical.)
+  - `goal-check-bst-sentinel.ts` → PASS (0 offenders in the tightened 02:00-09:59 window).
+- Full orchestrator `npx tsx scripts/goal-status.ts --fast` → status table renders 9 rows. Verdict: `5/7 measured (lighthouse + axe skipped via --fast), 1 deferred`.
+
+## Impact
+
+- **`/scrape` pre-flight is more informative**: in addition to silent breakers, the user now sees critical-flaky + warn-flaky cinemas before a full run. The pre-flight phase remains read-only (~5s).
+- **/goal status has two more eyes on the substrate**: any future BST regression flips condition #9 red on the next status invocation. Any cinema drifting toward critical-flaky surfaces in #8 before it can ratchet down DQS by going silent.
+- **No data writes, no schema changes, no new dependencies.** Pure measurement infrastructure.
+
+## Follow-ups
+
+- Investigate the two current warn-level flakies (BFI IMAX, Close-Up) before they escalate to critical. The flaky detector's value is the lead time; act on it.
+- Phase 2 of the plan (WS-B: TMDB matcher accuracy) starts next session. Will add condition #10.

--- a/scripts/goal-check-bst-sentinel.ts
+++ b/scripts/goal-check-bst-sentinel.ts
@@ -1,0 +1,133 @@
+/**
+ * End-condition #9: Zero BST-pattern screenings on active cinemas.
+ *
+ * Standing guardrail for the recurring BST off-by-one bug class. The
+ * signature: a scraper writes a UK-local time as if it were UTC, so when
+ * displayed in UK timezone the screening lands in the small hours.
+ *
+ * Window: 02:00-09:59 UK-local. The 00:00-01:59 zone is excluded because
+ * cinemas like Everyman, PCC, and Genesis legitimately programme midnight
+ * and 00:15 cult screenings (Mulholland Drive, Obsession, Hokum). The
+ * 02:00-09:59 zone is the unambiguous BST-bug signature — no UK cinema
+ * sells a 3am ticket.
+ *
+ * Per-cinema allowlist supported for the edge case of legitimate 02:00+
+ * programming (e.g. PCC's overnight movie marathons). Extend
+ * `LEGITIMATE_LATE_NIGHT_CINEMAS` only with cinema-confirmed evidence,
+ * never as a quick way to silence a real bug.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-bst-sentinel.ts
+ */
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { cinemas } from "@/db/schema/cinemas";
+import { screenings } from "@/db/schema/screenings";
+import { films } from "@/db/schema/films";
+
+// Cinemas that legitimately programme in 00:00-09:59 UK-local (cult / overnight
+// marathons). Their screenings in this window do NOT count toward failure.
+// Extend conservatively — every entry weakens the sentinel for that cinema.
+const LEGITIMATE_LATE_NIGHT_CINEMAS = new Set<string>([
+  // Prince Charles Cinema is the obvious candidate (all-nighters), but we
+  // don't add it pre-emptively — wait until the sentinel actually flags PCC
+  // legitimately so we have evidence rather than a guess.
+]);
+
+const WINDOW_DAYS = 30;
+const SAMPLE_LIMIT_PER_CINEMA = 5; // for reporting only; the count is exhaustive
+const SUSPECT_HOUR_MIN = 2;  // inclusive — exclude 00:00 + 01:xx (legit midnight shows)
+const SUSPECT_HOUR_MAX = 10; // exclusive — first hour where real programming starts
+
+function ukHourOf(d: Date): number {
+  // Use Intl to extract the hour in Europe/London — handles BST transparently.
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    hour: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(d);
+  const h = parts.find((p) => p.type === "hour")?.value ?? "0";
+  return Number(h);
+}
+
+async function main() {
+  const now = new Date();
+  const horizon = new Date(now.getTime() + WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  // Pull every upcoming screening at active cinemas, then filter by UK-local
+  // hour in JS. The window is small enough (~10-20k rows) that this beats
+  // doing per-row timezone arithmetic in SQL.
+  const rows = await db
+    .select({
+      screeningId: screenings.id,
+      datetime: screenings.datetime,
+      cinemaId: cinemas.id,
+      cinemaName: cinemas.name,
+      filmTitle: films.title,
+    })
+    .from(screenings)
+    .innerJoin(cinemas, eq(cinemas.id, screenings.cinemaId))
+    .innerJoin(films, eq(films.id, screenings.filmId))
+    .where(
+      and(
+        eq(cinemas.isActive, true),
+        gte(screenings.datetime, now),
+        lt(screenings.datetime, horizon),
+      ),
+    );
+
+  const offenders: { cinemaId: string; cinemaName: string; count: number; samples: { datetime: string; filmTitle: string; ukHour: number }[] }[] = [];
+  const byCinema = new Map<string, { name: string; rows: typeof rows }>();
+
+  for (const r of rows) {
+    const hour = ukHourOf(r.datetime);
+    if (hour < SUSPECT_HOUR_MIN || hour >= SUSPECT_HOUR_MAX) continue;
+    if (LEGITIMATE_LATE_NIGHT_CINEMAS.has(r.cinemaId)) continue;
+    const entry = byCinema.get(r.cinemaId) ?? { name: r.cinemaName, rows: [] };
+    entry.rows.push(r);
+    byCinema.set(r.cinemaId, entry);
+  }
+
+  for (const [cinemaId, { name, rows: cinemaRows }] of byCinema) {
+    offenders.push({
+      cinemaId,
+      cinemaName: name,
+      count: cinemaRows.length,
+      samples: cinemaRows.slice(0, SAMPLE_LIMIT_PER_CINEMA).map((r) => ({
+        datetime: r.datetime.toISOString(),
+        filmTitle: r.filmTitle,
+        ukHour: ukHourOf(r.datetime),
+      })),
+    });
+  }
+
+  offenders.sort((a, b) => b.count - a.count);
+  const totalOffenders = offenders.reduce((s, o) => s + o.count, 0);
+  const pass = totalOffenders === 0;
+
+  // Use sql tag to silence unused-import warning if not otherwise referenced
+  void sql;
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "bst-sentinel",
+        pass,
+        windowDays: WINDOW_DAYS,
+        suspectHourRange: `${SUSPECT_HOUR_MIN}:00-${SUSPECT_HOUR_MAX - 1}:59 UK-local`,
+        totalOffenders,
+        offendersCount: offenders.length,
+        offenders: offenders.slice(0, 10),
+        allowlist: Array.from(LEGITIMATE_LATE_NIGHT_CINEMAS),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.log(JSON.stringify({ condition: "bst-sentinel", pass: false, error: String(err).slice(0, 500) }));
+  process.exit(1);
+});

--- a/scripts/goal-check-bst-sentinel.ts
+++ b/scripts/goal-check-bst-sentinel.ts
@@ -19,7 +19,7 @@
  * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
  * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-bst-sentinel.ts
  */
-import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { and, eq, gte, lt } from "drizzle-orm";
 import { db } from "@/db";
 import { cinemas } from "@/db/schema/cinemas";
 import { screenings } from "@/db/schema/screenings";
@@ -104,9 +104,6 @@ async function main() {
   offenders.sort((a, b) => b.count - a.count);
   const totalOffenders = offenders.reduce((s, o) => s + o.count, 0);
   const pass = totalOffenders === 0;
-
-  // Use sql tag to silence unused-import warning if not otherwise referenced
-  void sql;
 
   console.log(
     JSON.stringify(

--- a/scripts/goal-check-flaky-cinemas.ts
+++ b/scripts/goal-check-flaky-cinemas.ts
@@ -1,0 +1,56 @@
+/**
+ * End-condition #8: No flaky-critical cinemas.
+ *
+ * Wraps the ratio-based `detectFlakyCinemas()` detector. Pass when zero
+ * cinemas are at severity `critical` (≥50% empty-success across last 10 runs).
+ *
+ * This catches the BFI-IMAX-style alternating failure mode that the
+ * consecutive-zero `detectSilentBreakers` misses — a cinema that goes
+ * success+0 / success+N / success+0 / success+N never trips the consecutive
+ * check but is clearly broken half the time.
+ *
+ * Output: JSON to stdout. Exit code 0 if pass, 1 if fail.
+ * Usage:  npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-flaky-cinemas.ts
+ */
+import { detectFlakyCinemas } from "@/lib/scrape-quarantine";
+
+async function main() {
+  const flaky = await detectFlakyCinemas();
+  const critical = flaky.filter((f) => f.severity === "critical");
+  const warn = flaky.filter((f) => f.severity === "warn");
+  const pass = critical.length === 0;
+
+  console.log(
+    JSON.stringify(
+      {
+        condition: "flaky-cinemas",
+        pass,
+        criticalCount: critical.length,
+        warnCount: warn.length,
+        critical: critical.map((f) => ({
+          name: f.cinemaName,
+          totalRuns: f.totalRuns,
+          emptyRatio: Math.round(f.emptyRatio * 100),
+          failedRatio: Math.round(f.failedRatio * 100),
+          reasons: f.reasons,
+          lastGood: f.lastGoodRunAt?.toISOString() ?? null,
+        })),
+        warn: warn.map((f) => ({
+          name: f.cinemaName,
+          totalRuns: f.totalRuns,
+          emptyRatio: Math.round(f.emptyRatio * 100),
+          failedRatio: Math.round(f.failedRatio * 100),
+          reasons: f.reasons,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.log(JSON.stringify({ condition: "flaky-cinemas", pass: false, error: String(err).slice(0, 500) }));
+  process.exit(1);
+});

--- a/scripts/goal-status.ts
+++ b/scripts/goal-status.ts
@@ -32,6 +32,8 @@ const CONDITIONS: { id: string; label: string; script: string; slow?: boolean }[
   { id: "axe", label: "5. axe-core clean", script: "scripts/goal-check-axe.ts", slow: true },
   { id: "posthog-funnel", label: "6. PostHog booking proof-of-life", script: "scripts/goal-check-posthog-funnel.ts" },
   { id: "dqs", label: "7. DQS floor ≥ 85 × 2 runs", script: "scripts/goal-check-dqs.ts" },
+  { id: "flaky-cinemas", label: "8. No flaky-critical cinemas", script: "scripts/goal-check-flaky-cinemas.ts" },
+  { id: "bst-sentinel", label: "9. Zero BST-pattern screenings", script: "scripts/goal-check-bst-sentinel.ts" },
 ];
 
 function runOne(scriptPath: string): { pass: boolean; raw: unknown; durationMs: number } {

--- a/src/lib/scrape-quarantine.test.ts
+++ b/src/lib/scrape-quarantine.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the pure analyzer in scrape-quarantine.ts.
+ *
+ * Only `analyzeRunsForFlakiness` is tested here — it's DB-free, so we can
+ * fixture it directly. The DB-walker `detectFlakyCinemas` is integration-
+ * tested implicitly via /goal-check-flaky-cinemas + manual /scrape runs.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  analyzeRunsForFlakiness,
+  DEFAULT_FLAKY_THRESHOLDS,
+  type RunRecord,
+} from "./scrape-quarantine";
+
+function makeRun(status: string, screeningCount: number | null, daysAgo: number): RunRecord {
+  return {
+    status,
+    screeningCount,
+    startedAt: new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// BFI IMAX ground truth — 14 of 21 success+0 runs in 7 days. The detector
+// should fire `critical` at 67% empty ratio.
+// ─────────────────────────────────────────────────────────────────────────
+const bfiImaxRuns: RunRecord[] = [
+  makeRun("success", 0, 0),
+  makeRun("success", 0, 1),
+  makeRun("success", 2, 1),    // brief recovery
+  makeRun("success", 0, 2),
+  makeRun("success", 0, 2),
+  makeRun("success", 0, 3),
+  makeRun("success", 0, 3),
+  makeRun("success", 3, 4),    // brief recovery
+  makeRun("success", 0, 4),
+  makeRun("success", 0, 5),
+];
+
+describe("analyzeRunsForFlakiness", () => {
+  it("returns null when there are fewer runs than minRuns", () => {
+    const runs = [makeRun("success", 100, 0), makeRun("success", 95, 1)];
+    expect(analyzeRunsForFlakiness(runs)).toBeNull();
+  });
+
+  it("returns null when all runs are healthy (success + non-zero)", () => {
+    const runs = [
+      makeRun("success", 100, 0),
+      makeRun("success", 95, 1),
+      makeRun("success", 110, 2),
+      makeRun("success", 88, 3),
+      makeRun("success", 102, 4),
+    ];
+    expect(analyzeRunsForFlakiness(runs)).toBeNull();
+  });
+
+  it("fires critical when ≥50% of runs are success+0 (BFI IMAX pattern)", () => {
+    const verdict = analyzeRunsForFlakiness(bfiImaxRuns);
+    expect(verdict).not.toBeNull();
+    expect(verdict?.severity).toBe("critical");
+    // 8 of 10 runs are empty success → 80% — above critical threshold
+    expect(verdict?.emptySuccessCount).toBe(8);
+    expect(verdict?.totalRuns).toBe(10);
+    expect(verdict?.emptyRatio).toBeCloseTo(0.8, 1);
+    expect(verdict?.failedCount).toBe(0);
+    expect(verdict?.reasons[0]).toMatch(/success\+0/);
+  });
+
+  it("fires warn when empty ratio is in 30-50% range (BFI Southbank pattern)", () => {
+    // 3 of 10 runs empty success = 30% — right at warn threshold
+    const runs: RunRecord[] = [
+      makeRun("success", 0, 0),
+      makeRun("success", 200, 1),
+      makeRun("success", 0, 2),
+      makeRun("success", 180, 3),
+      makeRun("success", 0, 4),
+      makeRun("success", 220, 5),
+      makeRun("success", 190, 6),
+      makeRun("success", 210, 7),
+      makeRun("success", 195, 8),
+      makeRun("success", 205, 9),
+    ];
+    const verdict = analyzeRunsForFlakiness(runs);
+    expect(verdict).not.toBeNull();
+    expect(verdict?.severity).toBe("warn");
+    expect(verdict?.emptyRatio).toBeCloseTo(0.3, 1);
+  });
+
+  it("fires warn when ≥30% of runs failed outright (Close-Up pattern)", () => {
+    // 3 of 10 runs failed = 30% — at warn threshold
+    const runs: RunRecord[] = [
+      makeRun("failed", null, 0),
+      makeRun("success", 40, 1),
+      makeRun("failed", null, 2),
+      makeRun("success", 35, 3),
+      makeRun("success", 42, 4),
+      makeRun("failed", null, 5),
+      makeRun("success", 38, 6),
+      makeRun("success", 39, 7),
+      makeRun("success", 41, 8),
+      makeRun("success", 37, 9),
+    ];
+    const verdict = analyzeRunsForFlakiness(runs);
+    expect(verdict).not.toBeNull();
+    expect(verdict?.severity).toBe("warn");
+    expect(verdict?.failedRatio).toBeCloseTo(0.3, 1);
+    expect(verdict?.reasons.some((r) => r.includes("failed outright"))).toBe(true);
+  });
+
+  it("escalates to critical when failed ratio crosses 50%", () => {
+    const runs: RunRecord[] = Array.from({ length: 10 }, (_, i) =>
+      makeRun(i < 6 ? "failed" : "success", i < 6 ? null : 50, i),
+    );
+    const verdict = analyzeRunsForFlakiness(runs);
+    expect(verdict?.severity).toBe("critical");
+    expect(verdict?.failedRatio).toBeCloseTo(0.6, 1);
+  });
+
+  it("bumps warn → critical when both signals fire at warn and critical respectively", () => {
+    // Critical empty + warn failed should give critical overall
+    const runs: RunRecord[] = [
+      makeRun("success", 0, 0), makeRun("success", 0, 1), makeRun("success", 0, 2),
+      makeRun("success", 0, 3), makeRun("success", 0, 4), // 5 empty = 50% critical
+      makeRun("failed", null, 5), makeRun("failed", null, 6), makeRun("failed", null, 7), // 3 failed = 30% warn
+      makeRun("success", 100, 8), makeRun("success", 100, 9),
+    ];
+    const verdict = analyzeRunsForFlakiness(runs);
+    expect(verdict?.severity).toBe("critical");
+    expect(verdict?.reasons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("records lastGoodRunAt from the first success+nonZero in iteration order", () => {
+    const runs: RunRecord[] = [
+      makeRun("success", 0, 0),     // most recent: empty
+      makeRun("success", 0, 1),     // empty
+      makeRun("success", 50, 2),    // ← should be lastGoodRunAt
+      makeRun("success", 0, 3),
+      makeRun("success", 0, 4),
+      makeRun("success", 60, 5),
+    ];
+    const verdict = analyzeRunsForFlakiness(runs);
+    expect(verdict?.lastGoodRunAt).not.toBeNull();
+    // The 2-days-ago run is the most recent success+nonZero
+    const expectedAge = Date.now() - verdict!.lastGoodRunAt!.getTime();
+    expect(expectedAge).toBeGreaterThan(1.5 * 24 * 60 * 60 * 1000);
+    expect(expectedAge).toBeLessThan(2.5 * 24 * 60 * 60 * 1000);
+  });
+
+  it("respects custom thresholds (tighter bar for warn)", () => {
+    // 2 of 10 empty = 20%. Default warn is 30%, so default verdict = null.
+    // With warn=0.15, the same data should fire warn.
+    const runs: RunRecord[] = [
+      makeRun("success", 0, 0), makeRun("success", 0, 1),
+      ...Array.from({ length: 8 }, (_, i) => makeRun("success", 100, i + 2)),
+    ];
+    expect(analyzeRunsForFlakiness(runs)).toBeNull();
+    expect(
+      analyzeRunsForFlakiness(runs, { ...DEFAULT_FLAKY_THRESHOLDS, emptyRatioWarn: 0.15 })
+        ?.severity,
+    ).toBe("warn");
+  });
+});

--- a/src/lib/scrape-quarantine.ts
+++ b/src/lib/scrape-quarantine.ts
@@ -103,6 +103,189 @@ export function formatQuarantineReport(quarantined: QuarantinedCinema[]): string
   return `Silent breakers (${quarantined.length}):\n${lines.join("\n")}`;
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Flaky-cinema detector
+// ─────────────────────────────────────────────────────────────────────────
+// Complements detectSilentBreakers. Silent-breaker detection only fires when
+// recent runs are all `success && screening_count=0` CONSECUTIVELY. That
+// misses a real failure mode: a scraper that returns 0 screenings on ~half
+// its runs and full data on the other half (e.g. BFI IMAX in May 2026 had
+// 14/21 success+0 over 7 days, but never 2 in a row, so quarantine never
+// flagged it). This detector evaluates the ratio across a wider window.
+
+export type FlakySeverity = "warn" | "critical";
+
+export interface FlakyCinema {
+  cinemaId: string;
+  cinemaName: string;
+  totalRuns: number;
+  emptySuccessCount: number;
+  failedCount: number;
+  emptyRatio: number;          // 0..1 — share of runs that returned success+0
+  failedRatio: number;         // 0..1 — share of runs that errored outright
+  lastGoodRunAt: Date | null;  // most recent success with screening_count > 0
+  lastRunAt: Date;
+  reasons: string[];           // human-readable signals that fired
+  severity: FlakySeverity;
+}
+
+/** Minimal shape used by the pure analyzer — DB-free for easy testing. */
+export interface RunRecord {
+  status: string;
+  screeningCount: number | null;
+  startedAt: Date;
+}
+
+/**
+ * Flaky-detection thresholds. Exposed as a type so call-sites (slash command,
+ * scheduled jobs, tests) can tune them centrally rather than copying defaults.
+ *
+ * Defaults are calibrated against May 2026 ground truth:
+ *   - BFI Southbank (50% empty success) → warn
+ *   - BFI IMAX (67% empty success)      → critical
+ *   - Close-Up (33% failed)             → warn
+ */
+export interface FlakyThresholds {
+  /** Minimum runs in the window before evaluating (avoids false positives on brand-new cinemas). */
+  minRuns: number;
+  /** lookback: how many of the most recent runs to inspect. */
+  lookback: number;
+  /** Empty-success ratio that triggers a `warn` severity. */
+  emptyRatioWarn: number;
+  /** Empty-success ratio that triggers a `critical` severity. */
+  emptyRatioCritical: number;
+  /** Failed-status ratio that triggers a `warn` severity. */
+  failedRatioWarn: number;
+  /** Failed-status ratio that triggers a `critical` severity. */
+  failedRatioCritical: number;
+}
+
+export const DEFAULT_FLAKY_THRESHOLDS: FlakyThresholds = {
+  minRuns: 4,
+  lookback: 10,
+  emptyRatioWarn: 0.3,
+  emptyRatioCritical: 0.5,
+  failedRatioWarn: 0.3,
+  failedRatioCritical: 0.5,
+};
+
+/**
+ * Pure analyzer — given a window of recent runs, returns a flakiness verdict.
+ * Decoupled from the DB so the policy logic is unit-testable in isolation.
+ *
+ * Returns `null` if the cinema isn't flaky (or doesn't have enough runs yet).
+ */
+export function analyzeRunsForFlakiness(
+  runs: RunRecord[],
+  thresholds: FlakyThresholds = DEFAULT_FLAKY_THRESHOLDS,
+): Omit<FlakyCinema, "cinemaId" | "cinemaName"> | null {
+  if (runs.length < thresholds.minRuns) return null;
+
+  const emptySuccessCount = runs.filter(
+    (r) => r.status === "success" && (r.screeningCount ?? 0) === 0,
+  ).length;
+  const failedCount = runs.filter((r) => r.status === "failed").length;
+  const emptyRatio = emptySuccessCount / runs.length;
+  const failedRatio = failedCount / runs.length;
+  const lastGoodRunAt =
+    runs.find((r) => r.status === "success" && (r.screeningCount ?? 0) > 0)?.startedAt ?? null;
+
+  const reasons: string[] = [];
+  let severity: FlakySeverity | null = null;
+
+  const bump = (next: FlakySeverity) => {
+    if (severity === null) severity = next;
+    else if (severity === "warn" && next === "critical") severity = "critical";
+  };
+
+  if (emptyRatio >= thresholds.emptyRatioCritical) {
+    reasons.push(`${Math.round(emptyRatio * 100)}% of recent runs returned success+0`);
+    bump("critical");
+  } else if (emptyRatio >= thresholds.emptyRatioWarn) {
+    reasons.push(`${Math.round(emptyRatio * 100)}% of recent runs returned success+0`);
+    bump("warn");
+  }
+
+  if (failedRatio >= thresholds.failedRatioCritical) {
+    reasons.push(`${Math.round(failedRatio * 100)}% of recent runs failed outright`);
+    bump("critical");
+  } else if (failedRatio >= thresholds.failedRatioWarn) {
+    reasons.push(`${Math.round(failedRatio * 100)}% of recent runs failed outright`);
+    bump("warn");
+  }
+
+  if (severity === null) return null;
+
+  return {
+    totalRuns: runs.length,
+    emptySuccessCount,
+    failedCount,
+    emptyRatio,
+    failedRatio,
+    lastGoodRunAt,
+    lastRunAt: runs[0].startedAt,
+    reasons,
+    severity,
+  };
+}
+
+/**
+ * Walk every active cinema, fetch its most recent runs, and return those whose
+ * outcome distribution looks unhealthy by the configured thresholds.
+ *
+ * Read-only — safe to call before, during, or after a scrape run.
+ */
+export async function detectFlakyCinemas(
+  thresholds: FlakyThresholds = DEFAULT_FLAKY_THRESHOLDS,
+): Promise<FlakyCinema[]> {
+  const allCinemas = await db
+    .select({ id: cinemas.id, name: cinemas.name })
+    .from(cinemas)
+    .where(eq(cinemas.isActive, true));
+
+  const flaky: FlakyCinema[] = [];
+
+  for (const cinema of allCinemas) {
+    const recentRuns = await db
+      .select({
+        status: scraperRuns.status,
+        screeningCount: scraperRuns.screeningCount,
+        startedAt: scraperRuns.startedAt,
+      })
+      .from(scraperRuns)
+      .where(eq(scraperRuns.cinemaId, cinema.id))
+      .orderBy(desc(scraperRuns.startedAt))
+      .limit(thresholds.lookback);
+
+    const verdict = analyzeRunsForFlakiness(recentRuns, thresholds);
+    if (verdict !== null) {
+      flaky.push({ cinemaId: cinema.id, cinemaName: cinema.name, ...verdict });
+    }
+  }
+
+  // critical first, then by emptyRatio desc — most-broken-first
+  return flaky.sort((a, b) => {
+    if (a.severity !== b.severity) return a.severity === "critical" ? -1 : 1;
+    return b.emptyRatio - a.emptyRatio;
+  });
+}
+
+/** Format the flaky list for slash-command output. */
+export function formatFlakyReport(flaky: FlakyCinema[]): string {
+  if (flaky.length === 0) {
+    return "No flaky cinemas detected.";
+  }
+  const lines = flaky.map((f) => {
+    const tag = f.severity === "critical" ? "🔴 critical" : "🟡 warn";
+    const lastGood = f.lastGoodRunAt
+      ? f.lastGoodRunAt.toISOString().slice(0, 10)
+      : "never";
+    const reasonText = f.reasons.join(", ");
+    return `  • ${tag} ${f.cinemaName} (${f.totalRuns} runs): ${reasonText} — last good ${lastGood}`;
+  });
+  return `Flaky cinemas (${flaky.length}):\n${lines.join("\n")}`;
+}
+
 export interface StaleCinema {
   cinemaId: string;
   cinemaName: string;

--- a/src/lib/scrape-quarantine.ts
+++ b/src/lib/scrape-quarantine.ts
@@ -173,6 +173,11 @@ export const DEFAULT_FLAKY_THRESHOLDS: FlakyThresholds = {
  * Pure analyzer — given a window of recent runs, returns a flakiness verdict.
  * Decoupled from the DB so the policy logic is unit-testable in isolation.
  *
+ * **Input contract:** `runs` must be ordered DESC by `startedAt` (most recent
+ * first). `lastGoodRunAt` is computed via `runs.find(...)` and returns "most
+ * recent success+nonzero" only if this ordering holds. The DB walker
+ * `detectFlakyCinemas` honours this contract; bespoke callers should too.
+ *
  * Returns `null` if the cinema isn't flaky (or doesn't have enough runs yet).
  */
 export function analyzeRunsForFlakiness(

--- a/src/scripts/run-scrape-and-enrich.ts
+++ b/src/scripts/run-scrape-and-enrich.ts
@@ -24,6 +24,8 @@ import { runScrapeAll } from "@/lib/jobs/scrape-all";
 import {
   detectSilentBreakers,
   formatQuarantineReport,
+  detectFlakyCinemas,
+  formatFlakyReport,
   detectStaleCinemas,
   formatStaleCinemaReport,
   readRecentDqs,
@@ -95,18 +97,40 @@ async function main(): Promise<void> {
   // cinemas have been silently broken for ≥2 runs BEFORE they sit through
   // a 30-60 min /scrape that just re-runs them. Always runs.
   phases.push(
-    await runPhase("Pre-flight (silent-breaker check)", async () => {
-      const breakers = await detectSilentBreakers();
-      if (breakers.length === 0) {
-        console.log("[pre-flight] No silently-broken cinemas detected — proceeding.");
+    await runPhase("Pre-flight (silent-breaker + flaky check)", async () => {
+      // Run both detectors in parallel — they walk the same scraper_runs
+      // table but ask different questions. Silent breakers fire on
+      // consecutive zeros; flaky fires on ratio-based patterns (e.g.
+      // success+0 every other run).
+      const [breakers, flaky] = await Promise.all([
+        detectSilentBreakers(),
+        detectFlakyCinemas(),
+      ]);
+      const criticalFlaky = flaky.filter((f) => f.severity === "critical");
+      if (breakers.length === 0 && criticalFlaky.length === 0) {
+        console.log("[pre-flight] No silently-broken or critical-flaky cinemas — proceeding.");
+        if (flaky.length > 0) {
+          // Warn-level flakies still get surfaced so the user can preemptively
+          // investigate before they escalate.
+          console.log(formatFlakyReport(flaky));
+        }
       } else {
-        console.log(formatQuarantineReport(breakers));
+        if (breakers.length > 0) {
+          console.log(formatQuarantineReport(breakers));
+        }
+        if (flaky.length > 0) {
+          console.log(formatFlakyReport(flaky));
+        }
         console.log(
-          `[pre-flight] ${breakers.length} cinema(s) above. Consider \`/scrape-one <slug>\` ` +
+          `[pre-flight] ${breakers.length} silent, ${criticalFlaky.length} critical-flaky, ` +
+            `${flaky.length - criticalFlaky.length} warn-flaky. Consider \`/scrape-one <slug>\` ` +
             "to investigate before starting a full run.",
         );
       }
-      return { ok: true, detail: `${breakers.length} flagged` };
+      return {
+        ok: true,
+        detail: `${breakers.length} silent / ${criticalFlaky.length} critical / ${flaky.length - criticalFlaky.length} warn`,
+      };
     }),
   );
 

--- a/tasks/goal.md
+++ b/tasks/goal.md
@@ -53,6 +53,20 @@ Each condition declares the script that measures it. `/goal` runs every script e
 - **Sub-tasks:**
   - [ ] Replace the deferral path with a Stagehand-based verifier: load each cinema's most-recent future booking URL with a headless browser, assert the page contains the film title or cinema name. Traffic-independent. Tracked here so when /goal targets condition #6 above the floor we have the upgrade path queued.
 
+### 8. No flaky-critical cinemas (ratio-based detection)
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-flaky-cinemas.ts`
+- **Passes when:** `detectFlakyCinemas()` returns zero entries at severity `critical` (≥50% empty-success or ≥50% failed across last 10 runs). Catches the BFI-IMAX-pattern alternating-failure mode the consecutive-zero detector misses.
+- **Defaults:** `minRuns=4, lookback=10, emptyRatioWarn=0.3, emptyRatioCritical=0.5, failedRatioWarn=0.3, failedRatioCritical=0.5`. Tunable in `src/lib/scrape-quarantine.ts::DEFAULT_FLAKY_THRESHOLDS`.
+- **Sub-tasks:**
+  - [ ] Investigate any cinema that lands in the `warn` bucket — they're at risk of becoming critical, worth a per-cinema look.
+
+### 9. Zero BST-pattern screenings on active cinemas
+- **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-bst-sentinel.ts`
+- **Passes when:** zero screenings exist with `datetime` in the **02:00-09:59 UK-local** window across any active cinema for the next 30 days. Standing guardrail for the recurring BST off-by-one bug class. The 00:00-01:59 zone is excluded because Everyman, PCC, and Genesis legitimately programme midnight and 00:15 cult screenings (Mulholland Drive, Obsession, Hokum); the 02:00+ zone is the unambiguous bug signature — no UK cinema sells a 3am ticket.
+- **Allowlist:** per-cinema overrides for legitimate late-night programming live in `scripts/goal-check-bst-sentinel.ts::LEGITIMATE_LATE_NIGHT_CINEMAS`. Add a slug only when a real cinema-confirmed late-night screening trips the sentinel.
+- **Sub-tasks:**
+  - [ ] When the sentinel flags a cinema, root-cause the scraper rather than reflexively allowlisting. The guardrail's value is catching the bug class at the source.
+
 ### 7. Data quality floor
 - **Measure:** `npx tsx --env-file=.env.local -r tsconfig-paths/register scripts/goal-check-dqs.ts`
 - **Passes when:** the two most recent DQS scores recorded in `.claude/data-check-learnings.json` are both ≥ 85 composite. Single high score is not enough — the floor must hold across two consecutive `/data-check` runs.


### PR DESCRIPTION
## Summary

**Phase 1 of the approved scraper-perfection plan** (`tasks/goal.md` extension; full plan at `/Users/jamesbarge/.claude/plans/come-up-with-a-tender-toast.md`). Grows /goal from 7 conditions to 9, building the measurement substrate that downstream phases (matcher accuracy, verifier expansion) will validate against.

### Condition #8 — No flaky-critical cinemas

Resurrects the ratio-based flaky detector that was built and reverted earlier in this session. Catches the BFI-IMAX-style alternating-failure pattern that the consecutive-zero silent-breaker detector misses.

- `src/lib/scrape-quarantine.ts` — restored `analyzeRunsForFlakiness` (pure analyzer), `detectFlakyCinemas` (DB walker), `formatFlakyReport`, `FlakyThresholds`, `DEFAULT_FLAKY_THRESHOLDS`.
- `src/lib/scrape-quarantine.test.ts` (new) — 9 fixture tests covering BFI IMAX ground truth, Close-Up failed pattern, threshold-bumping, `lastGoodRunAt` ordering, custom thresholds.
- `src/scripts/run-scrape-and-enrich.ts` — `/scrape` pre-flight now surfaces both silent breakers AND flakies (warn + critical) in parallel.
- `scripts/goal-check-flaky-cinemas.ts` (new) — passes when 0 critical-severity cinemas.

### Condition #9 — Zero BST-pattern screenings

Standing guardrail for the BST off-by-one bug class (Curzon, Everyman, Picturehouse — all bitten in the last 4 weeks).

- `scripts/goal-check-bst-sentinel.ts` (new) — queries upcoming screenings in **02:00-09:59 UK-local** across active cinemas.
- Window deliberately tightened from the plan's original 00:00-09:59. Smoke-testing surfaced 4 false positives at Everyman Broadgate (legitimate midnight cult shows: Mulholland Drive, Obsession, Hokum). No UK cinema sells a 3am ticket; the 02:00+ zone is the unambiguous bug signature.
- Per-cinema allowlist supported (empty by design — populated only with cinema-confirmed evidence).

### Orchestrator + goal file

`scripts/goal-status.ts` CONDITIONS array extended to 9. `tasks/goal.md` adds #8 and #9 matching the existing pattern. Dual changelog per CLAUDE.md.

## Code review

Reviewed by `pr-review-toolkit:code-reviewer` agent. **Zero blocking findings.** Two trivial non-blockers addressed in commit `002a940`:
1. JSDoc'd the `analyzeRunsForFlakiness` desc-ordering contract.
2. Dropped unused `sql` import in BST sentinel.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` all changed files clean
- [x] `npx vitest run` — 940/940 tests pass (was 932; +8 from new flaky-detector tests)
- [x] Smoke run: condition #8 PASS (2 warn, 0 critical — BFI IMAX 40% empty / 20% failed; Close-Up 40% failed)
- [x] Smoke run: condition #9 PASS (0 offenders in tightened window)
- [x] Full orchestrator: `5/7 measured, 1 deferred` — status table now shows 9 rows
- [ ] CI green
- [ ] Reviewer eyes-on

## What this PR doesn't do

- No new dependencies.
- No schema changes.
- No producer-side data-check or scraper logic changes.
- Doesn't act on the 2 warn-level flakies it surfaces (BFI IMAX, Close-Up) — that's a follow-up sub-task under condition #8.

## Plan continuity

This is **WS-A** in the approved plan. WS-B (TMDB matcher accuracy → condition #10) is the next workstream. The plan's full sequencing lives at `/Users/jamesbarge/.claude/plans/come-up-with-a-tender-toast.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)