### PR TITLE
refactor(scrape): extract iCal parser to scrapers/utils

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-05-17: Extract iCal parser to src/scrapers/utils/ical-parser.ts
+**PR**: TBD | **Files**: `src/scrapers/utils/ical-parser.ts` (new), `src/scrapers/cinemas/cinema-museum.ts`
+- Moves `parseVEvents` + supporting types from `cinemas/cinema-museum.ts` to `utils/ical-parser.ts`. Re-exported from the original location so the existing test file's import continues to work. No behaviour change.
+- Code-review follow-up flagged in #496's review: "Consider extracting the `parseVEvents` parser to `src/scrapers/utils/` if another iCal-feed venue surfaces in future audits." Pre-extracting now so the next iCal-feed venue (e.g. Bertha DocHouse's WordPress Events Calendar, or any other Pressidium-hosted London cinema) drops in with a single import.
+- 990/990 tests pass; type-clean; no test changes required.
+
+---
+
 ## 2026-05-17: /scrape post-run — delta-vs-baseline report (per-run yield UX surfacer)
 **PR**: TBD | **Files**: `src/lib/scrape-quarantine.ts`, `src/lib/scrape-quarantine.test.ts`, `src/scripts/run-scrape-and-enrich.ts`
 - New `detectYieldDeltaSinceBaseline(options?)` + `formatYieldDeltaReport(deltas)` in `src/lib/scrape-quarantine.ts`. Compares the most recent successful run per cinema to the mean of all successful runs from the prior 7 days (excluding the latest). Flags cinemas whose current count is ≤ 70% of baseline AND whose baseline mean is ≥ 10 (to filter small-cinema noise). Complements the existing yield-drop detector — yield-drop needs a 25-run window to fire; this fires after a single below-baseline run.

--- a/changelogs/2026-05-17-extract-ical-parser-to-utils.md
+++ b/changelogs/2026-05-17-extract-ical-parser-to-utils.md
@@ -1,0 +1,32 @@
+# Extract iCal parser to scrapers/utils
+
+**PR**: TBD
+**Date**: 2026-05-17
+
+## Context
+
+The Cinema Museum scraper (shipped via #500) included a minimal in-tree iCal parser (`parseVEvents`). Code review in #496 flagged it as a candidate for extraction to `src/scrapers/utils/` if a second iCal-feed venue arrived. Rather than wait, this pre-extracts the parser so any future iCal-based London venue can drop in with one import.
+
+## Changes
+
+### `src/scrapers/utils/ical-parser.ts` (new)
+
+- Moves `parseVEvents` and the `ParsedVEvent` interface verbatim from `cinemas/cinema-museum.ts`.
+- Adds an expanded docstring covering scope (RFC 5545 line folding + TEXT escapes + UK-local DTSTART) and explicit non-goals (UTC `Z` form, floating times, RRULE expansion).
+- The `unescapeIcalText` helper moves with it.
+
+### `src/scrapers/cinemas/cinema-museum.ts`
+
+- Imports `parseVEvents` from the new utils module.
+- Re-exports `parseVEvents` from the original location so the existing test file (`cinema-museum.test.ts` imports `parseVEvents` from `./cinema-museum`) keeps working without modification.
+
+## Verification
+
+- `npm run test:run` — 990/990 pass on the branch
+- `npx tsc --noEmit` — clean
+- No production behaviour change — pure file move + re-export
+
+## Impact
+
+- Future iCal-feed venues can drop in with `import { parseVEvents } from "../utils/ical-parser"` rather than copying the parser
+- Single source of truth for iCal handling makes future extensions (UTC support, RRULE expansion) trivial to add when needed

--- a/src/scrapers/cinemas/cinema-museum.ts
+++ b/src/scrapers/cinemas/cinema-museum.ts
@@ -28,6 +28,11 @@ import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
 import { FestivalDetector } from "../festivals/festival-detector";
 import { ukLocalToUTC } from "../utils/date-parser";
+import { parseVEvents } from "../utils/ical-parser";
+
+// Re-export so existing tests / imports of `parseVEvents` from this module
+// keep working. New code should import directly from `../utils/ical-parser`.
+export { parseVEvents } from "../utils/ical-parser";
 
 const ICAL_URL = "https://cinemamuseum.org.uk/schedule/?ical=1";
 const BASE_URL = "https://cinemamuseum.org.uk";
@@ -38,99 +43,6 @@ const EXCLUDED_CATEGORIES = new Set([
   "Bazaar",
   "Bazaars",
 ]);
-
-interface ParsedVEvent {
-  uid: string;
-  summary: string;
-  dtStartUKLocal: { year: number; month: number; day: number; hour: number; minute: number };
-  url?: string;
-  categories: string[];
-}
-
-/**
- * Minimal iCal VEVENT parser — only what we need from a 30-event feed.
- * Handles RFC 5545 line folding (continuation lines that start with " " or "\t")
- * and the `\,`, `\;`, `\\`, `\n` escape sequences in TEXT properties.
- *
- * Exported for unit testing.
- */
-export function parseVEvents(icalText: string): ParsedVEvent[] {
-  // Unfold line continuations (a leading space/tab continues the previous line)
-  const lines = icalText.replace(/\r\n[ \t]/g, "").replace(/\n[ \t]/g, "").split(/\r?\n/);
-
-  const events: ParsedVEvent[] = [];
-  let current: Partial<ParsedVEvent> & { _open?: boolean } | null = null;
-
-  for (const line of lines) {
-    if (line === "BEGIN:VEVENT") {
-      current = { _open: true, categories: [] };
-      continue;
-    }
-    if (line === "END:VEVENT") {
-      if (current && current.uid && current.summary && current.dtStartUKLocal) {
-        events.push({
-          uid: current.uid,
-          summary: current.summary,
-          dtStartUKLocal: current.dtStartUKLocal,
-          url: current.url,
-          categories: current.categories ?? [],
-        });
-      }
-      current = null;
-      continue;
-    }
-    if (!current?._open) continue;
-
-    // Split into "PROPERTY[;params]" and "value"
-    const colon = line.indexOf(":");
-    if (colon < 0) continue;
-    const propWithParams = line.slice(0, colon);
-    const rawValue = line.slice(colon + 1);
-    const semi = propWithParams.indexOf(";");
-    const prop = semi < 0 ? propWithParams : propWithParams.slice(0, semi);
-
-    switch (prop) {
-      case "UID":
-        current.uid = rawValue;
-        break;
-      case "SUMMARY":
-        current.summary = unescapeIcalText(rawValue);
-        break;
-      case "URL":
-        current.url = rawValue;
-        break;
-      case "CATEGORIES":
-        current.categories = rawValue.split(",").map((c) => c.trim()).filter(Boolean);
-        break;
-      case "DTSTART": {
-        // Format: 20260516T193000 (no tz, paired with TZID=Europe/London in params)
-        // or rare floating-time. Only handle the local-time UK form because that's
-        // what the feed always emits (TZID=Europe/London).
-        const m = rawValue.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})\d{2}/);
-        if (!m) break;
-        const [, year, month, day, hour, minute] = m;
-        current.dtStartUKLocal = {
-          year: parseInt(year, 10),
-          month: parseInt(month, 10) - 1, // 0-indexed
-          day: parseInt(day, 10),
-          hour: parseInt(hour, 10),
-          minute: parseInt(minute, 10),
-        };
-        break;
-      }
-    }
-  }
-
-  return events;
-}
-
-function unescapeIcalText(s: string): string {
-  return s
-    .replace(/\\n/gi, " ")
-    .replace(/\\,/g, ",")
-    .replace(/\\;/g, ";")
-    .replace(/\\\\/g, "\\");
-}
 
 export class CinemaMuseumScraper extends BaseScraper {
   config: ScraperConfig = {

--- a/src/scrapers/utils/ical-parser.ts
+++ b/src/scrapers/utils/ical-parser.ts
@@ -1,0 +1,125 @@
+/**
+ * Minimal iCal (RFC 5545) VEVENT parser — only what cinema scrapers need.
+ *
+ * Handles:
+ *   - Line folding: continuation lines starting with space/tab are unwrapped
+ *   - TEXT escape sequences: `\,`, `\;`, `\\`, `\n` in SUMMARY etc.
+ *   - DTSTART;TZID=Europe/London:YYYYMMDDTHHmmss — UK-local form (the only
+ *     timezone form we see in practice from WordPress Events Calendar feeds)
+ *
+ * NOT handled (out of scope — add only when a real venue needs them):
+ *   - UTC `DTSTART:YYYYMMDDTHHmmssZ` (would need `Z` branch + UTC parse)
+ *   - Floating times (no TZID, no Z)
+ *   - RRULE / recurrence expansion
+ *   - VALARM / VTIMEZONE / arbitrary X- properties (silently skipped)
+ *
+ * First used by the Cinema Museum scraper (2026-05-15). Extracted to utils on
+ * 2026-05-17 in preparation for any future iCal-based London venue (other
+ * Events-Calendar-WordPress sites, Bertha DocHouse's hypothetical iCal feed,
+ * etc.). The Cinema Museum scraper imports `parseVEvents` from here.
+ */
+
+export interface ParsedVEvent {
+  /** RFC 5545 UID — globally unique event ID. */
+  uid: string;
+  /** Event title (escapes unwrapped). */
+  summary: string;
+  /**
+   * Local-time DTSTART components for the UK timezone. Callers pair with
+   * `ukLocalToUTC` from `../utils/date-parser.ts` to get a Date.
+   */
+  dtStartUKLocal: {
+    year: number;
+    /** 0-indexed (January = 0) to match Date constructor convention. */
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+  };
+  /** Event detail URL if present. */
+  url?: string;
+  /** Comma-split CATEGORIES (trimmed, empty values dropped). */
+  categories: string[];
+}
+
+/** Public for unit testing. */
+export function parseVEvents(icalText: string): ParsedVEvent[] {
+  // Unfold line continuations (a leading space/tab continues the previous line)
+  const lines = icalText.replace(/\r\n[ \t]/g, "").replace(/\n[ \t]/g, "").split(/\r?\n/);
+
+  const events: ParsedVEvent[] = [];
+  let current: Partial<ParsedVEvent> & { _open?: boolean } | null = null;
+
+  for (const line of lines) {
+    if (line === "BEGIN:VEVENT") {
+      current = { _open: true, categories: [] };
+      continue;
+    }
+    if (line === "END:VEVENT") {
+      if (current && current.uid && current.summary && current.dtStartUKLocal) {
+        events.push({
+          uid: current.uid,
+          summary: current.summary,
+          dtStartUKLocal: current.dtStartUKLocal,
+          url: current.url,
+          categories: current.categories ?? [],
+        });
+      }
+      current = null;
+      continue;
+    }
+    if (!current?._open) continue;
+
+    // Split into "PROPERTY[;params]" and "value"
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const propWithParams = line.slice(0, colon);
+    const rawValue = line.slice(colon + 1);
+    const semi = propWithParams.indexOf(";");
+    const prop = semi < 0 ? propWithParams : propWithParams.slice(0, semi);
+
+    switch (prop) {
+      case "UID":
+        current.uid = rawValue;
+        break;
+      case "SUMMARY":
+        current.summary = unescapeIcalText(rawValue);
+        break;
+      case "URL":
+        current.url = rawValue;
+        break;
+      case "CATEGORIES":
+        current.categories = rawValue.split(",").map((c) => c.trim()).filter(Boolean);
+        break;
+      case "DTSTART": {
+        // Format: 20260516T193000 (no tz, paired with TZID=Europe/London in params).
+        // We deliberately ignore the TZID param value: every iCal feed we
+        // consume emits TZID=Europe/London, and the project's
+        // `ukLocalToUTC()` helper handles the UK-local → UTC conversion
+        // including BST. If a feed ever emits a different TZID, the resulting
+        // Date will be wrong — add explicit branching here at that point.
+        const m = rawValue.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})\d{2}/);
+        if (!m) break;
+        const [, year, month, day, hour, minute] = m;
+        current.dtStartUKLocal = {
+          year: parseInt(year, 10),
+          month: parseInt(month, 10) - 1, // 0-indexed
+          day: parseInt(day, 10),
+          hour: parseInt(hour, 10),
+          minute: parseInt(minute, 10),
+        };
+        break;
+      }
+    }
+  }
+
+  return events;
+}
+
+function unescapeIcalText(s: string): string {
+  return s
+    .replace(/\\n/gi, " ")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}


### PR DESCRIPTION
## Summary

Pre-extracts `parseVEvents` from `cinemas/cinema-museum.ts` to a dedicated `utils/ical-parser.ts` module. Re-exported from the original location so existing test imports keep working without modification.

## Why now

Code review in #496 flagged this as a follow-up: "Consider extracting the `parseVEvents` parser to `src/scrapers/utils/` if another iCal-feed venue surfaces in future audits." Pre-extracting now so any future iCal-based London venue (e.g. WordPress Events Calendar sites, Pressidium-hosted cinemas) drops in with a single import rather than a copy-paste.

## Test plan

- [x] `npm run test:run` — 990 / 990 pass on the branch
- [x] `npx tsc --noEmit` — clean
- [x] Pure file move + re-export; no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)