### PR TITLE
test(lib): add unit tests for title-extraction/patterns.ts (regex + escapeRegex)

### DIFF
--- a/changelogs/2026-05-18-title-extraction-patterns-tests.md
+++ b/changelogs/2026-05-18-title-extraction-patterns-tests.md
@@ -1,0 +1,43 @@
+# Add unit tests for src/lib/title-extraction/patterns.ts (regex patterns + escapeRegex)
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/title-extraction/patterns.test.ts` (new) — 27 vitest cases covering 4 regex patterns + the `escapeRegex` helper.
+
+## Coverage
+### Pattern matchers
+- **`PRESENTS_PATTERN`** (6) — matches `X presents "Y"` and `X present "Y"`, smart-quote U+201C, case-insensitivity, plus negative cases (no `presents` keyword, no surrounding quotes)
+- **`SINGALONG_PATTERN`** (5) — matches the 3 variants (`Sing-A-Long-A`, `Sing-A-Long`, `SingALongA`), case-insensitivity, negative case
+- **`DOUBLE_FEATURE_PATTERN`** (4) — captures first film, **non-greedy** behaviour on triple features (`A + B + C` → `A`), missing whitespace tolerance, negative case
+- **`FRANCHISE_PATTERN`** (7) — Star Wars, Harry, Lord, Indiana, Spider — and the **start-anchored** constraint (`The Star Wars Story` does NOT match)
+
+### `escapeRegex(str)` (5)
+- Each regex metacharacter from the implementation's character class (`.*+?^${}()|[]\\`)
+- Plain alphanumeric unchanged
+- Empty string
+- **Pinned contract**: hyphens and forward slashes are NOT escaped (not in the metacharacter class)
+- Round-trip property: escaped output can be embedded in `new RegExp()` and matches the original input literally
+
+## Why
+The 4 patterns are used by `extractFilmTitleSync` (the synchronous title extractor) to identify event-wrapped films, sing-along screenings, double features, and franchise titles. A regression silently changes which films get extracted vs left as-is, with downstream effects on TMDB matching.
+
+`escapeRegex` is a security-relevant helper: it ensures user-supplied title fragments can be safely embedded in dynamic regexes without ReDoS or syntax errors. The round-trip test pins this guarantee.
+
+## Pinned surprising contracts
+1. `DOUBLE_FEATURE_PATTERN` is **non-greedy** — `A + B + C` returns `A`, not `A + B`.
+2. `FRANCHISE_PATTERN` is **start-anchored** — titles where the franchise word appears mid-string don't match.
+3. `escapeRegex` does NOT escape `-` or `/` (not in the metacharacter class).
+4. `PRESENTS_PATTERN` requires both the `presents`/`present` keyword AND surrounding curly-or-straight quotes.
+
+## Impact
+- Functional: none. Pure test addition.
+- Coverage: lifts a 238-line patterns module to test coverage on every exported regex pattern + the escape helper.
+- Future-proofing: pins 4 non-obvious behaviours that callers implicitly rely on.
+
+## Verification
+`npx vitest run src/lib/title-extraction/patterns.test.ts` — 27 passed, 0 failed, 728ms.
+
+## Changelog deferral note
+Per the pattern in #523-#528, this PR omits the `RECENT_CHANGES.md` top-of-file entry to avoid rebase cascade. Batch catchup PR planned for session end.

--- a/src/lib/title-extraction/patterns.test.ts
+++ b/src/lib/title-extraction/patterns.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  DOUBLE_FEATURE_PATTERN,
+  FRANCHISE_PATTERN,
+  PRESENTS_PATTERN,
+  SINGALONG_PATTERN,
+  escapeRegex,
+} from "./patterns";
+
+describe("PRESENTS_PATTERN", () => {
+  it("matches 'X presents \"Title\"' and captures the title", () => {
+    const match = `Funeral Parade presents "Saint Maud"`.match(PRESENTS_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Saint Maud");
+  });
+
+  it("matches the verb 'present' (no s) as well", () => {
+    const match = `Studio Lab present "Citizen Kane"`.match(PRESENTS_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Citizen Kane");
+  });
+
+  it("matches smart-quote U+201C", () => {
+    const match = `Reclaim presents “Mad Max”`.match(PRESENTS_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Mad Max");
+  });
+
+  it("does NOT match titles without explicit 'presents' keyword", () => {
+    expect(`Funeral Parade "Saint Maud"`.match(PRESENTS_PATTERN)).toBeNull();
+  });
+
+  it("does NOT match titles without surrounding quotes", () => {
+    expect(`Funeral Parade presents Saint Maud`.match(PRESENTS_PATTERN)).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(`FUNERAL PARADE PRESENTS "saint maud"`.match(PRESENTS_PATTERN)).not.toBeNull();
+  });
+});
+
+describe("SINGALONG_PATTERN", () => {
+  it("matches 'Sing-A-Long-A Title'", () => {
+    const match = "Sing-A-Long-A Mamma Mia".match(SINGALONG_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Mamma Mia");
+  });
+
+  it("matches 'Sing-A-Long Title' (no trailing A)", () => {
+    const match = "Sing-A-Long Frozen".match(SINGALONG_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Frozen");
+  });
+
+  it("matches 'SingALongA Title' (no hyphens)", () => {
+    const match = "SingALongA Mamma Mia".match(SINGALONG_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Mamma Mia");
+  });
+
+  it("is case-insensitive", () => {
+    expect("SING-A-LONG-A MAMMA MIA".match(SINGALONG_PATTERN)).not.toBeNull();
+  });
+
+  it("does NOT match a plain title without the prefix", () => {
+    expect("Mamma Mia".match(SINGALONG_PATTERN)).toBeNull();
+  });
+});
+
+describe("DOUBLE_FEATURE_PATTERN", () => {
+  it("matches 'A + B' and captures the first film", () => {
+    const match = "Pulp Fiction + Reservoir Dogs".match(DOUBLE_FEATURE_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Pulp Fiction");
+  });
+
+  it("non-greedy capture: returns first film, not the entire LHS up to last +", () => {
+    // Pattern uses (.+?) — non-greedy — so for triple features the first match
+    // wins. Documenting via test.
+    const match = "A + B + C".match(DOUBLE_FEATURE_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("A");
+  });
+
+  it("does NOT match strings without ' + ' separator", () => {
+    expect("Pulp Fiction".match(DOUBLE_FEATURE_PATTERN)).toBeNull();
+  });
+
+  it("matches when whitespace around + is missing", () => {
+    // Pattern uses \s* so `+` without spaces still matches.
+    const match = "Pulp Fiction+Reservoir Dogs".match(DOUBLE_FEATURE_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("Pulp Fiction");
+  });
+});
+
+describe("FRANCHISE_PATTERN", () => {
+  it("matches 'Star Wars'", () => {
+    expect(FRANCHISE_PATTERN.test("Star Wars: A New Hope")).toBe(true);
+  });
+
+  it("matches 'Harry'", () => {
+    expect(FRANCHISE_PATTERN.test("Harry Potter and the Goblet of Fire")).toBe(
+      true,
+    );
+  });
+
+  it("matches 'Lord'", () => {
+    expect(FRANCHISE_PATTERN.test("Lord of the Rings: The Two Towers")).toBe(
+      true,
+    );
+  });
+
+  it("matches 'Indiana'", () => {
+    expect(FRANCHISE_PATTERN.test("Indiana Jones and the Last Crusade")).toBe(
+      true,
+    );
+  });
+
+  it("matches 'Spider' (case-insensitive)", () => {
+    expect(FRANCHISE_PATTERN.test("SPIDER-MAN: Across the Spider-Verse")).toBe(
+      true,
+    );
+  });
+
+  it("does NOT match arbitrary titles", () => {
+    expect(FRANCHISE_PATTERN.test("Vertigo")).toBe(false);
+    expect(FRANCHISE_PATTERN.test("Citizen Kane")).toBe(false);
+  });
+
+  it("matches at start-of-string only (anchored)", () => {
+    // Pattern starts with ^ — `The Star Wars Story` should NOT match.
+    expect(FRANCHISE_PATTERN.test("The Star Wars Story")).toBe(false);
+  });
+});
+
+describe("escapeRegex", () => {
+  it("escapes regex metacharacters", () => {
+    expect(escapeRegex("a.b")).toBe("a\\.b");
+    expect(escapeRegex("a*b")).toBe("a\\*b");
+    expect(escapeRegex("a+b")).toBe("a\\+b");
+    expect(escapeRegex("a?b")).toBe("a\\?b");
+    expect(escapeRegex("(a)")).toBe("\\(a\\)");
+    expect(escapeRegex("[a]")).toBe("\\[a\\]");
+    expect(escapeRegex("{a}")).toBe("\\{a\\}");
+    expect(escapeRegex("a^b")).toBe("a\\^b");
+    expect(escapeRegex("a$b")).toBe("a\\$b");
+    expect(escapeRegex("a|b")).toBe("a\\|b");
+    expect(escapeRegex("a\\b")).toBe("a\\\\b");
+  });
+
+  it("leaves plain alphanumeric strings unchanged", () => {
+    expect(escapeRegex("abc123")).toBe("abc123");
+  });
+
+  it("produces a string usable in a new RegExp()", () => {
+    // Real-world contract: the escaped string can be embedded in a regex.
+    const userInput = "The Lord of the Rings (2001)";
+    const escaped = escapeRegex(userInput);
+    // Should match the original input as a literal substring.
+    expect(new RegExp(escaped).test(userInput)).toBe(true);
+    // And should NOT explode at construction time.
+    expect(() => new RegExp(escaped)).not.toThrow();
+  });
+
+  it("handles empty string", () => {
+    expect(escapeRegex("")).toBe("");
+  });
+
+  it("does NOT escape characters that are not metacharacters", () => {
+    // Per the regex used (`[.*+?^${}()|[\]\\]`), a forward slash and hyphen
+    // are not escaped. Pin this so callers know.
+    expect(escapeRegex("a-b")).toBe("a-b");
+    expect(escapeRegex("a/b")).toBe("a/b");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/title-extraction/patterns.test.ts` with 27 vitest cases covering 4 regex patterns + `escapeRegex` helper.
- No behaviour change.

## Why
The 4 patterns drive `extractFilmTitleSync` — a regression silently changes which films get extracted vs left as-is, with downstream TMDB matching effects.

`escapeRegex` is security-relevant: it ensures user-supplied title fragments can be safely embedded in dynamic regexes. The round-trip test (`new RegExp(escapeRegex(input)).test(input)` → `true`) pins this guarantee.

## Pinned surprising contracts
1. `DOUBLE_FEATURE_PATTERN` is **non-greedy** — `A + B + C` returns `A`, not `A + B`
2. `FRANCHISE_PATTERN` is **start-anchored** — `The Star Wars Story` does NOT match
3. `escapeRegex` does NOT escape `-` or `/`
4. `PRESENTS_PATTERN` requires both `presents`/`present` keyword AND surrounding quotes

## Coverage breakdown
- PRESENTS_PATTERN: 6 cases
- SINGALONG_PATTERN: 5 cases (all 3 hyphen variants)
- DOUBLE_FEATURE_PATTERN: 4 cases (incl. non-greedy capture)
- FRANCHISE_PATTERN: 7 cases (5 franchises + anchor + negative)
- escapeRegex: 5 cases (each metachar + empty + round-trip property)

## Notes on review process & changelog deferral
- 2 files (test + dedicated changelog archive). Under 3-file Review Gate.
- Per the pattern in #523-#528, deferred `RECENT_CHANGES.md` update.

## Test plan
- [x] `npx vitest run src/lib/title-extraction/patterns.test.ts` → 27/27 passed (728ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)