### PR TITLE
chore: RECENT_CHANGES catch-up + trim (session deferred-changelog payoff)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,57 @@
-## 2026-05-18: Fix "the the" typo in data-quality warning message
-**PR**: TBD | **Files**: `src/lib/data-quality/index.ts`
+## 2026-05-18: Catch-up batch — RECENT_CHANGES entries for session test-coverage PRs
+**PR**: TBD | **Files**: `RECENT_CHANGES.md`
+- Adds canonical RECENT_CHANGES entries for the 6 test-coverage PRs (#521, #523, #524, #525, #526, #528) shipped earlier in the session that deliberately omitted the top-of-file entry to avoid the rebase-conflict cascade caused by multiple open PRs editing line 1.
+- Also corrects the `**PR**: TBD` on the "the the" typo entry to `**PR**: #519`.
+- Trims older entries to maintain the CLAUDE.md "~20 most recent" guidance.
+
+---
+
+## 2026-05-18: Add unit tests for src/lib/title-patterns.ts (38 cases) (#528)
+**PR**: #528 | **Files**: `src/lib/title-patterns.test.ts` (new)
+- 38 vitest cases covering all 3 exported functions: `isLikelyCleanTitle`, `cleanBasicCruft`, `decodeHtmlEntities`.
+- Pins the canonical title-cleanup regex layer used by both AI and regex-based extractors. Key contracts: short-prefix-before-colon heuristic + FRANCHISE allowlist; suffix strip families (Q&A, Director's Cut, Anniversary, BBFC rating); the "only 5 entities decoded" decoder contract (`&nbsp;` and `&eacute;` NOT decoded).
+
+---
+
+## 2026-05-18: Add unit tests for src/lib/title-extraction/search-variants.ts (#526)
+**PR**: #526 | **Files**: `src/lib/title-extraction/search-variants.test.ts` (new)
+- 14 vitest cases for `generateSearchVariations` (TMDB title-matching variant generator).
+- Pins two surprising contracts: year-strip is **end-anchored**, and transforms do NOT chain (`"Vertigo (1958)..."` does not produce `"Vertigo"`).
+
+---
+
+## 2026-05-18: Add unit tests for src/lib/geo-utils.ts (#525)
+**PR**: #525 | **Files**: `src/lib/geo-utils.test.ts` (new)
+- 13 vitest cases for `isCinemaInArea` and `getCinemasInArea` (the map-area filter on the cinema map).
+- Pins the polygon **auto-close convention** — callers supply N vertices, the implementation auto-appends the first. A future "refactor" requiring closed polygons from callers would now fail this test.
+
+---
+
+## 2026-05-18: Add unit tests for src/lib/external-urls.ts (#524)
+**PR**: #524 | **Files**: `src/lib/external-urls.test.ts` (new)
+- 18 vitest cases covering `getTmdbUrl`, `getImdbUrl`, and the non-trivial `generateLetterboxdUrl`.
+- Pins all 5 apostrophe-variant strips (`'`, `'`, `‘`, `´`, `` ` ``) — a single stray edit to the regex chain would silently 404 thousands of Letterboxd film links.
+
+---
+
+## 2026-05-18: Add unit tests for src/lib/admin-emails.ts (security-critical) (#523)
+**PR**: #523 | **Files**: `src/lib/admin-emails.test.ts` (new)
+- 18 vitest cases covering `getAdminEmailAllowlist` and `isAdminEmail`.
+- The most load-bearing test is **"substrings do NOT match"** — pins `Array.includes(email)` semantics against the easy-to-introduce bug of swapping to `String.includes` (`admin@example.com` must NOT match `secretadmin@example.com`).
+- Also covers env-var override semantics: env replaces default entirely (default admin REJECTED when env is set).
+
+---
+
+## 2026-05-18: Add unit tests for src/lib/levenshtein.ts (#521)
+**PR**: #521 | **Files**: `src/lib/levenshtein.test.ts` (new)
+- 17 vitest cases for both `levenshteinDistance` and `levenshteinSimilarity`.
+- Load-bearing for TMDB matching (`src/lib/tmdb/match.ts`), season linking, and fallback enrichment confidence — a regression silently degrades film-matching quality across the enrichment + scraping stack.
+- Pins UTF-16 surrogate-pair behaviour (🎬 counts as 2 code units) and the `maxLen=0` short-circuit in similarity.
+
+---
+
+## 2026-05-18: Fix "the the" typo in data-quality warning message (#519)
+**PR**: #519 | **Files**: `src/lib/data-quality/index.ts`
 - Single-character comment-only fix in the learnings-file-not-found warning. No code logic affected.
 - Surfaced while reviewing the file for the gitignore-Finder-duplicates PR; the canonical `index.ts` had a leftover duplicated "the" from the earlier Trigger.dev → cloud-orchestrator rename.
 
@@ -106,111 +158,5 @@
 - Wired into both pre-flight and post-run health phases of `/scrape`.
 - Bonus: updated `curzon-camden`/`curzon-richmond`/`curzon-wimbledon` venue comments to note 2026-05-15 web search shows live public listings — left `active: false` pending verification with a prod-side JWT probe (API still 401s locally without Cloudflare bypass).
 
----
-
-## 2026-05-17: /goal conditions #8 & #9 — flaky detector + BST sentinel (Phase 1 of scraper-perfection plan)
-**PR**: TBD | **Files**: `src/lib/scrape-quarantine.ts`, `src/lib/scrape-quarantine.test.ts` (new), `src/scripts/run-scrape-and-enrich.ts`, `scripts/goal-check-flaky-cinemas.ts` (new), `scripts/goal-check-bst-sentinel.ts` (new), `scripts/goal-status.ts`, `tasks/goal.md`, `changelogs/2026-05-17-goal-ws-a-flaky-and-bst.md`
-- Phase 1 of the "make scrapers perfect" plan (WS-A: measurement substrate). Two new end conditions added to `tasks/goal.md`, taking the goal from 7 conditions to 9.
-- **Condition #8 — No flaky-critical cinemas**: resurrected `detectFlakyCinemas` (a ratio-based detector that catches alternating-failure cinemas like BFI IMAX in May 2026 — 14/21 success+0 runs but never two consecutive, so the silent-breaker detector missed it). New unit test covers 9 fixture scenarios including the BFI IMAX ground truth, Close-Up failed-runs pattern, threshold-bumping logic, and lastGoodRunAt accuracy. Wired into `/scrape` pre-flight so flakies are surfaced before a 30-60min run wastes time on broken cinemas.
-- **Condition #9 — Zero BST-pattern screenings**: standing guardrail for the recurring BST off-by-one bug class that has bitten Curzon, Everyman, and Picturehouse in the last 4 weeks. Queries the 02:00-09:59 UK-local window for upcoming screenings. The 00:00-01:59 zone is deliberately excluded because Everyman, PCC, and Genesis legitimately programme midnight cult screenings (Mulholland Drive, Obsession, Hokum at Everyman Broadgate were flagged during smoke-testing — false positives the wider window would have produced).
-- Smoke run confirms both conditions PASS on current data — 2 cinemas at warn-level flakiness (BFI IMAX, Close-Up) but 0 critical; 0 BST offenders in the tightened 02:00+ window.
-
----
-
-## 2026-05-17: DQS verifier repair — Barbican selector, Rio fallback, Picturehouse API
-**PR**: TBD | **Files**: `scripts/data-check.ts`, `tasks/goal.md`, `changelogs/2026-05-17-dqs-verifier-repair.md`
-- Diagnostic probe (now deleted) ran each `cinemaVerifications` verifier against one current production screening per cinema. Three verifiers were broken in different ways:
-  - **Barbican** — selector `a[href*="/whats-on/"]` was matching site-wide nav menu items (`"Cinema"`, `"Theatre & dance"`) instead of film cards. Switched to body-text contains-prefix search (the Genesis/Rich Mix pattern that already works). Probed `"The Devil Wears Prada 2"` against the Barbican listing — body contains the title, body-text fallback matches.
-  - **Rio** — the `var Events = {...}` regex no longer matches the embedded JSON. Verifier was returning `fetch_error` on every call, which excluded Rio from the denominator but added zero confirmed. Added a body-text fallback so the page-fetched-but-JSON-missing case still produces a `confirmed` when the title is present.
-  - **Picturehouse** — `https://www.picturehouses.com/cinema/<slug>` URL 301-redirects to the homepage, so the verifier was scanning the homepage for film titles. Switched to the same POST API the existing scraper uses (`/api/scheduled-movies-ajax` with `cinema_id` form field, mapped via `PICTUREHOUSE_VENUES.chainVenueId`). Smoke-tested against Clapham — API returned 200 with 24 movie titles.
-- ICA, Genesis, Rich Mix were already healthy. Curzon + Everyman correctly return `fetch_error` when their fetches fail (Cloudflare / wrong URL) — excluded from denominator, not dragging the rate.
-- After the next two `/data-check` runs, condition #7 should transition from `deferred-passing` back to genuinely-passing on the recorded `compositeScore` (the verification signal should rise above the 0.1 threshold).
-
----
-
-## 2026-05-16: /goal condition #7 — defer when verification signal is structurally zero
-**PR**: TBD | **Files**: `scripts/goal-check-dqs.ts`, `tasks/goal.md`, `changelogs/2026-05-16-goal-condition-7-dqs-verification-deferral.md`
-- Full `/goal status` (no `--fast`) ran today and revealed condition #7 (DQS floor ≥ 85) failing at 76.62/77.42. Drilling into the composite: every dimension above 85 except `verificationPassRate` at 0. Verification is computed from `cinemaVerifications` (static HTML verifiers for Rio, ICA, Barbican, Close-Up, Genesis, Rich Mix in `scripts/data-check.ts`) — they're all returning non-`confirmed` status, likely from cinema booking-page schema drift.
-- `goal-check-dqs.ts` now mirrors the condition #6 deferral pattern: when verification is structurally broken (≤ 0.1 for two consecutive runs), the composite is recomputed excluding the 15% verification weight (remaining weights proportionally rescaled). If the adjusted composite clears 85 on both runs, the condition is `pass: true, deferred: true`. The `anyDeferred` rollup gate (shipped in PR #502) prevents the goal from being falsely declared achieved while #7 is deferred. The fix for the underlying verifiers is queued as a sub-task in `tasks/goal.md`.
-- Adjusted composites for the current state: latest 90.15, previous 91.1 — both well above the 85 floor. Confirms the non-verification dimensions are healthy.
-
----
-
-## 2026-05-15: /goal condition #6 — defer below 500-event traffic floor
-**PR**: TBD | **Files**: `scripts/goal-check-posthog-funnel.ts`, `scripts/goal-status.ts`, `tasks/goal.md`, `changelogs/2026-05-15-goal-condition-6-traffic-floor.md`
-- Empirical probe found pictures.london emits 52 `booking_link_clicked` events / 30d across 56 active cinemas, all properly tagged with `cinema_id`. The "31 zero-click cinemas" surfaced in the first /goal run is a traffic-distribution artefact, not a tracking bug or product defect.
-- Condition #6 now defers when total monthly clicks < 500 (returns `pass: true, deferred: true`). Above the floor, the existing per-cinema check engages. This stops /goal from endlessly targeting an impossible-at-this-traffic condition while the goal file pins the upgrade path (Stagehand-based booking-URL verifier as a sub-task).
-- Orchestrator status table now shows `ℹ️ — deferred` instead of `✅` for deferred conditions so users don't misread the rollup as proof the underlying thing works. The headline verdict ("🎯 ALL CONDITIONS PASS — goal is ACHIEVED") is now gated on `!anyDeferred` so the goal can't be falsely declared achieved while a condition is in deferred state.
-- Regression guard: persists prior `totalClicks` to `.claude/goal-posthog-funnel-last.json`. If the current window's total drops below 50% of a prior baseline that was above the floor, the condition fails loudly with a "volume regression" reason rather than silently flipping to deferred-pass. Catches analytics breakage (PostHog key rotated, frontend tracker removed, ad-blocker surge) instead of masking it.
-
----
-
-## 2026-05-15: Add Cinema Museum scraper via iCal feed
-**PR**: TBD | **Files**: `src/scrapers/cinemas/cinema-museum.ts`, `src/scrapers/cinemas/cinema-museum.test.ts`, `src/scrapers/registry.ts`, `src/config/cinema-registry.ts`
-- New scraper for **The Cinema Museum** (Kennington, SE11) — independent venue in the former Lambeth workhouse, programmes 35mm + silent + Kennington Bioscope evenings. Priority 2 in the 2026-05-15 London coverage audit. Active cinema count 57 → 58.
-- Uses the WordPress Events Calendar plugin's public **iCal feed** (`/schedule/?ical=1`) rather than HTML scraping — single request, structured data (DTSTART, SUMMARY, URL, UID, CATEGORIES), no DOM parsing.
-- Minimal in-tree iCal parser (`parseVEvents`) — RFC 5545 line folding + TEXT escapes (`\,`, `\;`, `\\`, `\n`). No new npm dependency.
-- Filters out `Tours` and `Bazaars` categories (museum tours, bric-a-brac sales) — keeps film screenings, talks, Kennington Bioscope, and the 35mm classics series.
-- **WAF workaround**: cinemamuseum.org.uk's Pressidium host returns 403 for browser-like User-Agents on the iCal endpoint but allows generic calendar-client UAs. The scraper overrides both `fetchPages` and `healthCheck` with a `pictures-cinema-museum-scraper/1.0` UA. Documented inline.
-- 11 unit tests (3 parser, 8 scraper) against a 3-event iCal fixture covering filtering, BST→UTC conversion, UID prefixing, URL preservation, escape unescape, line folding, empty feed.
-- Live verification: 23 valid screenings in ~725 ms; programme through May/June 2026.
-
----
-
-## 2026-05-15: Add Bertha DocHouse scraper — first new London independent
-**PR**: TBD | **Files**: `src/scrapers/cinemas/bertha-dochouse.ts`, `src/scrapers/cinemas/bertha-dochouse.test.ts`, `src/scrapers/registry.ts`, `src/config/cinema-registry.ts`
-- New Cheerio-based scraper for **Bertha DocHouse** (dochouse.org) — the UK's only year-round documentary cinema, inside Curzon Bloomsbury but programmed independently. Identified as Priority 1 in the 2026-05-15 London coverage audit.
-- 2-step list-then-detail pattern: `/whats-on/` paginates events; each `/event/<slug>/` carries screening times + Curzon `BLO1-XXXXXX` ticket IDs (used as `sourceId`).
-- 9 unit tests covering title, time parsing, sourceId derivation, non-Bertha ticket filtering, defensive empty handling, and the today-edge-case where `parseScreeningDate` would otherwise +1 year a same-day screening.
-- Live verification: returns 43 valid screenings across 21 events in ~20 s; covers the programme through early June.
-
----
-
-## 2026-05-15: /goal command — terminal goal-driven loop with measurable end conditions
-**PR**: TBD | **Files**: `tasks/goal.md`, `scripts/goal-check-{coverage,silent-breakers,booking-links,lighthouse,axe,posthog-funnel,dqs}.ts`, `scripts/goal-status.ts`, `changelogs/2026-05-15-goal-command.md`
-- New `/goal` slash command (local in `.claude/commands/`): unlike `/kaizen` and `/posthog-optimize` (perpetual), this one declares an explicit finish line and exits when crossed. Reads `tasks/goal.md`, runs all measurement scripts, picks the highest-leverage failing condition, fixes one sub-task per invocation, holds merge behind the existing `ship it` deployment gate.
-- Goal: "Pictures.london v1 — complete, fast, accessible, trustworthy". Seven end conditions: London independents covered, no silent breakers, zero broken booking links, Lighthouse mobile ≥90, axe-core clean, PostHog `booking_click` proof-of-life per cinema, DQS floor ≥85 across two consecutive `/data-check` runs.
-- Orchestrator (`scripts/goal-status.ts`) runs every check, prints status table, writes `.claude/goal-status.json` for the slash command to read. `--fast` skips lighthouse + axe for inner-loop iteration.
-- No new dependencies — lighthouse and axe-core invoked via `npx` on demand per CLAUDE.md dep-rule.
-
----
-
-## 2026-05-15: /scrape follow-ups — is_repertory at write time + stale-cinema is_active filter
-**PR**: TBD | **Files**: `src/scripts/cleanup-upcoming-films.ts`, `src/lib/scrape-quarantine.ts`
-- Closes the cycle-N+1 patrol dependency for `is_repertory`: the TMDB-match UPDATE path in `cleanup-upcoming-films.ts` now sets `isRepertory: isRepertoryFilm(release_date)` alongside `year`. The patrol caught 5 misflagged films in 5 consecutive cycles before this; now repertory films are tagged at write time using the same helper `film-matching.ts` already uses.
-- `detectStaleCinemas` now filters `WHERE c.is_active = true`, excluding 5 zombie cinemas (curzon-camden / curzon-richmond / curzon-wimbledon / everyman-walthamstow / nickel) that would otherwise appear as "never scraped" in every `/scrape` post-run report indefinitely.
-
----
-
-## 2026-05-15: Push recurring data-check fixes into /scrape (prefix/suffix sync + foreign-bracket + write guards + stale surfacing)
-**PR**: TBD | **Files**: `src/scrapers/utils/film-title-cleaner.ts`, `src/scrapers/utils/film-write-guards.ts` (new), `src/scrapers/pipeline.ts`, `src/scrapers/utils/film-matching.ts`, `src/scripts/cleanup-upcoming-films.ts`, `src/lib/scrape-quarantine.ts`, `src/scripts/run-scrape-and-enrich.ts`, plus tests
-- **Patrol-learned prefixes/suffixes feed the scraper**: `film-title-cleaner` now loads `.claude/data-check-learnings.json` at module init and appends `prefixesToStrip` (79) + `suffixesToStrip` (25) to its existing hand-curated lists. Gracefully degrades to empty arrays when the file isn't present (CI / fresh checkouts). Same patterns the patrol fixes after-the-fact now apply at scrape time.
-- **Foreign-title-bracket normalizer**: new `extractEnglishFromBracket` detects `Original (English)` titles (Garden Cinema, Cine Lumière, BFI repertory) and routes the LOOKUP through the English form for TMDB matching while keeping the original on the films row for display. Wired into `pipeline.ts::getOrCreateFilm`.
-- **Write-site guards** (`film-write-guards.ts`): `sanitizeYear` rejects `0` / `Number("") = 0` / pre-1900 / future-noise values. `sanitizeDirectors` refuses arrays containing `% Starring %` and warns. Applied at `film-matching.ts:212` (TMDB-matched insert) and `cleanup-upcoming-films.ts:257` (enrichment update).
-- **Known non-film titles**: new `getKnownNonFilmType` / `isKnownNonFilmTitle` helpers expose `learnings.json::knownNonFilmTitles` (34 entries) for callers to set content_type before film resolution (full wiring deferred to follow-up).
-- **/scrape report observability**: post-run summary now lists cinemas with no scrape in the last 24h + recent patrol DQS stats (count, avg, min) from learnings.json. Both read-only, fail open if the file isn't present.
-
----
-
-## 2026-05-15: Dedup screenings + prevent recurrence in /scrape (BST shifts, film-id flips, BFI cluster bug)
-**PR**: TBD | **Files**: `src/scrapers/utils/screening-classification.ts`, `src/scrapers/pipeline.ts`, `src/scrapers/bfi-pdf/programme-changes-parser.ts`, `src/db/migrations/0011_screenings_cinema_source_unique.sql`, plus cleanup scripts + tests
-- Removed **1,065 bogus screening rows** in three classes:
-  - **710 (cinema_id, source_id) duplicates** in upcoming screenings — same source resolved to different films (e.g. Hard Boiled @ The Nickel, 135 same-datetime) OR BST off-by-one regressions producing datetime+1h dupes (e.g. Wake in Fright @ The Gate, Shrek @ Everyman Maida Vale — 409 of these). For same-datetime: latest scrape wins. For BST-shift: earlier datetime always wins (the +1h variant is always the bug).
-  - **254 (cinema_id, source_id) duplicates** across past dates (so the unique-index migration could be applied).
-  - **351 BFI Southbank "many films at same datetime" rows** — the programme-changes-parser's `getFollowingText` was grabbing the full parent paragraph's text, so 6+ films sharing one `<p>` each got matched against every sibling's screening times.
-- **Pipeline prevention**: `processScreenings` now uses `(cinema_id, source_id)` as conflict target when sourceId is set, so a re-scrape with a corrected datetime UPDATEs the existing row in place. `checkForDuplicate` Layer 0 dropped the datetime filter to match.
-- **DB enforcement**: new partial unique index `idx_screenings_cinema_source ON screenings (cinema_id, source_id) WHERE source_id IS NOT NULL` makes the invariant non-negotiable.
-- **BFI parser fix**: `getFollowingText` now walks DOM siblings and stops at the next `<b>`/`<strong>`, with a fallback that slices parent text correctly when only text nodes follow. Regression test added in `programme-changes-parser.test.ts`.
-
----
-
-## 2026-05-14: Multi-day rolling calendar — always show upcoming films
-**PR**: TBD | **Files**: `frontend/src/lib/calendar-filter.ts`, `frontend/src/routes/+page.svelte`, `frontend/src/lib/components/calendar/DayMasthead.svelte`, `frontend/test-all.spec.ts`, `frontend/tests/mobile.spec.ts`
-- Homepage no longer goes blank late at night when today's screenings are all past. The default view now shows a rolling window: today + as many upcoming days as needed to fill at least ~24 films (capped at 7 days).
-- Each day is its own `<section>` with a day header ("Today · Thursday, the fourteenth", "Tomorrow · Friday, the fifteenth", or just "Saturday, the sixteenth" for later days). Films within each day stay sorted by Letterboxd rating (the existing `compareFilmsByCalendarPriority` ordering), but the sort **resets per day**.
-- `buildFilmMap` default range changed from `[today, today]` to `[today, ∞)`. The DayMasthead day-strip buttons now anchor the window from the clicked day onwards (one-sided range) instead of collapsing to a single day. Date-picker / filter-sidebar single-day presets still set both ends.
-- Desktop's old `hybridFilms` flat-grid is replaced with day-grouped sections. Mobile's global `.mobile-date-label` is replaced with per-section headers.
-
----
 
 <!-- Older entries archived to /changelogs/. Per CLAUDE.md: keep only ~20 most recent. -->

--- a/changelogs/2026-05-18-recent-changes-catchup.md
+++ b/changelogs/2026-05-18-recent-changes-catchup.md
@@ -1,0 +1,35 @@
+# RECENT_CHANGES catch-up — entries for session test-coverage PRs
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `RECENT_CHANGES.md` — adds 6 new entries (1 per deferred-changelog PR shipped this session: #521, #523, #524, #525, #526, #528).
+- `RECENT_CHANGES.md` — corrects the `**PR**: TBD` on the typo-fix entry to `**PR**: #519`.
+- `RECENT_CHANGES.md` — trims older entries from the bottom to maintain the CLAUDE.md "~20 most recent" guideline (was at 24, would have been 31 after the catch-up additions; trimmed back to 20).
+
+## Context
+Over the course of this session, 6 test-coverage PRs (#521, #523, #524, #525, #526, #528) deliberately omitted their `RECENT_CHANGES.md` top-of-file entry to avoid a rebase-conflict cascade. Each entry would conflict with every other open PR also adding to line 1, and each merge would invalidate the others. The pattern adopted was: ship with the dedicated `changelogs/YYYY-MM-DD-*.md` archive file only, and follow up with a batch catch-up PR at session end. This is that catch-up PR.
+
+The dedicated `changelogs/` archive files for each PR are already on `main` — this PR is the visible "summary at the top of the file" half of the project's two-location changelog convention.
+
+## Why this workflow
+The two-location convention (`RECENT_CHANGES.md` + `changelogs/YYYY-MM-DD-*.md`) is great for sequential single-PR sessions but breaks down at >2 concurrent PRs because of guaranteed top-of-file conflicts. A future tooling improvement could mitigate this:
+
+- **Option A**: a `pnpm changelog:bake` script that scans `changelogs/*.md` for entries with `PR: TBD` and pre-pends a one-line summary to `RECENT_CHANGES.md`, run by the merge bot.
+- **Option B**: change `RECENT_CHANGES.md` format to an auto-generated TOC of `changelogs/*.md` files, generated on merge.
+
+Worth considering for a follow-up. The current PR just unblocks the immediate session.
+
+## Impact
+- Documentation: brings `RECENT_CHANGES.md` to a current, consistent state.
+- Convention compliance: each PR shipped in this session now has both required changelog touchpoints (archive + summary line).
+- No code changes.
+
+## Verification
+- `grep -c "^## " RECENT_CHANGES.md` returns `20` (target per CLAUDE.md).
+- Top 6 new entries reference the 6 deferred PRs correctly.
+- Typo-fix entry now shows `**PR**: #519`.
+
+## Trimmed entries
+The 11 entries removed from the bottom were dated 2026-05-14 through 2026-05-17 and covered: multi-day rolling calendar, screening de-dup, /scrape recurring-fix pushes, /scrape is_repertory follow-ups, /goal command, Bertha DocHouse scraper, Cinema Museum scraper, /goal conditions #6/#7/#8/#9, DQS verifier repair. The full text of each remains in `changelogs/*.md` per the trim convention.


### PR DESCRIPTION
## Summary
- Adds 6 deferred `RECENT_CHANGES.md` top-of-file entries for #521, #523, #524, #525, #526, #528 — session test-coverage PRs that intentionally omitted the edit to avoid a multi-PR rebase cascade.
- Corrects the `**PR**: TBD` on the typo-fix entry to `**PR**: #519`.
- Trims older entries (31 → 20) per the CLAUDE.md "~20 most recent" guideline. All trimmed entries remain in `changelogs/*.md` archive files.

## Why deferred-changelog was used
The two-location changelog convention is great for sequential single-PR sessions but breaks down at 2+ concurrent PRs because every PR edits line 1 of `RECENT_CHANGES.md`. Each merge invalidates the others, forcing infinite rebases. The pattern adopted halfway through this session was: ship with only the dedicated `changelogs/*.md` archive file, defer the top-of-file edit to a single batch catch-up PR. This is that PR.

## Proposed future tooling improvement
Documented in the changelog archive: a `changelog:bake` script that auto-pre-pends a one-line summary to `RECENT_CHANGES.md` by scanning `changelogs/*.md` for `PR: TBD` entries. Would eliminate the conflict cascade structurally.

## Test plan
- [x] `grep -c "^## " RECENT_CHANGES.md` → 20 (target per CLAUDE.md)
- [x] Top 6 new entries reference the 6 deferred PRs correctly
- [x] Typo-fix entry now shows `**PR**: #519`

🤖 Generated with [Claude Code](https://claude.com/claude-code)