### PR TITLE
refactor(lib): collapse identical if/else branches in batchExtractTitles

### DIFF
--- a/changelogs/2026-05-18-title-extraction-dead-branch.md
+++ b/changelogs/2026-05-18-title-extraction-dead-branch.md
@@ -1,0 +1,40 @@
+# Remove dead if/else branch in batchExtractTitles
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/title-extraction/index.ts` — collapse a redundant `if (isLikelyCleanTitle(title)) { … } else { … }` where both branches did **the exact same thing**. Also removes the now-unused `isLikelyCleanTitle` import.
+
+## Before
+```ts
+for (const title of uniqueTitles) {
+  if (isLikelyCleanTitle(title)) {
+    results.set(title, await extractFilmTitle(title));
+  } else {
+    results.set(title, await extractFilmTitle(title));
+  }
+}
+```
+
+## After
+```ts
+for (const title of uniqueTitles) {
+  results.set(title, await extractFilmTitle(title));
+}
+```
+
+## Context
+The comment above the function explains the history: "previous implementation sequenced 'ambiguous' titles through an LLM with rate limiting; that's gone now, so this is just a deduped fan-out." The if/else stayed behind as fossilised scaffolding after the LLM-extraction path was removed. Both branches resolved to identical code; the `isLikelyCleanTitle` import was no longer load-bearing.
+
+## Impact
+- Functional: none. Both branches were identical before; the simplification preserves behaviour exactly.
+- Readability: one fewer fake decision point for maintainers to evaluate.
+- Lint: removes an unused import (would otherwise have surfaced on the next `noUnusedLocals` audit).
+
+## Verification
+- `npx vitest run src/lib/title-extraction` — 108/108 passed in 742ms.
+- The pre-existing tsc errors in `.next/types/**` are unrelated (stale Next.js build artefacts referencing deleted `.js` route files; not caused by this change).
+
+## Changelog deferral note
+Per the pattern in #523-#530, this PR omits the `RECENT_CHANGES.md` top-of-file entry. Will be batched in the next periodic catch-up.

--- a/src/lib/title-extraction/index.ts
+++ b/src/lib/title-extraction/index.ts
@@ -15,7 +15,7 @@ export { extractFilmTitleSync, type PatternExtractionResult } from "./pattern-ex
 export { extractFilmTitleAI, hasWordOverlap, type AIExtractionResult } from "./ai-extractor";
 export { generateSearchVariations } from "./search-variants";
 
-import { extractFilmTitleAI, isLikelyCleanTitle, type AIExtractionResult } from "./ai-extractor";
+import { extractFilmTitleAI, type AIExtractionResult } from "./ai-extractor";
 
 /**
  * Async pattern-based title extraction. Wraps the sync extractor for callers
@@ -50,11 +50,7 @@ export async function batchExtractTitles(
   const uniqueTitles = [...new Set(rawTitles)];
 
   for (const title of uniqueTitles) {
-    if (isLikelyCleanTitle(title)) {
-      results.set(title, await extractFilmTitle(title));
-    } else {
-      results.set(title, await extractFilmTitle(title));
-    }
+    results.set(title, await extractFilmTitle(title));
   }
 
   return results;


### PR DESCRIPTION
## Summary
- `src/lib/title-extraction/index.ts`: collapses an `if/else` where both branches did **the exact same thing**. Removes the now-unused `isLikelyCleanTitle` import.
- Behaviour-preserving. The comment above the function already explains the history: the LLM-routing path was removed earlier; the if/else scaffolding stayed behind.

## Before / after
Before:
```ts
if (isLikelyCleanTitle(title)) {
  results.set(title, await extractFilmTitle(title));
} else {
  results.set(title, await extractFilmTitle(title));
}
```
After:
```ts
results.set(title, await extractFilmTitle(title));
```

## Test plan
- [x] `npx vitest run src/lib/title-extraction` → 108/108 passed (742ms)

## Notes
2 files (source + changelog archive). Below 3-file Review Gate. Deferred-changelog per #523-#530 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)