### PR TITLE
test(lib): add unit tests for cn (Tailwind class merger)

### DIFF
--- a/changelogs/2026-05-18-cn-tests.md
+++ b/changelogs/2026-05-18-cn-tests.md
@@ -1,0 +1,33 @@
+# Add unit tests for src/lib/cn.ts (Tailwind class merger)
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/cn.test.ts` (new) — 12 vitest cases covering the `cn` utility.
+
+## Why
+`cn` has 65+ frontend importers — every component composing Tailwind classes goes through it. The composition of `clsx` (for conditional flattening) + `tailwind-merge` (for last-wins conflict resolution) is the contract the entire UI layer relies on.
+
+## Coverage
+- Single string passthrough
+- Multi-string joining
+- Array flattening (clsx behaviour)
+- Falsy-value filtering (false, null, undefined, '', 0)
+- Conditional inclusion via short-circuit
+- Object syntax (`{ 'p-4': true, 'p-8': false }`)
+- **Tailwind conflict resolution** — last conflicting utility wins (`p-4` + `p-8` → `p-8`)
+- Non-conflicting utilities preserved
+- Empty argument / empty array → empty string
+- Nested array flattening
+- **The React `cn(base, className)` override pattern** — user-supplied `className` correctly overrides base utility conflicts via tailwind-merge
+
+## Impact
+- Functional: none. Pure test addition.
+- Coverage: pins the contract of a 13-line utility that 65+ components rely on.
+
+## Verification
+`npx vitest run src/lib/cn.test.ts` — 12 passed, 0 failed, 570ms.
+
+## Changelog deferral note
+Per #523-#530, omits the `RECENT_CHANGES.md` top-of-file entry. Batched next.

--- a/src/lib/cn.test.ts
+++ b/src/lib/cn.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "./cn";
+
+// `cn` is the Tailwind class-merger used by 65+ frontend imports. It composes
+// clsx (for conditional flattening) and tailwind-merge (for Tailwind-aware
+// last-wins resolution of conflicting utility classes). These tests pin the
+// composition behaviour — *not* the implementation details of clsx/tailwind-merge,
+// which have their own test suites.
+
+describe("cn", () => {
+  it("returns the same class when given a single string", () => {
+    expect(cn("p-4")).toBe("p-4");
+  });
+
+  it("joins multiple class strings with spaces", () => {
+    expect(cn("p-4", "text-lg")).toBe("p-4 text-lg");
+  });
+
+  it("flattens arrays via clsx", () => {
+    expect(cn(["p-4", "text-lg"])).toBe("p-4 text-lg");
+  });
+
+  it("filters out falsy values (false, null, undefined, empty string, 0)", () => {
+    expect(cn("p-4", false && "hidden", null, undefined, "", 0, "text-lg")).toBe(
+      "p-4 text-lg",
+    );
+  });
+
+  it("includes truthy conditional classes", () => {
+    const isActive = true;
+    expect(cn("p-4", isActive && "bg-accent-gold")).toBe("p-4 bg-accent-gold");
+  });
+
+  it("supports clsx object syntax", () => {
+    expect(cn({ "p-4": true, "p-8": false, "text-lg": true })).toBe(
+      "p-4 text-lg",
+    );
+  });
+
+  it("uses tailwind-merge to resolve conflicting utility classes (last wins)", () => {
+    // p-4 and p-8 are conflicting padding utilities. Tailwind-merge keeps p-8.
+    expect(cn("p-4", "p-8")).toBe("p-8");
+  });
+
+  it("resolves conflicting utilities across separator categories", () => {
+    // px-4 (horizontal padding) and px-8 (horizontal padding) → px-8 wins.
+    expect(cn("px-4 py-2", "px-8")).toBe("py-2 px-8");
+  });
+
+  it("does NOT collapse non-conflicting utilities", () => {
+    // p-4 and text-lg target different properties; both kept.
+    expect(cn("p-4", "text-lg")).toBe("p-4 text-lg");
+  });
+
+  it("returns an empty string for no arguments / empty array", () => {
+    expect(cn()).toBe("");
+    expect(cn([])).toBe("");
+  });
+
+  it("handles nested arrays (clsx flattens recursively)", () => {
+    expect(cn(["p-4", ["text-lg", ["font-bold"]]])).toBe(
+      "p-4 text-lg font-bold",
+    );
+  });
+
+  it("survives the common React 'className' append pattern", () => {
+    // Common pattern: cn("base classes", className) where className is
+    // user-supplied. Falsy fall-through is critical.
+    const userClassName: string | undefined = undefined;
+    expect(cn("p-4 text-base", userClassName)).toBe("p-4 text-base");
+
+    const userOverride = "p-8";
+    // User override wins via tailwind-merge.
+    expect(cn("p-4 text-base", userOverride)).toBe("text-base p-8");
+  });
+});


### PR DESCRIPTION
12 cases for cn — 65+ frontend importers rely on it. Pins clsx+tailwind-merge composition behaviour incl. p-4+p-8→p-8 conflict resolution and the React cn(base, className) override pattern. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)