### PR TITLE
test(lib): add unit tests for image-processor.isImageAccessible

### DIFF
--- a/changelogs/2026-05-18-image-processor-tests.md
+++ b/changelogs/2026-05-18-image-processor-tests.md
@@ -1,0 +1,36 @@
+# Add unit tests for src/lib/image-processor.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/image-processor.test.ts` (new) — 8 vitest cases mocking `globalThis.fetch`.
+
+## Coverage
+- 200 + `image/jpeg` → true
+- 200 + `image/png` → true
+- 200 + `text/html` → false (the common 404-as-HTML-200 case)
+- 4xx + image content-type → false
+- 5xx + image content-type → false
+- Network error (fetch throws) → false
+- Missing content-type header → false (the `|| ""` + `.startsWith("image/")` chain)
+- HEAD method + Mozilla-prefixed User-Agent
+
+## Why
+`isImageAccessible` is the gating check for poster URLs across the enrichment pipeline. Two non-obvious behaviours are now pinned:
+
+1. **`response.ok` alone is not enough** — the function ALSO requires `content-type` to start with `image/`. This catches the "page returns 200 with HTML error page instead of the poster" case that's common with TMDB-mediated poster URLs hitting expired CDN paths.
+2. **Missing content-type → false** — the `headers.get(...) || ""` coalescing prevents `undefined.startsWith` crashes but also means a legitimately-image response without the header is rejected.
+
+## Impact
+- Functional: none. Pure test addition.
+- Coverage: 24-line untested HTTP probe → 100% line coverage.
+
+## Verification
+`npx vitest run src/lib/image-processor.test.ts` — 8 passed, 0 failed.
+
+## Side note
+First version of the User-Agent test asserted `Mozilla.*Chrome` — turns out the `CHROME_USER_AGENT` constant doesn't contain the literal word "Chrome" (it ends at `AppleWebKit/537.36`). Switched to a simpler `^Mozilla\/5\.0` check.
+
+## Changelog deferral note
+Per #523-#530, omits the `RECENT_CHANGES.md` top-of-file entry.

--- a/src/lib/image-processor.test.ts
+++ b/src/lib/image-processor.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isImageAccessible } from "./image-processor";
+
+const originalFetch = globalThis.fetch;
+
+function imageResponse(status: number, contentType: string | null): Response {
+  const headers = new Headers();
+  if (contentType !== null) headers.set("content-type", contentType);
+  return new Response("", { status, headers });
+}
+
+describe("isImageAccessible", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns true for 200 + image/* content-type", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(imageResponse(200, "image/jpeg"));
+    expect(await isImageAccessible("https://example.com/foo.jpg")).toBe(true);
+  });
+
+  it("returns true for image/png", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(imageResponse(200, "image/png"));
+    expect(await isImageAccessible("https://example.com/foo.png")).toBe(true);
+  });
+
+  it("returns false for 200 + non-image content-type (e.g. text/html)", async () => {
+    // Common case: the URL returns a 404-styled HTML page with 200 status.
+    globalThis.fetch = vi.fn().mockResolvedValue(imageResponse(200, "text/html"));
+    expect(await isImageAccessible("https://example.com/notfound")).toBe(false);
+  });
+
+  it("returns false for 404 even with image content-type", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(imageResponse(404, "image/jpeg"));
+    expect(await isImageAccessible("https://example.com/foo.jpg")).toBe(false);
+  });
+
+  it("returns false for 5xx", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(imageResponse(503, "image/jpeg"));
+    expect(await isImageAccessible("https://example.com/foo.jpg")).toBe(false);
+  });
+
+  it("returns false when network error throws", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+    expect(await isImageAccessible("https://example.com/foo.jpg")).toBe(false);
+  });
+
+  it("returns false when content-type header is missing", async () => {
+    // Implementation does `|| ""` then `.startsWith("image/")` → false.
+    globalThis.fetch = vi.fn().mockResolvedValue(imageResponse(200, null));
+    expect(await isImageAccessible("https://example.com/foo.jpg")).toBe(false);
+  });
+
+  it("uses HEAD method with a Mozilla-prefixed User-Agent header", async () => {
+    const mock = vi.fn().mockResolvedValue(imageResponse(200, "image/jpeg"));
+    globalThis.fetch = mock;
+    await isImageAccessible("https://example.com/foo.jpg");
+    expect(mock).toHaveBeenCalledWith(
+      "https://example.com/foo.jpg",
+      expect.objectContaining({
+        method: "HEAD",
+        headers: expect.objectContaining({
+          "User-Agent": expect.stringMatching(/^Mozilla\/5\.0/),
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
8 cases for the poster-URL accessibility check. Pins (1) response.ok alone is not enough — content-type must start with image/; (2) missing content-type → false. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)