### PR TITLE
test(scrapers): add unit tests for utils/venue-from-registry.ts

### DIFF
--- a/changelogs/2026-05-18-venue-from-registry-tests.md
+++ b/changelogs/2026-05-18-venue-from-registry-tests.md
@@ -1,0 +1,22 @@
+# Add unit tests for src/scrapers/utils/venue-from-registry.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/scrapers/utils/venue-from-registry.test.ts` (new) — 7 vitest cases for `cinemaToVenue` and `getVenueFromRegistry`. Uses real registry fixtures (bfi-southbank, rio-dalston).
+
+## Coverage
+- Full field mapping (id, name, shortName, website, address tuple, features)
+- **Pinned shape contract**: borough is DROPPED in conversion (CinemaDefinition has it, VenueDefinition does not)
+- **Pinned null transform**: `chain: null` → `chain: undefined` via the `?? undefined` shorthand
+- Features array reference preserved (identity, not copy)
+- getVenueFromRegistry: returns venue for known ID, throws for missing ID, error message includes the missing ID for grep-ability
+
+## Why
+This module bridges the cinema-registry data model to the scraper runner's VenueDefinition. A shape regression silently breaks the scraper fleet — e.g. if borough leaked through, downstream code might try to use it; if features stopped propagating, the IMAX/35mm filter on the frontend would break.
+
+The "throws with the ID in the message" test is small but meaningful — it makes production errors greppable in CloudWatch/Vercel logs.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/scrapers/utils/venue-from-registry.test.ts
+++ b/src/scrapers/utils/venue-from-registry.test.ts
@@ -18,9 +18,11 @@ describe("cinemaToVenue", () => {
     expect(venue.name).toBe(bfi.name);
     expect(venue.shortName).toBe(bfi.shortName);
     expect(venue.website).toBe(bfi.website);
-    expect(venue.address.street).toBe(bfi.address.street);
-    expect(venue.address.area).toBe(bfi.address.area);
-    expect(venue.address.postcode).toBe(bfi.address.postcode);
+    // VenueDefinition has `address` as optional; assert presence before drilling in.
+    expect(venue.address).toBeDefined();
+    expect(venue.address?.street).toBe(bfi.address.street);
+    expect(venue.address?.area).toBe(bfi.address.area);
+    expect(venue.address?.postcode).toBe(bfi.address.postcode);
   });
 
   it("does NOT include the borough field on the venue address (CinemaDefinition has it, VenueDefinition does not)", () => {
@@ -31,7 +33,7 @@ describe("cinemaToVenue", () => {
     // The transformer explicitly picks {street, area, postcode} — borough is
     // omitted. Pinning this so a refactor doesn't accidentally widen the
     // VenueDefinition shape and leak borough into scraper output.
-    expect((venue.address as Record<string, unknown>).borough).toBeUndefined();
+    expect((venue.address as Record<string, unknown> | undefined)?.borough).toBeUndefined();
   });
 
   it("converts null chain to undefined (explicit chain ?? undefined transform)", () => {

--- a/src/scrapers/utils/venue-from-registry.test.ts
+++ b/src/scrapers/utils/venue-from-registry.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  cinemaToVenue,
+  getVenueFromRegistry,
+} from "./venue-from-registry";
+import { getCinemaById } from "@/config/cinema-registry";
+
+// Use a known-real cinema (BFI Southbank) as a fixture so we don't have to
+// stub the registry. The shape contract is what we're testing.
+
+describe("cinemaToVenue", () => {
+  it("converts a CinemaDefinition into a VenueDefinition with all required fields", () => {
+    const bfi = getCinemaById("bfi-southbank");
+    if (!bfi) throw new Error("test fixture missing: bfi-southbank");
+
+    const venue = cinemaToVenue(bfi);
+    expect(venue.id).toBe(bfi.id);
+    expect(venue.name).toBe(bfi.name);
+    expect(venue.shortName).toBe(bfi.shortName);
+    expect(venue.website).toBe(bfi.website);
+    expect(venue.address.street).toBe(bfi.address.street);
+    expect(venue.address.area).toBe(bfi.address.area);
+    expect(venue.address.postcode).toBe(bfi.address.postcode);
+  });
+
+  it("does NOT include the borough field on the venue address (CinemaDefinition has it, VenueDefinition does not)", () => {
+    const bfi = getCinemaById("bfi-southbank");
+    if (!bfi) throw new Error("test fixture missing: bfi-southbank");
+
+    const venue = cinemaToVenue(bfi);
+    // The transformer explicitly picks {street, area, postcode} — borough is
+    // omitted. Pinning this so a refactor doesn't accidentally widen the
+    // VenueDefinition shape and leak borough into scraper output.
+    expect((venue.address as Record<string, unknown>).borough).toBeUndefined();
+  });
+
+  it("converts null chain to undefined (explicit chain ?? undefined transform)", () => {
+    // The function does `chain: cinema.chain ?? undefined` — for cinemas
+    // without a chain (independents), the venue's chain field becomes
+    // undefined rather than null. Pin this transform.
+    const independent = getCinemaById("rio-dalston");
+    if (!independent) throw new Error("test fixture missing: rio-dalston");
+
+    const venue = cinemaToVenue(independent);
+    if (independent.chain === null || independent.chain === undefined) {
+      expect(venue.chain).toBeUndefined();
+    }
+  });
+
+  it("preserves features array reference", () => {
+    const bfi = getCinemaById("bfi-southbank");
+    if (!bfi) throw new Error("test fixture missing: bfi-southbank");
+
+    const venue = cinemaToVenue(bfi);
+    expect(venue.features).toBe(bfi.features);
+  });
+});
+
+describe("getVenueFromRegistry", () => {
+  it("returns a VenueDefinition for a known cinema ID", () => {
+    const venue = getVenueFromRegistry("bfi-southbank");
+    expect(venue.id).toBe("bfi-southbank");
+    expect(venue.name).toBe("BFI Southbank");
+  });
+
+  it("throws when the cinema ID is not in the registry", () => {
+    expect(() => getVenueFromRegistry("nonexistent-cinema-xyz")).toThrow(
+      /not found in registry/,
+    );
+  });
+
+  it("error message includes the missing ID for grep-ability", () => {
+    expect(() => getVenueFromRegistry("xyzzy-plugh")).toThrow(/xyzzy-plugh/);
+  });
+});


### PR DESCRIPTION
7 cases bridging cinema-registry to scraper VenueDefinition. Pins borough-drop, null→undefined chain transform, features ref preservation, grep-able error messages. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)