### PR TITLE
test(lib): add unit tests for data-quality/load-thresholds.ts

### DIFF
--- a/changelogs/2026-05-18-load-thresholds-tests.md
+++ b/changelogs/2026-05-18-load-thresholds-tests.md
@@ -1,0 +1,23 @@
+# Add unit tests for src/lib/data-quality/load-thresholds.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/data-quality/load-thresholds.test.ts` (new) — 8 vitest cases.
+
+## Coverage
+- Full Thresholds shape (5 sub-objects)
+- All tmdb fields are numbers
+- Dodgy-detection bounds in plausible ranges (year > 1800, maxYear > minYear, runtime > 0)
+- **Pinned identity caching**: repeated `loadThresholds()` calls return the same reference (module-scope cached). Pinned so a refactor doesn't reintroduce per-call I/O.
+- **Pinned `$comment` strip**: JSON metadata field is removed in the IIFE that builds STATIC_THRESHOLDS.
+- safetyFloors similarity values are in [0,1]
+- Async variant returns identical reference to sync variant
+- Async variant doesn't throw
+
+## Why
+Thresholds drive the entire data-quality pipeline (TMDB matching cutoffs, duplicate detection, non-film pattern budgets). The module-scope caching is load-bearing because hot paths call `loadThresholds()` per row — moving back to per-call I/O would balloon scrape runtime. The `$comment` strip is also load-bearing — without it, callers would see an unexpected key when iterating Thresholds.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/data-quality/load-thresholds.test.ts
+++ b/src/lib/data-quality/load-thresholds.test.ts
@@ -37,7 +37,7 @@ describe("loadThresholds", () => {
   it("strips the `$comment` field from the JSON-loaded object", () => {
     // The implementation explicitly does `delete copy.$comment` so callers
     // don't see the JSON metadata field as a Thresholds property.
-    const t = loadThresholds() as Record<string, unknown>;
+    const t = loadThresholds() as unknown as Record<string, unknown>;
     expect(t.$comment).toBeUndefined();
   });
 

--- a/src/lib/data-quality/load-thresholds.test.ts
+++ b/src/lib/data-quality/load-thresholds.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { loadThresholds, loadThresholdsAsync } from "./load-thresholds";
+
+describe("loadThresholds", () => {
+  it("returns the full Thresholds shape", () => {
+    const t = loadThresholds();
+    expect(t.tmdb).toBeDefined();
+    expect(t.duplicateDetection).toBeDefined();
+    expect(t.dodgyDetection).toBeDefined();
+    expect(t.nonFilmDetection).toBeDefined();
+    expect(t.safetyFloors).toBeDefined();
+  });
+
+  it("exposes all tmdb fields as numbers", () => {
+    const { tmdb } = loadThresholds();
+    expect(typeof tmdb.minTitleSimilarity).toBe("number");
+    expect(typeof tmdb.titleSimilarityWeight).toBe("number");
+    expect(typeof tmdb.competitorThresholdRatio).toBe("number");
+    expect(typeof tmdb.minMatchConfidence).toBe("number");
+    expect(typeof tmdb.yearMatchPenaltyRecovery).toBe("number");
+  });
+
+  it("exposes dodgy detection bounds as numbers in plausible ranges", () => {
+    const { dodgyDetection } = loadThresholds();
+    expect(dodgyDetection.maxTitleLength).toBeGreaterThan(0);
+    expect(dodgyDetection.minYear).toBeGreaterThan(1800);
+    expect(dodgyDetection.maxYear).toBeGreaterThan(dodgyDetection.minYear);
+    expect(dodgyDetection.maxRuntime).toBeGreaterThan(0);
+  });
+
+  it("returns identical reference on repeated calls (cached module-scope value)", () => {
+    // Reading thresholds at runtime would risk inconsistent reads if the JSON
+    // were dynamically loaded; pinning the module-scope caching contract.
+    expect(loadThresholds()).toBe(loadThresholds());
+  });
+
+  it("strips the `$comment` field from the JSON-loaded object", () => {
+    // The implementation explicitly does `delete copy.$comment` so callers
+    // don't see the JSON metadata field as a Thresholds property.
+    const t = loadThresholds() as Record<string, unknown>;
+    expect(t.$comment).toBeUndefined();
+  });
+
+  it("safetyFloors values are in [0,1] range (similarities) or sensible positives (counts)", () => {
+    const { safetyFloors } = loadThresholds();
+    expect(safetyFloors.minAutoMergeSimilarity).toBeGreaterThanOrEqual(0);
+    expect(safetyFloors.minAutoMergeSimilarity).toBeLessThanOrEqual(1);
+    expect(safetyFloors.minTmdbConfidence).toBeGreaterThanOrEqual(0);
+    expect(safetyFloors.minTmdbConfidence).toBeLessThanOrEqual(1);
+    expect(safetyFloors.maxNewNonFilmPatterns).toBeGreaterThan(0);
+  });
+});
+
+describe("loadThresholdsAsync", () => {
+  it("resolves with the same value as the synchronous variant", async () => {
+    const sync = loadThresholds();
+    const asyncResult = await loadThresholdsAsync();
+    expect(asyncResult).toBe(sync);
+  });
+
+  it("never throws (no I/O under the hood since module-scope load)", async () => {
+    // Pinning: a future refactor adding I/O back must NOT silently change
+    // the throw semantics that callers depend on.
+    await expect(loadThresholdsAsync()).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
8 cases. Pins module-scope identity caching and the JSON $comment strip. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)