### PR TITLE
test(lib): add unit tests for constants.getSpecialFormat (format-badge priority)

### DIFF
--- a/changelogs/2026-05-18-constants-tests.md
+++ b/changelogs/2026-05-18-constants-tests.md
@@ -1,0 +1,18 @@
+# Add unit tests for src/lib/constants.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/constants.test.ts` (new) — 10 vitest cases.
+
+## Coverage
+- `POSTER_BLUR_PLACEHOLDER` is a valid base64-encoded PNG (with PNG signature verification)
+- `getSpecialFormat`: null/undefined/empty inputs, non-special inputs, all 4 normalised forms (35mm, 70mm, IMAX, 4K), case-insensitivity
+- **Pinned priority**: 70mm > 35mm > IMAX > 4K when a string contains multiple tags. The if/else cascade order determines which badge appears on the frontend.
+
+## Why
+`getSpecialFormat` powers the format badge ("IMAX", "70mm" etc.) on every film card. A regression that swaps priority would silently surface the wrong badge on multi-format screenings ("70mm IMAX" → "IMAX" badge instead of "70mm").
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { getSpecialFormat, POSTER_BLUR_PLACEHOLDER } from "./constants";
+
+describe("POSTER_BLUR_PLACEHOLDER", () => {
+  it("is a valid base64 data URL for a PNG image", () => {
+    expect(POSTER_BLUR_PLACEHOLDER).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("decodes to a non-empty buffer (no truncation)", () => {
+    const b64 = POSTER_BLUR_PLACEHOLDER.split(",")[1];
+    const buf = Buffer.from(b64, "base64");
+    expect(buf.length).toBeGreaterThan(50);
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+    expect(buf.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])))
+      .toBe(true);
+  });
+});
+
+describe("getSpecialFormat", () => {
+  it("returns null for null/undefined/empty input", () => {
+    expect(getSpecialFormat(null)).toBeNull();
+    expect(getSpecialFormat(undefined)).toBeNull();
+    expect(getSpecialFormat("")).toBeNull();
+  });
+
+  it("returns null for non-special formats", () => {
+    expect(getSpecialFormat("digital")).toBeNull();
+    expect(getSpecialFormat("Standard")).toBeNull();
+    expect(getSpecialFormat("DCP")).toBeNull();
+  });
+
+  it("normalises 35mm variants", () => {
+    expect(getSpecialFormat("35mm")).toBe("35mm");
+    expect(getSpecialFormat("35MM")).toBe("35mm");
+    expect(getSpecialFormat("35mm Print")).toBe("35mm");
+  });
+
+  it("normalises 70mm variants", () => {
+    expect(getSpecialFormat("70mm")).toBe("70mm");
+    expect(getSpecialFormat("70MM IMAX")).toBe("70mm"); // 70mm wins via the explicit if-order
+  });
+
+  it("normalises IMAX variants (case-insensitive)", () => {
+    expect(getSpecialFormat("IMAX")).toBe("IMAX");
+    expect(getSpecialFormat("imax")).toBe("IMAX");
+    expect(getSpecialFormat("IMAX Laser")).toBe("IMAX");
+  });
+
+  it("normalises 4K variants", () => {
+    expect(getSpecialFormat("4K")).toBe("4K");
+    expect(getSpecialFormat("4k restoration")).toBe("4K");
+  });
+
+  it("priority is 70mm > 35mm > IMAX > 4K within the if/else cascade for a multi-tag string", () => {
+    // The cascading if-blocks pick the FIRST match in the order: 70mm, 35mm,
+    // IMAX, 4K. Pinning this priority so a refactor doesn't accidentally
+    // reorder the checks and break frontend format-badge displays.
+    expect(getSpecialFormat("70mm IMAX")).toBe("70mm");
+    expect(getSpecialFormat("35mm 4K Restoration")).toBe("35mm");
+    expect(getSpecialFormat("IMAX 4K")).toBe("IMAX");
+  });
+
+  it("returns null for whitespace-only strings (no special tokens)", () => {
+    expect(getSpecialFormat("   ")).toBeNull();
+  });
+});


### PR DESCRIPTION
10 cases. Pins the 70mm > 35mm > IMAX > 4K cascade priority that determines which badge appears on multi-format screenings, plus PNG signature check on POSTER_BLUR_PLACEHOLDER. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)