### PR TITLE
test(lib): add unit tests for auth pure functions (verifyCronSecret + error helpers)

### DIFF
--- a/changelogs/2026-05-18-auth-pure-fns-tests.md
+++ b/changelogs/2026-05-18-auth-pure-fns-tests.md
@@ -1,0 +1,26 @@
+# Add unit tests for pure functions in src/lib/auth.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/auth.test.ts` (new) — 10 vitest cases covering `unauthorizedResponse`, `forbiddenResponse`, and `verifyCronSecret`.
+- Skips the Clerk-dependent functions (`getCurrentUserId`, `requireAuth`, `requireAdmin`, `withAdminAuth`) which need auth-context mocking.
+
+## Coverage (security-critical: `verifyCronSecret`)
+- Happy path: `Bearer <correct-secret>` → true
+- Missing authorization header → false
+- Mismatched token → false
+- **Pinned case-sensitivity**: lowercase `bearer ` is NOT stripped — only literal `Bearer `. Captured so a refactor to a case-insensitive regex (`.replace(/^Bearer\s+/i, "")`) gets flagged as a behaviour change.
+- CRON_SECRET unset + empty bearer → false (no accidental "undefined === undefined" bypass)
+- CRON_SECRET unset + no header → false
+- Bare `Bearer` (no trailing space) → false
+- Repeated `Bearer Bearer …` → false (single-pass `.replace`)
+
+## Why
+`verifyCronSecret` gates every cron route. A weakened auth check is exactly the kind of regression where every test you write is a security win. The Bearer-prefix case-sensitivity is particularly worth pinning — it's the kind of thing a casual "let me make this more forgiving" PR could change without realising the impact.
+
+The unauthorizedResponse / forbiddenResponse tests are tiny but pin the canonical error JSON body so a refactor doesn't accidentally change the API response shape (which would break frontend error parsing).
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the pure functions in src/lib/auth.ts.
+ *
+ * Skips the Clerk-dependent functions (`getCurrentUserId`, `requireAuth`,
+ * `requireAdmin`, `withAdminAuth`) since they require auth-context mocking.
+ * These tests cover the security-critical `verifyCronSecret` and the
+ * `unauthorizedResponse` / `forbiddenResponse` helpers.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  forbiddenResponse,
+  unauthorizedResponse,
+  verifyCronSecret,
+} from "./auth";
+
+describe("unauthorizedResponse", () => {
+  it("returns a 401 Response with the canonical error body", async () => {
+    const res = unauthorizedResponse();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+});
+
+describe("forbiddenResponse", () => {
+  it("returns a 403 Response with the canonical error body", async () => {
+    const res = forbiddenResponse();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Forbidden" });
+  });
+});
+
+describe("verifyCronSecret", () => {
+  let savedSecret: string | undefined;
+
+  beforeEach(() => {
+    savedSecret = process.env.CRON_SECRET;
+    process.env.CRON_SECRET = "test-cron-secret-123";
+  });
+
+  afterEach(() => {
+    if (savedSecret === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = savedSecret;
+  });
+
+  function reqWithAuth(authHeader?: string): Request {
+    const headers: Record<string, string> = {};
+    if (authHeader !== undefined) headers["authorization"] = authHeader;
+    return new Request("https://example.com/api/cron/x", { headers });
+  }
+
+  it("returns true when the Bearer token matches CRON_SECRET", () => {
+    expect(verifyCronSecret(reqWithAuth("Bearer test-cron-secret-123"))).toBe(true);
+  });
+
+  it("returns false when no authorization header is present", () => {
+    expect(verifyCronSecret(reqWithAuth())).toBe(false);
+  });
+
+  it("returns false when the Bearer token does not match", () => {
+    expect(verifyCronSecret(reqWithAuth("Bearer wrong-secret"))).toBe(false);
+  });
+
+  it("strips ONLY the literal 'Bearer ' prefix (leading lowercase 'bearer' is NOT stripped)", () => {
+    // The implementation does .replace("Bearer ", "") — case-sensitive.
+    // Lowercase "bearer " stays in the token string, so the comparison fails.
+    // Pinning this so a refactor to .replace(/^Bearer\s+/i, "") gets flagged
+    // as a behaviour change before it lands.
+    expect(verifyCronSecret(reqWithAuth("bearer test-cron-secret-123"))).toBe(false);
+  });
+
+  it("returns false when CRON_SECRET env var is unset and token is empty", () => {
+    delete process.env.CRON_SECRET;
+    // Both undefined → matches via `token === undefined`. Pin behaviour.
+    // Note: this is a SECURITY-CRITICAL edge case. The function returns false
+    // (correctly) when the secret is unset AND token has the Bearer-prefix
+    // shape — because the prefix-stripped value is empty string, which doesn't
+    // === undefined.
+    expect(verifyCronSecret(reqWithAuth("Bearer "))).toBe(false);
+  });
+
+  it("returns false when CRON_SECRET is unset and token is also missing", () => {
+    delete process.env.CRON_SECRET;
+    expect(verifyCronSecret(reqWithAuth())).toBe(false);
+  });
+
+  it("does NOT treat the bare 'Bearer' (no trailing space) as a Bearer scheme", () => {
+    // .replace("Bearer ", "") needs the trailing space to find anything.
+    // Without it, the whole string survives and won't match the secret.
+    expect(verifyCronSecret(reqWithAuth("Bearer"))).toBe(false);
+  });
+
+  it("does NOT support multiple Bearer prefixes (the first-match strip only)", () => {
+    // .replace strips ONE occurrence. Repeated prefixes survive.
+    expect(verifyCronSecret(reqWithAuth("Bearer Bearer test-cron-secret-123"))).toBe(false);
+  });
+});


### PR DESCRIPTION
10 cases. Pins the 'Bearer ' case-sensitive prefix strip and the unset-CRON_SECRET/empty-bearer security edge case. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)