### PR TITLE
test(lib): add unit tests for stripCodeFences (gemini + deepseek)

### DIFF
--- a/changelogs/2026-05-18-ai-clients-stripcodefences-tests.md
+++ b/changelogs/2026-05-18-ai-clients-stripcodefences-tests.md
@@ -1,0 +1,28 @@
+# Add unit tests for stripCodeFences (gemini.ts + deepseek.ts)
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/ai-clients-stripcodefences.test.ts` (new) — 10 vitest cases run against BOTH gemini.stripCodeFences and deepseek.stripCodeFences (20 total assertions). The two implementations are byte-identical; the dual-suite pattern means a future refactor to extract a shared helper will surface any behaviour drift immediately.
+
+## Coverage
+- Strip ```json (with language tag) + trailing ```
+- Strip ``` (no language tag) + trailing ```
+- Strip ```json with no newline before content
+- Pass-through for clean JSON (no fences)
+- Empty input
+- Whitespace-only input
+- Preserve internal newlines
+- Mid-string ``` NOT stripped (only leading/trailing)
+- Idempotence on already-clean input
+- **Pinned regex anchor contract**: whitespace BEFORE the leading fence prevents the strip (regex is `^`-anchored, `.trim()` runs AFTER the replace passes). A casual refactor to pre-trim would silently change behaviour.
+
+## Why
+Both AI clients pipe JSON responses through `stripCodeFences` before `JSON.parse()`. A regression here surfaces as `SyntaxError` from JSON.parse in the enrichment/QA/data-quality stacks — opaque failure mode. The pinned `^`-anchored contract is particularly worth pinning because "let me add a pre-trim to be safe" is exactly the kind of intuitive change that would break things.
+
+## Future-proofing
+The two implementations are byte-identical — a follow-up PR can extract them to a shared helper. This test file's dual-suite pattern is designed to make that refactor safe: the same 10 cases run against both function references, so consolidation can't silently change behaviour without test failures.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/ai-clients-stripcodefences.test.ts
+++ b/src/lib/ai-clients-stripcodefences.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for `stripCodeFences` from both src/lib/gemini.ts and src/lib/deepseek.ts.
+ *
+ * Both modules export identical implementations (DRY duplication noted in
+ * the codebase — a future PR can extract to a shared helper). For now, this
+ * test file pins the contract for BOTH so a refactor to consolidate them
+ * doesn't silently change the behaviour of either caller.
+ */
+import { describe, expect, it } from "vitest";
+import { stripCodeFences as stripCodeFencesGemini } from "./gemini";
+import { stripCodeFences as stripCodeFencesDeepSeek } from "./deepseek";
+
+// The two implementations are identical; run the same suite against both.
+const SUITES: Array<[string, (s: string) => string]> = [
+  ["gemini.stripCodeFences", stripCodeFencesGemini],
+  ["deepseek.stripCodeFences", stripCodeFencesDeepSeek],
+];
+
+for (const [name, strip] of SUITES) {
+  describe(name, () => {
+    it("strips leading ```json fence and trailing ```", () => {
+      const input = '```json\n{"foo": 1}\n```';
+      expect(strip(input)).toBe('{"foo": 1}');
+    });
+
+    it("strips leading ``` (no language tag)", () => {
+      const input = '```\n{"foo": 1}\n```';
+      expect(strip(input)).toBe('{"foo": 1}');
+    });
+
+    it("strips ```json with no trailing newline before content", () => {
+      const input = '```json{"foo": 1}```';
+      expect(strip(input)).toBe('{"foo": 1}');
+    });
+
+    it("returns clean JSON unchanged (no fences present)", () => {
+      expect(strip('{"foo": 1}')).toBe('{"foo": 1}');
+    });
+
+    it("does NOT strip a leading fence if there's whitespace before it (regex is ^-anchored)", () => {
+      // Implementation: `.replace(/^\`\`\`(?:json)?\s*\n?/, "")` — `^` anchors to
+      // the very start of the string, so whitespace BEFORE the fence prevents
+      // the strip. Pinning this so a refactor doesn't accidentally introduce
+      // pre-trim() that would silently change behaviour.
+      const input = '  ```json\n{"x": 2}\n```  ';
+      expect(strip(input)).toBe('```json\n{"x": 2}');
+    });
+
+    it("returns empty string for empty input", () => {
+      expect(strip("")).toBe("");
+    });
+
+    it("returns whitespace-only input as empty after trim", () => {
+      expect(strip("   \n  ")).toBe("");
+    });
+
+    it("preserves internal newlines in the fenced content", () => {
+      const input = "```json\n{\n  \"a\": 1,\n  \"b\": 2\n}\n```";
+      expect(strip(input)).toBe('{\n  "a": 1,\n  "b": 2\n}');
+    });
+
+    it("does NOT strip ``` that appears mid-string (only at start/end)", () => {
+      const input = "```json\nbefore ``` middle\n```";
+      // Leading fence stripped, trailing fence stripped, middle ``` preserved.
+      expect(strip(input)).toBe("before ``` middle");
+    });
+
+    it("is idempotent when called twice on already-clean input", () => {
+      const clean = '{"foo": 1}';
+      expect(strip(strip(clean))).toBe(clean);
+    });
+  });
+}


### PR DESCRIPTION
10 cases × 2 implementations = 20 assertions. Dual-suite pattern protects a future DRY refactor. Pins the ^-anchored regex contract. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)