### PR TITLE
test(lib): add unit tests for likelyNeedsClassification (classifier gate)

### DIFF
--- a/changelogs/2026-05-18-event-classifier-likely-needs-tests.md
+++ b/changelogs/2026-05-18-event-classifier-likely-needs-tests.md
@@ -1,0 +1,25 @@
+# Add unit tests for likelyNeedsClassification (event-classifier gate)
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/event-classifier-likely-needs.test.ts` (new) — 27 vitest cases (mostly via `it.each`) covering the 22-regex pattern set.
+
+## Coverage families
+- Plain film titles → false (control)
+- Q&A patterns (3 variants)
+- Format patterns: 35mm, 70mm, IMAX, 4K, 3D (5 cases)
+- Event patterns: premiere, preview, sing-along, double-bill, marathon (6 cases)
+- Accessibility patterns: relaxed, subtitle, audio-description (3 cases)
+- Repertory/season patterns: intro, discussion, anniversary, restoration, season, retrospective (6 cases)
+- Case-insensitivity sanity
+- **Word-boundary requirement**: `\b3d\b` does NOT match substrings like "in-3deed" or "Imax3D" (no word boundary)
+
+## Why
+This function is the gate that decides whether to invoke the (expensive) Gemini classifier for each screening title. A regression that broadens the match silently inflates AI API spend; one that narrows it silently mis-classifies special-event screenings as plain films. The case-insensitivity + word-boundary contracts are both load-bearing.
+
+Separate from `event-classifier.test.ts` because the rest of the module needs Gemini API mocks — this file tests only the pure heuristic.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/event-classifier-likely-needs.test.ts
+++ b/src/lib/event-classifier-likely-needs.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for `likelyNeedsClassification` from src/lib/event-classifier.ts.
+ *
+ * Separate test file (rather than event-classifier.test.ts) because the
+ * classifier itself needs Gemini mocks. This file tests only the pure
+ * heuristic gate function.
+ */
+import { describe, expect, it } from "vitest";
+import { likelyNeedsClassification } from "./event-classifier";
+
+describe("likelyNeedsClassification", () => {
+  it("returns false for a plain film title", () => {
+    expect(likelyNeedsClassification("Vertigo")).toBe(false);
+    expect(likelyNeedsClassification("The Lord of the Rings")).toBe(false);
+  });
+
+  // Q&A variants
+  it.each([
+    ["Anatomy of a Fall + Q&A", true],
+    ["The Brutalist Q & A", true],
+    ["X + q&a", true],
+  ])("Q&A pattern: %j → %j", (input, expected) => {
+    expect(likelyNeedsClassification(input)).toBe(expected);
+  });
+
+  // Format variants
+  it.each([
+    ["The Shining 35mm", true],
+    ["2001 70mm IMAX", true],
+    ["Inception IMAX", true],
+    ["Vertigo 4K Restoration", true],
+    ["Avatar 3D", true],
+  ])("format pattern: %j → %j", (input, expected) => {
+    expect(likelyNeedsClassification(input)).toBe(expected);
+  });
+
+  // Event variants
+  it.each([
+    ["UK Premiere: Saltburn", true],
+    ["Sneak Preview", true],
+    ["Saint Maud Sing-A-Long", true],
+    ["Mamma Mia Singalong", true],
+    ["Pulp Fiction + Reservoir Dogs Double Bill", true],
+    ["The Marathon", true],
+  ])("event-type pattern: %j → %j", (input, expected) => {
+    expect(likelyNeedsClassification(input)).toBe(expected);
+  });
+
+  // Accessibility variants
+  it.each([
+    ["Frozen Relaxed Screening", true],
+    ["Citizen Kane with Subtitles", true],
+    ["Casablanca audio described", true],
+  ])("accessibility pattern: %j → %j", (input, expected) => {
+    expect(likelyNeedsClassification(input)).toBe(expected);
+  });
+
+  // Repertory/season variants
+  it.each([
+    ["Vertigo + Intro by Critic", true],
+    ["Saltburn + Discussion", true],
+    ["The Brutalist 30th Anniversary", true],
+    ["Saint Maud (4K Restoration)", true],
+    ["Kurosawa Season: Ran", true],
+    ["Studio Ghibli Retrospective", true],
+  ])("repertory/season pattern: %j → %j", (input, expected) => {
+    expect(likelyNeedsClassification(input)).toBe(expected);
+  });
+
+  it("is case-insensitive (regex flags include /i)", () => {
+    expect(likelyNeedsClassification("ANATOMY OF A FALL + Q&A")).toBe(true);
+    expect(likelyNeedsClassification("THE SHINING 35MM")).toBe(true);
+  });
+
+  it("requires word-boundary matches (does NOT fire on substrings)", () => {
+    // `\b3d\b` requires word boundaries — should NOT match the literal "3d"
+    // embedded in "in-3deed" or similar non-format mentions.
+    expect(likelyNeedsClassification("The In-3deed Hour")).toBe(false);
+    expect(likelyNeedsClassification("Imax3D")).toBe(false); // no word boundary
+  });
+
+  it("returns true for an empty string only if a pattern matches (no false-positives)", () => {
+    expect(likelyNeedsClassification("")).toBe(false);
+  });
+});


### PR DESCRIPTION
27 cases covering all 22 regex patterns. Gate function decides whether to invoke expensive Gemini classifier. Pins case-insensitivity + word-boundary requirements. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)