### PR TITLE
test(db): add unit tests for safe-query.ts

### DIFF
--- a/changelogs/2026-05-18-safe-query-tests.md
+++ b/changelogs/2026-05-18-safe-query-tests.md
@@ -1,0 +1,24 @@
+# Add unit tests for src/db/safe-query.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/db/safe-query.test.ts` (new) — 9 vitest cases using `vi.resetModules()` + dynamic import to exercise both DATABASE_URL-set and DATABASE_URL-unset code paths.
+
+## Coverage
+- DATABASE_URL set + query succeeds → returns query result
+- DATABASE_URL unset → returns fallback WITHOUT calling queryFn
+- DATABASE_URL empty string → returns fallback
+- **Pinned localhost exclusion**: `localhost:5432/postgres` is treated as "no DATABASE_URL" (the build-time CI guard). A future refactor that drops this exclusion would silently try to connect to a non-existent local DB during CI builds.
+- DATABASE_URL set + query throws → fallback (error swallowed)
+- Error is logged to console.error (observable)
+- isDatabaseAvailable returns true/false matching the snapshot logic
+
+## Why
+`safeQuery` is the build-time resilience layer — Next.js page builds call DB-dependent queries through it so they don't crash CI when DATABASE_URL is absent. A regression that bypasses the fallback would crash production builds in environments without DB connectivity.
+
+The localhost-exclusion is particularly worth pinning. It's a non-obvious branch that exists specifically to handle the "dev environment without postgres running" case — a casual cleanup PR that removes "this looks redundant" would break offline builds.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/db/safe-query.test.ts
+++ b/src/db/safe-query.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for src/db/safe-query.ts.
+ *
+ * `hasDatabaseUrl` is computed at module load time from process.env, so the
+ * tests' behaviour depends on whether DATABASE_URL is set when vitest runs.
+ * We test both branches via vi.resetModules() + dynamic re-import.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_DB_URL = process.env.DATABASE_URL;
+
+async function importWithDbUrl(value: string | undefined) {
+  vi.resetModules();
+  if (value === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = value;
+  }
+  return await import("./safe-query");
+}
+
+describe("safeQuery", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (ORIGINAL_DB_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DB_URL;
+    vi.resetModules();
+  });
+
+  it("returns the query result when DATABASE_URL is set and query succeeds", async () => {
+    const { safeQuery } = await importWithDbUrl(
+      "postgres://user:pass@db.example.com:5432/prod",
+    );
+    const result = await safeQuery(async () => "hello", "fallback");
+    expect(result).toBe("hello");
+  });
+
+  it("returns fallback when DATABASE_URL is missing (no query execution)", async () => {
+    const { safeQuery } = await importWithDbUrl(undefined);
+    const queryFn = vi.fn(async () => "never");
+    const result = await safeQuery(queryFn, "fallback-value");
+    expect(result).toBe("fallback-value");
+    expect(queryFn).not.toHaveBeenCalled();
+  });
+
+  it("returns fallback when DATABASE_URL is empty string", async () => {
+    const { safeQuery } = await importWithDbUrl("");
+    const queryFn = vi.fn(async () => "never");
+    const result = await safeQuery(queryFn, "default");
+    expect(result).toBe("default");
+    expect(queryFn).not.toHaveBeenCalled();
+  });
+
+  it("treats localhost:5432/postgres as 'no DATABASE_URL' (fallback path)", async () => {
+    // The implementation explicitly excludes the localhost dev URL so that
+    // builds in CI don't try to connect to a non-existent local postgres.
+    // Pinning this branch.
+    const { safeQuery } = await importWithDbUrl(
+      "postgres://postgres:postgres@localhost:5432/postgres",
+    );
+    const queryFn = vi.fn(async () => "never");
+    const result = await safeQuery(queryFn, "fb");
+    expect(result).toBe("fb");
+    expect(queryFn).not.toHaveBeenCalled();
+  });
+
+  it("returns fallback (and swallows error) when query throws", async () => {
+    const { safeQuery } = await importWithDbUrl(
+      "postgres://u:p@db.example.com:5432/prod",
+    );
+    const result = await safeQuery(
+      async () => {
+        throw new Error("connection refused");
+      },
+      "error-fallback",
+    );
+    expect(result).toBe("error-fallback");
+  });
+
+  it("logs the error to console.error on failure (observable)", async () => {
+    const { safeQuery } = await importWithDbUrl(
+      "postgres://u:p@db.example.com:5432/prod",
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await safeQuery(
+      async () => {
+        throw new Error("boom");
+      },
+      "fb",
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    const firstCall = errorSpy.mock.calls[0];
+    expect(firstCall[0]).toMatch(/Query failed/);
+  });
+});
+
+describe("isDatabaseAvailable", () => {
+  afterEach(() => {
+    if (ORIGINAL_DB_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DB_URL;
+    vi.resetModules();
+  });
+
+  it("returns true when DATABASE_URL is a real production-style URL", async () => {
+    const { isDatabaseAvailable } = await importWithDbUrl(
+      "postgres://u:p@db.example.com:5432/prod",
+    );
+    expect(isDatabaseAvailable()).toBe(true);
+  });
+
+  it("returns false when DATABASE_URL is unset", async () => {
+    const { isDatabaseAvailable } = await importWithDbUrl(undefined);
+    expect(isDatabaseAvailable()).toBe(false);
+  });
+
+  it("returns false for the localhost-postgres dev URL", async () => {
+    const { isDatabaseAvailable } = await importWithDbUrl(
+      "postgres://postgres:postgres@localhost:5432/postgres",
+    );
+    expect(isDatabaseAvailable()).toBe(false);
+  });
+});


### PR DESCRIPTION
9 cases covering both DATABASE_URL-set/unset paths. Pins the localhost-exclusion branch (build-time CI guard). Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)