### PR TITLE
test(db): add unit tests for cursor-pagination primitives (parseCursor + buildCursor)

### DIFF
--- a/changelogs/2026-05-18-cursor-pagination-tests.md
+++ b/changelogs/2026-05-18-cursor-pagination-tests.md
@@ -1,0 +1,28 @@
+# Add unit tests for cursor-pagination primitives in screening.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/db/repositories/cursor-pagination.test.ts` (new) — 10 vitest cases for `parseCursor` + `buildCursor` + roundtrip integrity.
+
+## Why
+Cursor-based pagination drives the `/api/screenings` infinite-scroll experience. A regression in parse/build silently corrupts pagination (duplicates, missed rows, infinite loops). The pure-function pair is perfect for round-trip testing.
+
+## Coverage
+- parseCursor:
+  - Happy path: splits at LAST `_` (UUID right of split)
+  - No underscore → null
+  - Empty datetime → null
+  - Empty id → null
+  - Unparseable datetime → null
+  - Empty string → null
+  - Pinned `lastIndexOf` semantics for unusual inputs
+- buildCursor:
+  - Canonical `<ISO>_<id>` format
+- Roundtrip:
+  - Datetime + id preserved through buildCursor → parseCursor
+  - UUID-with-hyphens id preserved (since split is at `_`, not `-`)
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/db/repositories/cursor-pagination.test.ts
+++ b/src/db/repositories/cursor-pagination.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the cursor-pagination primitives in src/db/repositories/screening.ts.
+ *
+ * Separate from screening.test.ts because that file tests the integration
+ * with Drizzle; here we focus on the pure parseCursor/buildCursor pair.
+ */
+import { describe, expect, it } from "vitest";
+import { buildCursor, parseCursor } from "./screening";
+
+describe("parseCursor", () => {
+  it("splits at the LAST underscore — UUID is right of split", () => {
+    const result = parseCursor("2026-05-18T19:30:00.000Z_abc-123-uuid");
+    expect(result).toEqual({
+      datetime: "2026-05-18T19:30:00.000Z",
+      id: "abc-123-uuid",
+    });
+  });
+
+  it("returns null when the cursor has no underscore", () => {
+    expect(parseCursor("nounderscorehere")).toBeNull();
+  });
+
+  it("returns null when datetime portion is empty", () => {
+    expect(parseCursor("_abc")).toBeNull();
+  });
+
+  it("returns null when id portion is empty", () => {
+    expect(parseCursor("2026-05-18T19:30:00.000Z_")).toBeNull();
+  });
+
+  it("returns null when datetime portion is unparseable", () => {
+    expect(parseCursor("not-a-date_abc-uuid")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseCursor("")).toBeNull();
+  });
+
+  it("uses lastIndexOf — handles UUIDs containing underscores in the datetime portion (unusual but pin)", () => {
+    // ISO datetimes don't contain underscores, but if a datetime were somehow
+    // to include one, the LAST underscore wins (so the UUID part stays intact).
+    // We pin the behaviour: the cursor format treats everything-up-to-last-_
+    // as datetime, after-last-_ as id.
+    const result = parseCursor("2026-05-18T19:30:00_foo_bar-uuid");
+    // Date.parse("2026-05-18T19:30:00_foo") returns NaN, so this becomes null.
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildCursor", () => {
+  it("formats as '<ISO datetime>_<id>'", () => {
+    const screening = {
+      id: "abc-uuid-123",
+      datetime: new Date("2026-05-18T19:30:00.000Z"),
+    };
+    // Use unknown cast — the function only reads datetime + id, so a partial
+    // ScreeningWithDetails is fine for testing the formatter contract.
+    expect(buildCursor(screening as unknown as Parameters<typeof buildCursor>[0])).toBe(
+      "2026-05-18T19:30:00.000Z_abc-uuid-123",
+    );
+  });
+});
+
+describe("parseCursor + buildCursor roundtrip", () => {
+  it("preserves datetime + id through build → parse", () => {
+    const original = {
+      id: "abc-uuid-123",
+      datetime: new Date("2026-05-18T19:30:00.000Z"),
+    };
+    const cursor = buildCursor(original as unknown as Parameters<typeof buildCursor>[0]);
+    const parsed = parseCursor(cursor);
+    expect(parsed).toEqual({
+      datetime: "2026-05-18T19:30:00.000Z",
+      id: "abc-uuid-123",
+    });
+  });
+
+  it("preserves datetime + id even when id contains hyphens (UUID-style)", () => {
+    const original = {
+      id: "00000000-0000-0000-0000-000000000000",
+      datetime: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const cursor = buildCursor(original as unknown as Parameters<typeof buildCursor>[0]);
+    const parsed = parseCursor(cursor);
+    expect(parsed?.id).toBe("00000000-0000-0000-0000-000000000000");
+  });
+});


### PR DESCRIPTION
10 cases incl. roundtrip integrity. Pins lastIndexOf split + UUID-with-hyphens preservation. Drives /api/screenings infinite scroll. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)