### PR TITLE
refactor(lib): DRY stripCodeFences across gemini + deepseek

### DIFF
--- a/changelogs/2026-05-18-dry-stripcodefences.md
+++ b/changelogs/2026-05-18-dry-stripcodefences.md
@@ -1,0 +1,25 @@
+# DRY stripCodeFences across gemini.ts + deepseek.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/strip-code-fences.ts` (new) — canonical implementation of `stripCodeFences`
+- `src/lib/gemini.ts` — replaces inline implementation with `export { stripCodeFences } from "./strip-code-fences"`
+- `src/lib/deepseek.ts` — same re-export pattern
+
+## Why
+The two modules had byte-identical implementations of `stripCodeFences` (noted as a follow-up in PR #545's body). This PR removes the duplication while preserving all import paths — callers continue to import from `@/lib/gemini` or `@/lib/deepseek` unchanged.
+
+The dual-suite test from PR #545 (`ai-clients-stripcodefences.test.ts`) verifies both import paths still produce identical results after the consolidation — which is the test pattern's whole point.
+
+## Impact
+- Functional: none. Byte-identical re-export. Existing 20 vitest cases (10 × 2 import paths) still pass.
+- Maintainability: a single source of truth for the regex chain. The pinned `^`-anchored behaviour is now documented in one place (a comment block in `strip-code-fences.ts`) rather than two slightly-diverging comments.
+- Callers: zero changes needed; `@/lib/gemini` and `@/lib/deepseek` re-export the same symbol.
+
+## Verification
+`npx vitest run src/lib/ai-clients-stripcodefences.test.ts` — 20 passed, 0 failed.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/deepseek.ts
+++ b/src/lib/deepseek.ts
@@ -38,13 +38,12 @@ function getClient(): OpenAI {
  * Strip markdown code fences. DeepSeek with `response_format: json_object`
  * returns clean JSON, but we keep this for parity with the Gemini client
  * and to handle non-JSON responses that may still arrive fenced.
+ *
+ * Re-exported from the shared helper for backwards compatibility with
+ * existing imports (`@/lib/deepseek`); the canonical implementation lives
+ * in `@/lib/strip-code-fences`.
  */
-export function stripCodeFences(text: string): string {
-  return text
-    .replace(/^```(?:json)?\s*\n?/, "")
-    .replace(/\n?```\s*$/, "")
-    .trim();
-}
+export { stripCodeFences } from "./strip-code-fences";
 
 interface GenerateOptions {
   systemPrompt?: string;

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -30,13 +30,12 @@ function getClient(): GoogleGenAI {
 /**
  * Strip markdown code fences that Gemini sometimes wraps around JSON responses.
  * Safe to call on text that doesn't have fences.
+ *
+ * Re-exported from the shared helper for backwards compatibility with
+ * existing imports (`@/lib/gemini`); the canonical implementation lives in
+ * `@/lib/strip-code-fences`.
  */
-export function stripCodeFences(text: string): string {
-  return text
-    .replace(/^```(?:json)?\s*\n?/, "")
-    .replace(/\n?```\s*$/, "")
-    .trim();
-}
+export { stripCodeFences } from "./strip-code-fences";
 
 /**
  * Generate text from a prompt (simple variant).

--- a/src/lib/strip-code-fences.ts
+++ b/src/lib/strip-code-fences.ts
@@ -1,0 +1,26 @@
+/**
+ * Strip markdown code fences that LLM responses sometimes wrap around JSON.
+ * Safe to call on text that doesn't have fences (idempotent identity).
+ *
+ * Shared by src/lib/gemini.ts and src/lib/deepseek.ts — historically each
+ * exported its own byte-identical copy. Consolidated 2026-05-18 to a single
+ * source of truth; the gemini/deepseek modules now re-export this for
+ * backwards compatibility with existing callers.
+ *
+ * Pinned contract (see `ai-clients-stripcodefences.test.ts` — the dual-suite
+ * test that protected the original duplication is still in place):
+ *
+ * - Strips a leading ```json or ``` (optionally followed by a newline) only
+ *   when at the very START of the string (`^`-anchored regex)
+ * - Strips a trailing ``` (optionally preceded by a newline) only at the END
+ * - Trims the result
+ * - Preserves mid-string ``` characters
+ * - Whitespace BEFORE the leading fence prevents the strip (because of the
+ *   `^` anchor — `.trim()` runs AFTER the replaces)
+ */
+export function stripCodeFences(text: string): string {
+  return text
+    .replace(/^```(?:json)?\s*\n?/, "")
+    .replace(/\n?```\s*$/, "")
+    .trim();
+}


### PR DESCRIPTION
Follow-up to #545. Extracts the byte-identical helper to src/lib/strip-code-fences.ts; both modules re-export for backwards compat. 20 vitest cases (dual-suite) still pass. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)