### PR TITLE
test(lib): add unit tests for title-extraction/index cache primitives

### DIFF
--- a/changelogs/2026-05-18-title-extraction-index-tests.md
+++ b/changelogs/2026-05-18-title-extraction-index-tests.md
@@ -1,0 +1,25 @@
+# Add unit tests for src/lib/title-extraction/index.ts (cache primitives)
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/title-extraction/index.test.ts` (new) — 9 vitest cases for `extractFilmTitle`, `extractFilmTitleCached`, `clearTitleCache`, `batchExtractTitles`.
+
+## Coverage
+- extractFilmTitle: returns AIExtractionResult with filmTitle + confidence ∈ {high, medium, low}
+- extractFilmTitleCached: reference-equal on cache hit, different objects for different keys
+- **Pinned cache-key contract**: cache is case-sensitive on the RAW input string (no normalisation)
+- clearTitleCache: subsequent call returns a fresh instance (cache invalidated)
+- batchExtractTitles: Map keyed by raw title, dedup via Set, empty-input handling
+
+## Why
+This module is the **single entry point** for title extraction across the entire scraper pipeline (`extractFilmTitleCached` is called once per scraped film). A regression in the cache primitives either:
+- Returns stale data for a re-scraped venue (false hit on case-sensitivity)
+- Bypasses the cache (silently O(n²) instead of O(n))
+- Loses cache-clear semantics needed by long-running pipelines
+
+The case-sensitivity test in particular pins a non-obvious choice — a future refactor that switches to lowercase keys would silently change cache hit rates.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/title-extraction/index.test.ts
+++ b/src/lib/title-extraction/index.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for src/lib/title-extraction/index.ts — the title-cache module.
+ *
+ * Tests the cache + clear + batch primitives, NOT the underlying extractor
+ * (which has its own tests in ai-extractor.test.ts).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  batchExtractTitles,
+  clearTitleCache,
+  extractFilmTitle,
+  extractFilmTitleCached,
+} from "./index";
+
+describe("extractFilmTitle", () => {
+  it("returns an AIExtractionResult for a plain film title (sync extractor under the hood)", async () => {
+    const result = await extractFilmTitle("Vertigo");
+    // AIExtractionResult shape: { filmTitle, canonicalTitle, confidence: "high" | "medium" | "low" }
+    expect(result.filmTitle).toBe("Vertigo");
+    expect(["high", "medium", "low"]).toContain(result.confidence);
+  });
+});
+
+describe("extractFilmTitleCached", () => {
+  afterEach(() => {
+    clearTitleCache();
+  });
+
+  it("returns identical reference on cache hit (same string → same AIExtractionResult instance)", async () => {
+    const first = await extractFilmTitleCached("Fight Club");
+    const second = await extractFilmTitleCached("Fight Club");
+    // The cache stores the result object directly — should be reference-equal.
+    expect(second).toBe(first);
+  });
+
+  it("treats different titles as different cache keys (no false hits)", async () => {
+    const a = await extractFilmTitleCached("Fight Club");
+    const b = await extractFilmTitleCached("Citizen Kane");
+    expect(a).not.toBe(b);
+    expect(a.filmTitle).toBe("Fight Club");
+    expect(b.filmTitle).toBe("Citizen Kane");
+  });
+
+  it("cache is case-sensitive on the raw input (different cases → different cache entries)", async () => {
+    const lower = await extractFilmTitleCached("vertigo");
+    const upper = await extractFilmTitleCached("Vertigo");
+    // Pin the contract: cache key is the RAW input string, not normalised.
+    expect(lower).not.toBe(upper);
+  });
+});
+
+describe("clearTitleCache", () => {
+  it("invalidates the cache so the next call returns a fresh instance", async () => {
+    const before = await extractFilmTitleCached("Saint Maud");
+    clearTitleCache();
+    const after = await extractFilmTitleCached("Saint Maud");
+    // Same value but different object reference — cache was cleared.
+    expect(after).not.toBe(before);
+    expect(after.filmTitle).toBe(before.filmTitle);
+  });
+});
+
+describe("batchExtractTitles", () => {
+  it("returns a Map keyed by raw title with one entry per unique input", async () => {
+    const result = await batchExtractTitles(["A", "B", "A", "C"]);
+    expect(result.size).toBe(3);
+    expect(result.has("A")).toBe(true);
+    expect(result.has("B")).toBe(true);
+    expect(result.has("C")).toBe(true);
+  });
+
+  it("handles an empty input array", async () => {
+    const result = await batchExtractTitles([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("preserves the original title in each entry's AIExtractionResult", async () => {
+    const result = await batchExtractTitles(["Vertigo", "The Shining"]);
+    expect(result.get("Vertigo")?.filmTitle).toBe("Vertigo");
+    expect(result.get("The Shining")?.filmTitle).toBe("The Shining");
+  });
+
+  it("deduplicates via Set before processing (only one result per unique title)", async () => {
+    const titles = ["A", "A", "A", "A"];
+    const result = await batchExtractTitles(titles);
+    expect(result.size).toBe(1);
+  });
+});


### PR DESCRIPTION
9 cases. Pins case-sensitive cache keys + reference-equality on hits + fresh-instance after clearTitleCache. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)