### PR TITLE
test(stores): add unit tests for runAllStorageMigrations

### DIFF
--- a/changelogs/2026-05-18-migrate-storage-tests.md
+++ b/changelogs/2026-05-18-migrate-storage-tests.md
@@ -1,0 +1,24 @@
+# Add unit tests for runAllStorageMigrations (postboxd → pictures rebrand)
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/stores/utils/migrate-storage.test.ts` (new) — 7 vitest cases using jsdom localStorage.
+
+## Coverage
+- Single-key migration (old → new, old removed)
+- Both-keys-present: prefer NEW, clean up OLD
+- New-key-only: untouched
+- Neither: no-op
+- Batch migration of all 7 configured key pairs
+- Summary log only fires when ≥1 migration occurred (no noise for fresh installs)
+- Idempotent (running twice produces same end state)
+
+## Why
+This module runs on every app boot for users who installed the previous "Postboxd" version and now have the "Pictures" rebrand. A regression that drops a migration loses user data (filter settings, film-status preferences, cookie-consent). A regression that overwrites new with old data downgrades fresh users to stale defaults.
+
+The "prefer NEW when both exist" contract is particularly worth pinning — a flipped precedence would silently lose new-user state.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/stores/utils/migrate-storage.test.ts
+++ b/src/stores/utils/migrate-storage.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for `runAllStorageMigrations` from src/stores/utils/migrate-storage.ts.
+ *
+ * Uses the jsdom global `localStorage` provided by vitest's `environment: jsdom`
+ * config (see vitest.config.ts) — no manual stubs needed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAllStorageMigrations } from "./migrate-storage";
+
+const KEY_PAIRS = [
+  ["postboxd-filters", "pictures-filters"],
+  ["postboxd-preferences", "pictures-preferences"],
+  ["postboxd-film-status", "pictures-film-status"],
+  ["postboxd-discovery", "pictures-discovery"],
+  ["postboxd-cookie-consent", "pictures-cookie-consent"],
+  ["postboxd-reachable", "pictures-reachable"],
+  ["postboxd-festivals", "pictures-festivals"],
+] as const;
+
+describe("runAllStorageMigrations", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("migrates a single old key to the new key when only old key exists", () => {
+    localStorage.setItem("postboxd-filters", "test-data");
+    runAllStorageMigrations();
+    expect(localStorage.getItem("postboxd-filters")).toBeNull();
+    expect(localStorage.getItem("pictures-filters")).toBe("test-data");
+  });
+
+  it("prefers existing new-key data and CLEANS UP the old key when both exist", () => {
+    localStorage.setItem("postboxd-filters", "OLD-data");
+    localStorage.setItem("pictures-filters", "NEW-data");
+    runAllStorageMigrations();
+    // Old removed, new preserved.
+    expect(localStorage.getItem("postboxd-filters")).toBeNull();
+    expect(localStorage.getItem("pictures-filters")).toBe("NEW-data");
+  });
+
+  it("leaves new key untouched when only new key exists", () => {
+    localStorage.setItem("pictures-preferences", "fresh-install-data");
+    runAllStorageMigrations();
+    expect(localStorage.getItem("pictures-preferences")).toBe("fresh-install-data");
+  });
+
+  it("is a no-op when neither key exists", () => {
+    runAllStorageMigrations();
+    expect(localStorage.getItem("postboxd-filters")).toBeNull();
+    expect(localStorage.getItem("pictures-filters")).toBeNull();
+  });
+
+  it("migrates all configured key pairs in a single call", () => {
+    // Seed all old keys with unique sentinel values.
+    for (const [oldKey] of KEY_PAIRS) {
+      localStorage.setItem(oldKey, `data-for-${oldKey}`);
+    }
+
+    runAllStorageMigrations();
+
+    for (const [oldKey, newKey] of KEY_PAIRS) {
+      expect(localStorage.getItem(oldKey)).toBeNull();
+      expect(localStorage.getItem(newKey)).toBe(`data-for-${oldKey}`);
+    }
+  });
+
+  it("only logs a summary when at least one migration occurred", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    runAllStorageMigrations();
+    // No old keys present → no summary log
+    expect(
+      logSpy.mock.calls.some((c) =>
+        String(c[0]).includes("Completed"),
+      ),
+    ).toBe(false);
+
+    logSpy.mockClear();
+    localStorage.setItem("postboxd-filters", "x");
+    runAllStorageMigrations();
+    // Summary log appears
+    expect(
+      logSpy.mock.calls.some((c) =>
+        String(c[0]).includes("Completed 1 migrations"),
+      ),
+    ).toBe(true);
+  });
+
+  it("is idempotent (running twice produces same end state, no errors)", () => {
+    localStorage.setItem("postboxd-cookie-consent", "accepted");
+    runAllStorageMigrations();
+    runAllStorageMigrations();
+    expect(localStorage.getItem("pictures-cookie-consent")).toBe("accepted");
+    expect(localStorage.getItem("postboxd-cookie-consent")).toBeNull();
+  });
+});


### PR DESCRIPTION
7 cases for the postboxd→pictures localStorage migration. Pins 'prefer NEW when both exist' precedence + idempotence. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)