### PR TITLE
test(stores): add unit tests for cookie-consent (PECR/UK-GDPR)

### DIFF
--- a/changelogs/2026-05-18-cookie-consent-tests.md
+++ b/changelogs/2026-05-18-cookie-consent-tests.md
@@ -1,0 +1,26 @@
+# Add unit tests for cookie-consent Zustand store
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/stores/cookie-consent.test.ts` (new) — 9 vitest cases covering all actions + helpers.
+
+## Why
+The cookie-consent store gates analytics tracking under PECR/UK-GDPR. A regression in `canTrack()` either:
+- Tracks users who rejected (legal risk, ICO complaint surface)
+- Doesn't track users who accepted (no analytics data, broken funnel reporting)
+
+The `hasDecided()` predicate controls when the consent banner shows — a regression silently shows the banner to users who already chose.
+
+## Coverage
+- Initial state: 'pending' + null timestamp
+- acceptAnalytics: status + stamped timestamp
+- rejectAnalytics: status + stamped timestamp
+- resetConsent: reverts to pending + null
+- hasDecided: true for accepted/rejected, false for pending
+- **Pinned `canTrack()` contract**: returns true ONLY for 'accepted' (NOT for 'pending', NOT for 'rejected')
+- Persistence: state survives across getState() calls (persist middleware contract)
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/stores/cookie-consent.test.ts
+++ b/src/stores/cookie-consent.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the cookie-consent Zustand store.
+ *
+ * The store uses `persist` middleware backed by localStorage. We clear
+ * localStorage and reset the store state between tests for isolation.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useCookieConsent } from "./cookie-consent";
+
+describe("cookie-consent store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useCookieConsent.setState({
+      analyticsConsent: "pending",
+      consentUpdatedAt: null,
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts in 'pending' state with null timestamp", () => {
+    const s = useCookieConsent.getState();
+    expect(s.analyticsConsent).toBe("pending");
+    expect(s.consentUpdatedAt).toBeNull();
+  });
+
+  it("acceptAnalytics sets status to 'accepted' and stamps consentUpdatedAt", () => {
+    const before = Date.now();
+    useCookieConsent.getState().acceptAnalytics();
+    const after = Date.now();
+
+    const s = useCookieConsent.getState();
+    expect(s.analyticsConsent).toBe("accepted");
+    expect(s.consentUpdatedAt).toBeTruthy();
+
+    const stampedMs = new Date(s.consentUpdatedAt!).getTime();
+    expect(stampedMs).toBeGreaterThanOrEqual(before);
+    expect(stampedMs).toBeLessThanOrEqual(after);
+  });
+
+  it("rejectAnalytics sets status to 'rejected' and stamps consentUpdatedAt", () => {
+    useCookieConsent.getState().rejectAnalytics();
+    const s = useCookieConsent.getState();
+    expect(s.analyticsConsent).toBe("rejected");
+    expect(s.consentUpdatedAt).toBeTruthy();
+  });
+
+  it("resetConsent reverts to 'pending' + null timestamp", () => {
+    useCookieConsent.getState().acceptAnalytics();
+    useCookieConsent.getState().resetConsent();
+
+    const s = useCookieConsent.getState();
+    expect(s.analyticsConsent).toBe("pending");
+    expect(s.consentUpdatedAt).toBeNull();
+  });
+
+  it("hasDecided returns true after accept", () => {
+    useCookieConsent.getState().acceptAnalytics();
+    expect(useCookieConsent.getState().hasDecided()).toBe(true);
+  });
+
+  it("hasDecided returns true after reject", () => {
+    useCookieConsent.getState().rejectAnalytics();
+    expect(useCookieConsent.getState().hasDecided()).toBe(true);
+  });
+
+  it("hasDecided returns false in 'pending' state", () => {
+    expect(useCookieConsent.getState().hasDecided()).toBe(false);
+  });
+
+  it("canTrack returns true ONLY for 'accepted'", () => {
+    expect(useCookieConsent.getState().canTrack()).toBe(false); // pending
+    useCookieConsent.getState().rejectAnalytics();
+    expect(useCookieConsent.getState().canTrack()).toBe(false); // rejected
+    useCookieConsent.getState().acceptAnalytics();
+    expect(useCookieConsent.getState().canTrack()).toBe(true);
+  });
+
+  it("persists analytics consent across getState calls (persist middleware contract)", () => {
+    useCookieConsent.getState().acceptAnalytics();
+    // The 'persist' middleware writes through to localStorage; the next read
+    // sees the persisted value. We verify state survives independent reads.
+    expect(useCookieConsent.getState().analyticsConsent).toBe("accepted");
+    expect(useCookieConsent.getState().canTrack()).toBe(true);
+  });
+});


### PR DESCRIPTION
9 cases. PECR/UK-GDPR-critical store. Pins canTrack() === 'accepted'-only contract. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)