### PR TITLE
test(api): add unit tests for admin/agents/shared helpers

### DIFF
--- a/changelogs/2026-05-18-admin-agents-shared-tests.md
+++ b/changelogs/2026-05-18-admin-agents-shared-tests.md
@@ -1,0 +1,19 @@
+# Add unit tests for admin agent API shared helpers
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/app/api/admin/agents/shared.test.ts` (new) — 7 vitest cases for `geminiKeyMissingResponse` and `agentErrorResponse`.
+
+## Coverage
+- geminiKeyMissingResponse: 200 status, success=false, GEMINI_API_KEY mentioned in error message (greppable in admin UI / Vercel logs)
+- agentErrorResponse: 500 status, structured fields (success, summary, error), 'Unknown error' fallback for non-Error throwables (string/null/undefined)
+- **Pinned log format**: logPrefix is composed as `{prefix} error:` for grepping
+- **Pinned summary format**: `{label} failed` suffix for UI parsing consistency
+
+## Why
+These two helpers normalise the admin agent route error contract — every admin API for /agents/* uses them. A regression in the response shape silently breaks the admin UI's error-state rendering; a regression in the log prefix breaks the CloudWatch dashboards.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/app/api/admin/agents/shared.test.ts
+++ b/src/app/api/admin/agents/shared.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  agentErrorResponse,
+  geminiKeyMissingResponse,
+} from "./shared";
+
+describe("geminiKeyMissingResponse", () => {
+  it("returns a 200 JSON response with success=false", async () => {
+    const res = geminiKeyMissingResponse();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.summary).toBe("Agent not configured");
+  });
+
+  it("error message mentions GEMINI_API_KEY (greppable in admin UI logs)", async () => {
+    const body = await geminiKeyMissingResponse().json();
+    expect(body.error).toMatch(/GEMINI_API_KEY/);
+    expect(body.error).toMatch(/Vercel/);
+  });
+});
+
+describe("agentErrorResponse", () => {
+  it("returns a 500 JSON response with structured fields", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = agentErrorResponse("Test", "Test op", new Error("boom"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.summary).toBe("Test op failed");
+    expect(body.error).toBe("boom");
+  });
+
+  it("falls back to 'Unknown error' for non-Error throwables", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = agentErrorResponse("X", "Y", "string thrown");
+    const body = await res.json();
+    expect(body.error).toBe("Unknown error");
+  });
+
+  it("falls back to 'Unknown error' for null/undefined", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect((await agentErrorResponse("X", "Y", null).json()).error).toBe(
+      "Unknown error",
+    );
+    expect((await agentErrorResponse("X", "Y", undefined).json()).error).toBe(
+      "Unknown error",
+    );
+  });
+
+  it("logs the error with the supplied logPrefix (greppable in CloudWatch)", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("xyz");
+    agentErrorResponse("[admin-agents-links]", "Op", err);
+    expect(spy).toHaveBeenCalledWith("[admin-agents-links] error:", err);
+    spy.mockRestore();
+  });
+
+  it("composes summaryLabel + ' failed' (consistent suffix for UI parsing)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = agentErrorResponse("X", "Enrichment", new Error("e"));
+    expect((await res.json()).summary).toBe("Enrichment failed");
+  });
+});


### PR DESCRIPTION
7 cases. Pins response shape contract, log format, and summary suffix for the admin agent route error helpers. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)