### PR TITLE
test(lib): add unit tests for generateHealthSummary

### DIFF
--- a/changelogs/2026-05-18-scraper-health-alerts-tests.md
+++ b/changelogs/2026-05-18-scraper-health-alerts-tests.md
@@ -1,0 +1,21 @@
+# Add unit tests for generateHealthSummary
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/scraper-health/alerts.test.ts` (new) — 7 vitest cases for `generateHealthSummary`.
+
+## Coverage
+- Header line present
+- ISO timestamp embedded
+- Total/Healthy/Warning/Critical counts on one line
+- Alerts section OMITTED when empty (avoids "Alerts (0)" noise)
+- **Pinned alert-type prefix logic**: `[WARNING]` for warn-types, `[CRITICAL]` for any alertType starting with "critical" (the `alertType.startsWith("critical")` branch)
+- Alerts count header `Alerts (N):` rendered when alerts present
+
+## Why
+The health summary is what gets posted to the Telegram alert channel and dumped into CloudWatch logs when the nightly scraper health check runs. A regression to the count line breaks the alert-dashboard parser; a regression to the [CRITICAL]/[WARNING] prefix breaks human-eye triage at 3am.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/scraper-health/alerts.test.ts
+++ b/src/lib/scraper-health/alerts.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { generateHealthSummary } from "./alerts";
+import type { HealthCheckResult } from "./index";
+
+function makeResult(overrides: Partial<HealthCheckResult> = {}): HealthCheckResult {
+  return {
+    timestamp: new Date("2026-05-18T12:00:00.000Z"),
+    totalCinemas: 10,
+    healthyCinemas: 8,
+    warnCinemas: 1,
+    criticalCinemas: 1,
+    metrics: [],
+    alerts: [],
+    ...overrides,
+  };
+}
+
+describe("generateHealthSummary", () => {
+  it("includes the header line", () => {
+    const out = generateHealthSummary(makeResult());
+    expect(out).toContain("=== Scraper Health Check ===");
+  });
+
+  it("includes the ISO timestamp", () => {
+    const out = generateHealthSummary(makeResult());
+    expect(out).toContain("2026-05-18T12:00:00.000Z");
+  });
+
+  it("includes Total/Healthy/Warning/Critical counts on a single line", () => {
+    const out = generateHealthSummary(
+      makeResult({
+        totalCinemas: 60,
+        healthyCinemas: 50,
+        warnCinemas: 7,
+        criticalCinemas: 3,
+      }),
+    );
+    expect(out).toContain("Total: 60 | Healthy: 50 | Warning: 7 | Critical: 3");
+  });
+
+  it("omits the Alerts section when alerts array is empty", () => {
+    const out = generateHealthSummary(makeResult({ alerts: [] }));
+    expect(out).not.toContain("Alerts");
+  });
+
+  it("renders [WARNING] prefix for warn-type alerts", () => {
+    const out = generateHealthSummary(
+      makeResult({
+        alerts: [
+          {
+            cinemaId: "bfi-southbank",
+            cinemaName: "BFI Southbank",
+            alertType: "warn_stale",
+            message: "BFI Southbank: last scrape 13h ago",
+            hoursSinceLastScrape: 13,
+            screeningsCount: 100,
+          },
+        ],
+      }),
+    );
+    expect(out).toContain("[WARNING] BFI Southbank: last scrape 13h ago");
+  });
+
+  it("renders [CRITICAL] prefix for critical-type alerts (alertType.startsWith('critical'))", () => {
+    const out = generateHealthSummary(
+      makeResult({
+        alerts: [
+          {
+            cinemaId: "rio-dalston",
+            cinemaName: "Rio Dalston",
+            alertType: "critical_no_screenings",
+            message: "Rio Dalston has no screenings",
+            hoursSinceLastScrape: null,
+            screeningsCount: 0,
+          },
+        ],
+      }),
+    );
+    expect(out).toContain("[CRITICAL] Rio Dalston has no screenings");
+  });
+
+  it("renders the alerts count header", () => {
+    const out = generateHealthSummary(
+      makeResult({
+        alerts: [
+          {
+            cinemaId: "a",
+            cinemaName: "A",
+            alertType: "warn_stale",
+            message: "msg1",
+            hoursSinceLastScrape: 13,
+            screeningsCount: 5,
+          },
+          {
+            cinemaId: "b",
+            cinemaName: "B",
+            alertType: "warn_stale",
+            message: "msg2",
+            hoursSinceLastScrape: 14,
+            screeningsCount: 5,
+          },
+        ],
+      }),
+    );
+    expect(out).toContain("Alerts (2):");
+  });
+});

--- a/src/lib/scraper-health/alerts.test.ts
+++ b/src/lib/scraper-health/alerts.test.ts
@@ -50,7 +50,7 @@ describe("generateHealthSummary", () => {
           {
             cinemaId: "bfi-southbank",
             cinemaName: "BFI Southbank",
-            alertType: "warn_stale",
+            alertType: "warning_stale",
             message: "BFI Southbank: last scrape 13h ago",
             hoursSinceLastScrape: 13,
             screeningsCount: 100,
@@ -68,7 +68,7 @@ describe("generateHealthSummary", () => {
           {
             cinemaId: "rio-dalston",
             cinemaName: "Rio Dalston",
-            alertType: "critical_no_screenings",
+            alertType: "critical_volume",
             message: "Rio Dalston has no screenings",
             hoursSinceLastScrape: null,
             screeningsCount: 0,
@@ -86,7 +86,7 @@ describe("generateHealthSummary", () => {
           {
             cinemaId: "a",
             cinemaName: "A",
-            alertType: "warn_stale",
+            alertType: "warning_stale",
             message: "msg1",
             hoursSinceLastScrape: 13,
             screeningsCount: 5,
@@ -94,7 +94,7 @@ describe("generateHealthSummary", () => {
           {
             cinemaId: "b",
             cinemaName: "B",
-            alertType: "warn_stale",
+            alertType: "warning_stale",
             message: "msg2",
             hoursSinceLastScrape: 14,
             screeningsCount: 5,


### PR DESCRIPTION
7 cases pinning the Telegram-alert summary format used at 3am triage. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)