### PR TITLE
test(lib): add unit tests for tmdb/match pure helpers

### DIFF
--- a/changelogs/2026-05-18-tmdb-match-pure-fns-tests.md
+++ b/changelogs/2026-05-18-tmdb-match-pure-fns-tests.md
@@ -1,0 +1,19 @@
+# Add unit tests for pure helpers in tmdb/match.ts
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/lib/tmdb/match-pure-fns.test.ts` (new) — 14 cases for `isRepertoryFilm` + `getDecade`.
+
+## Why
+`isRepertoryFilm` drives the "REPERTORY / NEW RELEASE" badge on every film card AND the programming-type filter pipe. A regression flips repertory labels across the calendar (false-positive: new releases show as repertory; false-negative: classics show as new).
+
+`getDecade` powers the decade filter chips.
+
+## Coverage
+- isRepertoryFilm: undefined/empty → false, current/last-year → false, 2+ years old → true; yyyy-MM-dd format; year-only string; NaN-year fallback to false
+- getDecade: year-0/year-9 of decade, millennium boundary, pre-1900
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/lib/tmdb/match-pure-fns.test.ts
+++ b/src/lib/tmdb/match-pure-fns.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the pure helper functions in src/lib/tmdb/match.ts.
+ *
+ * Skips the big `matchTitle` function — it has DB + ambiguity + Levenshtein
+ * dependencies and warrants its own integration tests. This file covers
+ * the small standalone helpers only.
+ */
+import { describe, expect, it } from "vitest";
+import { getDecade, isRepertoryFilm } from "./match";
+
+describe("isRepertoryFilm", () => {
+  it("returns false for undefined release date", () => {
+    expect(isRepertoryFilm(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isRepertoryFilm("")).toBe(false);
+  });
+
+  it("returns true for clearly old films (e.g. 1958 Vertigo)", () => {
+    expect(isRepertoryFilm("1958-05-09")).toBe(true);
+  });
+
+  it("returns false for current-year films", () => {
+    const thisYear = new Date().getFullYear();
+    expect(isRepertoryFilm(`${thisYear}-01-01`)).toBe(false);
+  });
+
+  it("returns false for last-year films (within the 2-year cutoff)", () => {
+    const lastYear = new Date().getFullYear() - 1;
+    expect(isRepertoryFilm(`${lastYear}-06-01`)).toBe(false);
+  });
+
+  it("parses year from yyyy-MM-dd format (slices at first '-')", () => {
+    // The implementation does `releaseDate.split("-")[0]` → first token only.
+    expect(isRepertoryFilm("1980-12-31")).toBe(true);
+  });
+
+  it("handles year-only strings", () => {
+    expect(isRepertoryFilm("1980")).toBe(true);
+  });
+
+  it("returns false for unparseable date strings (NaN year)", () => {
+    // parseInt("garbage", 10) → NaN, NaN < anything → false.
+    expect(isRepertoryFilm("not-a-date")).toBe(false);
+  });
+});
+
+describe("getDecade", () => {
+  it("formats 1958 as '1950s'", () => {
+    expect(getDecade(1958)).toBe("1950s");
+  });
+
+  it("formats 2024 as '2020s'", () => {
+    expect(getDecade(2024)).toBe("2020s");
+  });
+
+  it("formats year-0 of a decade correctly (1980 → 1980s)", () => {
+    expect(getDecade(1980)).toBe("1980s");
+  });
+
+  it("formats year-9 of a decade correctly (1989 → 1980s)", () => {
+    expect(getDecade(1989)).toBe("1980s");
+  });
+
+  it("handles edge of millennium (2000 → 2000s)", () => {
+    expect(getDecade(2000)).toBe("2000s");
+  });
+
+  it("handles years before 1900 (1899 → 1890s)", () => {
+    expect(getDecade(1899)).toBe("1890s");
+  });
+});


### PR DESCRIPTION
14 cases for isRepertoryFilm + getDecade. Drives repertory badge + decade filter. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)