### PR TITLE
test(stores): add unit tests for discovery (onboarding) store

### DIFF
--- a/changelogs/2026-05-18-discovery-store-tests.md
+++ b/changelogs/2026-05-18-discovery-store-tests.md
@@ -1,0 +1,24 @@
+# Add unit tests for discovery Zustand store
+
+**PR**: TBD
+**Date**: 2026-05-18
+
+## Changes
+- `src/stores/discovery.test.ts` (new) — 9 cases for the discovery / onboarding-banner store.
+
+## Coverage
+- Default state (both flags false, dismissedAt null)
+- markFeatureVisited sets only the specified flag
+- dismissBanner stamps ISO timestamp
+- shouldShowBanner: true initially, false after both features visited, true with only one, false after manual dismissal
+- resetDiscovery reverts to defaults
+
+## Why
+This store gates the onboarding banner that introduces the Reachable and Map features. A regression that flips the shouldShowBanner logic either:
+- Hides the banner from new users (no discovery → no engagement)
+- Shows it forever to existing users (annoyance / repeat dismissals)
+
+The "EITHER visit both OR dismiss" precedence is what makes the banner feel non-naggy — pinned by the test.
+
+## Changelog deferral note
+Per #523-#530.

--- a/src/stores/discovery.test.ts
+++ b/src/stores/discovery.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useDiscovery } from "./discovery";
+
+describe("discovery store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useDiscovery.getState().resetDiscovery();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts with both features unvisited and banner not dismissed", () => {
+    const s = useDiscovery.getState();
+    expect(s.hasVisitedReachable).toBe(false);
+    expect(s.hasVisitedMap).toBe(false);
+    expect(s.bannerDismissedAt).toBeNull();
+  });
+
+  it("markFeatureVisited('reachable') sets only that flag", () => {
+    useDiscovery.getState().markFeatureVisited("reachable");
+    const s = useDiscovery.getState();
+    expect(s.hasVisitedReachable).toBe(true);
+    expect(s.hasVisitedMap).toBe(false);
+  });
+
+  it("markFeatureVisited('map') sets only that flag", () => {
+    useDiscovery.getState().markFeatureVisited("map");
+    const s = useDiscovery.getState();
+    expect(s.hasVisitedMap).toBe(true);
+    expect(s.hasVisitedReachable).toBe(false);
+  });
+
+  it("dismissBanner stamps an ISO timestamp", () => {
+    const before = Date.now();
+    useDiscovery.getState().dismissBanner();
+    const after = Date.now();
+    const stamped = useDiscovery.getState().bannerDismissedAt;
+    expect(stamped).toBeTruthy();
+    const ms = new Date(stamped!).getTime();
+    expect(ms).toBeGreaterThanOrEqual(before);
+    expect(ms).toBeLessThanOrEqual(after);
+  });
+
+  it("shouldShowBanner returns true initially", () => {
+    expect(useDiscovery.getState().shouldShowBanner()).toBe(true);
+  });
+
+  it("shouldShowBanner returns false after BOTH features visited (auto-hide)", () => {
+    useDiscovery.getState().markFeatureVisited("reachable");
+    useDiscovery.getState().markFeatureVisited("map");
+    expect(useDiscovery.getState().shouldShowBanner()).toBe(false);
+  });
+
+  it("shouldShowBanner still TRUE when only one feature visited", () => {
+    useDiscovery.getState().markFeatureVisited("reachable");
+    expect(useDiscovery.getState().shouldShowBanner()).toBe(true);
+  });
+
+  it("shouldShowBanner returns false after manual dismissal (even without visiting features)", () => {
+    useDiscovery.getState().dismissBanner();
+    expect(useDiscovery.getState().shouldShowBanner()).toBe(false);
+  });
+
+  it("resetDiscovery reverts to default state", () => {
+    useDiscovery.getState().markFeatureVisited("reachable");
+    useDiscovery.getState().dismissBanner();
+    useDiscovery.getState().resetDiscovery();
+    const s = useDiscovery.getState();
+    expect(s.hasVisitedReachable).toBe(false);
+    expect(s.bannerDismissedAt).toBeNull();
+  });
+});


### PR DESCRIPTION
9 cases. Pins shouldShowBanner precedence for onboarding UX. Deferred-changelog per #523-#530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)