### PR TITLE
feat(data-check): 5 dirty-title detectors + cinema-drop watcher

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -100,6 +100,14 @@
 
 ---
 
+## 2026-05-19: data-check.ts — 5 new dirty-title + scraper-health detectors
+**PR**: #568 | **Files**: `scripts/data-check.ts`
+- Adds 5 new issue types to the patrol's `crossReferenceDb` pass: `dirty_title_html_entity` (score 50), `dirty_title_event_prefix` (40), `dirty_title_all_caps` (35), `dirty_title_format_suffix` (35), `suspicious_orphan_film` (22).
+- Adds 1 global cycle-start detector: `cinema_screening_drop` (score 65) — flags cinemas whose 14-day upcoming count is <50% of 14-day rolling average (degraded scrapers).
+- All six surface issues the patrol's existing auto-fix loop can act on (decode entities, smart-title-case, strip prefix, reclassify event, investigate scraper). Pre-existing rows previously missed by the at-scrape `cleanFilmTitle` pipeline now surface within one patrol cycle.
+
+---
+
 ## 2026-05-18: Catch-up batch — RECENT_CHANGES entries for session test-coverage PRs
 **PR**: TBD | **Files**: `RECENT_CHANGES.md`
 - Adds canonical RECENT_CHANGES entries for the 6 test-coverage PRs (#521, #523, #524, #525, #526, #528) shipped earlier in the session that deliberately omitted the top-of-file entry to avoid the rebase-conflict cascade caused by multiple open PRs editing line 1.

--- a/changelogs/2026-05-19-data-check-new-detectors.md
+++ b/changelogs/2026-05-19-data-check-new-detectors.md
@@ -1,0 +1,38 @@
+# data-check.ts — 5 new dirty-title + scraper-health detectors
+
+**PR**: TBD
+**Date**: 2026-05-19
+
+## Changes
+
+Added six new issue types to `scripts/data-check.ts` so the patrol surfaces problems the at-scrape `cleanFilmTitle` pipeline misses on pre-existing DB rows.
+
+### Per-film detections (run inside the existing batch loop)
+
+| Issue type | Impact score | Severity | Detection |
+| ---------- | ------------ | -------- | --------- |
+| `dirty_title_html_entity` | 50 | high | Title contains an undecoded HTML entity (`&amp;`, `&rsquo;`, `&#nnn;`, etc.) |
+| `dirty_title_event_prefix` | 40 | high | Title contains a `X presents:` event prefix |
+| `dirty_title_all_caps` | 35 | medium | Title is entirely uppercase (with at least 4 consecutive caps) |
+| `dirty_title_format_suffix` | 35 | medium | Title ends in `(35mm)`, `(70mm)`, `(IMAX)`, `(Q&A)`, `(VHS SCREENING)`, `(sing-along)`, etc. — these belong on `screening.format` |
+| `suspicious_orphan_film` | 22 | medium | Film has exactly one future screening AND no TMDB ID — likely scrape error or misclassified event |
+
+### Global cycle-start detection (runs once when cursor is null)
+
+| Issue type | Impact score | Severity | Detection |
+| ---------- | ------------ | -------- | --------- |
+| `cinema_screening_drop` | 65 | high | Cinema's 14-day upcoming count is <50% of 14-day rolling average (computed from `scraped_at`-grouped daily counts) — surfaces degraded scrapers automatically |
+
+Each issue includes a `metadata.suggestedFix` string (`decode-html-entities`, `smart-title-case`, `strip-event-prefix`, `strip-format-suffix`, `investigate-or-reclassify`, `investigate-scraper`) so the patrol's auto-fix loop can route to the right handler.
+
+## Impact
+
+- **Production data**: 26 dirty titles in the DB at session start were already cleaned by a parallel one-off script. These detectors ensure the next dirty-title batch (from new scrapes) is caught within one patrol cycle, not lost in the noise.
+- **Cinema-drop detection**: previously the patrol had no signal for "this scraper is silently broken" until a scraper-health agent ran separately. The new global check makes the patrol the single source of scraper-degradation alerts.
+- **Suspicious-orphan flag**: surfaces ~50 films per cycle that are statistically likely scrape errors (1 future screening + no TMDB match). Patrol can investigate or reclassify without manually digging through 1,100+ future films.
+
+## Testing
+
+- Typecheck (`npx tsc --noEmit`) clean.
+- Lint (`npx eslint`) clean for new code (1 pre-existing `any` warning at line 1828 unrelated to this change).
+- Standalone verifier script confirmed all 5 per-film detectors and the global cinema-drop SQL run correctly against the live DB.

--- a/scripts/data-check.ts
+++ b/scripts/data-check.ts
@@ -292,21 +292,35 @@ const IMPACT_SCORES: Record<string, number> = {
   known_wrong_tmdb: 80,
   suspect_wrong_tmdb: 70,
   broken_booking_url: 60,
+  cinema_screening_drop: 65,
   screening_not_on_website: 65,
   screening_time_mismatch: 45,
   duplicate_screening: 50,
+  dirty_title_html_entity: 50,
   suspect_non_film: 45,
+  dirty_title_event_prefix: 40,
   missing_tmdb: 40,
   missing_poster: 35,
+  dirty_title_all_caps: 35,
+  dirty_title_format_suffix: 35,
   wrong_repertory_tag: 30,
   wrong_new_tag: 30,
   needs_tmdb_backfill: 25,
+  suspicious_orphan_film: 22,
   missing_synopsis: 20,
   missing_cast: 15,
   missing_year: 15,
   missing_letterboxd: 12,
   needs_letterboxd_rating: 10,
 };
+
+// ── New detection regexes for dirty-title detection ───────────────────
+// Format-suffix detection is on a deliberate allowlist — these are formats
+// that should be stored as `screening.format`, never appended to the film title.
+const DIRTY_FORMAT_SUFFIX_RE = /\((?:35mm|70mm|16mm|IMAX|Q&A|with intro|VHS SCREENING|preview|sing[- ]?along)\)\s*$/i;
+const DIRTY_HTML_ENTITY_RE = /&(?:amp|quot|nbsp|hellip|mdash|ndash|rsquo|lsquo|apos|#\d+);/;
+const DIRTY_ALL_CAPS_RE = /^[A-Z0-9\s\-:.,'!?&()'’–—\/#]+$/u;
+const DIRTY_EVENT_PREFIX_RE = /\s+presents\s*:/i;
 
 function severityFromScore(score: number): SeverityTier {
   if (score >= 70) return "critical";
@@ -887,6 +901,132 @@ async function crossReferenceDb(
         filmTitle: dbFilm.title,
         description: "Film has TMDB ID but no cast members",
       });
+    }
+
+    // Dirty-title detection — surfaces issues for the patrol's auto-fix loop.
+    // Each check is *additional* to the existing at-scrape `cleanFilmTitle`
+    // pipeline; these catch pre-existing rows that pipeline missed.
+    if (DIRTY_HTML_ENTITY_RE.test(dbFilm.title)) {
+      rawIssues.push({
+        type: "dirty_title_html_entity",
+        filmId: dbFilm.id,
+        filmTitle: dbFilm.title,
+        description: "Title contains undecoded HTML entity (&amp;, &rsquo;, &#nnn;, etc.)",
+        metadata: { suggestedFix: "decode-html-entities" },
+      });
+    }
+    // ALL CAPS detection — only flag multi-word ALL CAPS titles >= 10 chars.
+    // Skips stylized single words (DUNE, BLADE, BOUND, WALL-E) and short
+    // multi-word titles (STAR WARS, MIB 3). Real dirty rows are virtually
+    // always 10+ chars with a space (e.g. "MY NAME IS MONDAY: A NIGHT...").
+    if (
+      DIRTY_ALL_CAPS_RE.test(dbFilm.title) &&
+      /[A-Z]{4,}/.test(dbFilm.title) &&
+      !/[a-z]/.test(dbFilm.title) &&
+      dbFilm.title.length >= 10 &&
+      /\s/.test(dbFilm.title)
+    ) {
+      rawIssues.push({
+        type: "dirty_title_all_caps",
+        filmId: dbFilm.id,
+        filmTitle: dbFilm.title,
+        description: "Title is ALL CAPS — should be smart-title-cased (preserving acronyms)",
+        metadata: { suggestedFix: "smart-title-case" },
+      });
+    }
+    if (DIRTY_EVENT_PREFIX_RE.test(dbFilm.title)) {
+      rawIssues.push({
+        type: "dirty_title_event_prefix",
+        filmId: dbFilm.id,
+        filmTitle: dbFilm.title,
+        description: "Title contains a 'X presents:' event prefix that should be stripped",
+        metadata: { suggestedFix: "strip-event-prefix" },
+      });
+    }
+    if (DIRTY_FORMAT_SUFFIX_RE.test(dbFilm.title)) {
+      rawIssues.push({
+        type: "dirty_title_format_suffix",
+        filmId: dbFilm.id,
+        filmTitle: dbFilm.title,
+        description: "Title ends in a format suffix that belongs on screening.format, not the title",
+        metadata: { suggestedFix: "strip-format-suffix" },
+      });
+    }
+  }
+
+  // ── Suspicious-orphan detection (single screening + no TMDB) ──────────
+  // Films with exactly one future screening AND no TMDB match are statistically
+  // likely to be scrape errors (one-off mistitled entries) rather than legitimate
+  // rare bookings. Flag for review — never auto-delete.
+  if (batchFilms.length > 0) {
+    const ids = batchFilms.map(f => f.id);
+    const orphans = await sql<Array<{ film_id: string; cnt: number }>>`
+      SELECT film_id, COUNT(*)::int AS cnt
+      FROM screenings
+      WHERE film_id = ANY(${ids}::text[]) AND datetime >= ${now}::timestamptz
+      GROUP BY film_id HAVING COUNT(*) = 1
+    `;
+    const orphanIds = new Set(orphans.map(o => o.film_id));
+    for (const dbFilm of batchFilms) {
+      if (!orphanIds.has(dbFilm.id)) continue;
+      if (dbFilm.tmdb_id) continue;
+      if (dbFilm.content_type !== "film") continue;
+      rawIssues.push({
+        type: "suspicious_orphan_film",
+        filmId: dbFilm.id,
+        filmTitle: dbFilm.title,
+        description: "Single future screening AND no TMDB ID — likely scrape error or event misclassified as film",
+        metadata: { screeningCount: 1, suggestedFix: "investigate-or-reclassify" },
+      });
+    }
+  }
+
+  // ── Cinema-screening-drop detection (global, once per run) ────────────
+  // Detect cinemas whose upcoming-screening count is < 50% of the 7-day rolling
+  // average (computed from screenings.scraped_at). Indicates a degraded scraper.
+  // Only runs on the first batch of each cycle to avoid duplicate reporting.
+  if (!cursor.cursorFilmTitle) {
+    try {
+      const drops = await sql<Array<{ cinema_id: string; cinema_name: string; current_cnt: number; avg_cnt: number; drop_pct: number }>>`
+        WITH current_count AS (
+          SELECT cinema_id, COUNT(*)::int AS cnt FROM screenings
+          WHERE datetime >= NOW() AND datetime < NOW() + INTERVAL '14 days'
+          GROUP BY cinema_id
+        ),
+        baseline_count AS (
+          SELECT cinema_id, AVG(daily_cnt) AS avg_cnt FROM (
+            SELECT cinema_id, DATE(scraped_at) AS day, COUNT(*)::int AS daily_cnt
+            FROM screenings
+            WHERE scraped_at >= NOW() - INTERVAL '14 days'
+              AND scraped_at < NOW() - INTERVAL '1 day'
+              AND datetime >= scraped_at AND datetime < scraped_at + INTERVAL '14 days'
+            GROUP BY cinema_id, DATE(scraped_at)
+          ) x
+          GROUP BY cinema_id HAVING COUNT(*) >= 3
+        )
+        SELECT c.id AS cinema_id, c.name AS cinema_name,
+               COALESCE(cc.cnt, 0) AS current_cnt,
+               ROUND(bc.avg_cnt)::int AS avg_cnt,
+               ROUND(100 * (1 - COALESCE(cc.cnt, 0)::numeric / bc.avg_cnt), 1)::float AS drop_pct
+        FROM cinemas c
+        JOIN baseline_count bc ON bc.cinema_id = c.id
+        LEFT JOIN current_count cc ON cc.cinema_id = c.id
+        WHERE c.is_active = TRUE
+          AND bc.avg_cnt >= 5
+          AND COALESCE(cc.cnt, 0) < bc.avg_cnt * 0.5
+        ORDER BY drop_pct DESC
+      `;
+      for (const d of drops) {
+        rawIssues.push({
+          type: "cinema_screening_drop",
+          filmId: "", // not film-scoped
+          filmTitle: `${d.cinema_name} (cinema-wide)`,
+          description: `${d.cinema_name}: ${d.current_cnt} upcoming screenings vs 7-day avg ${d.avg_cnt} (${d.drop_pct.toFixed(0)}% drop) — scraper likely degraded`,
+          metadata: { cinemaId: d.cinema_id, currentCount: d.current_cnt, avgCount: d.avg_cnt, dropPct: d.drop_pct, suggestedFix: "investigate-scraper" },
+        });
+      }
+    } catch (e) {
+      console.error("cinema_screening_drop detection failed:", e);
     }
   }
 


### PR DESCRIPTION
## Summary
Adds six new issue types to `scripts/data-check.ts` so the patrol surfaces problems the at-scrape `cleanFilmTitle` pipeline misses on pre-existing DB rows.

**Per-film detections** (inside existing batch loop):
- `dirty_title_html_entity` (50) — undecoded `&amp;`, `&rsquo;`, `&#nnn;`
- `dirty_title_event_prefix` (40) — `X presents:` patterns
- `dirty_title_all_caps` (35) — multi-word ALL CAPS ≥10 chars (guards against DUNE/BLADE/WALL-E)
- `dirty_title_format_suffix` (35) — `(35mm)`/`(70mm)`/`(IMAX)`/`(Q&A)`
- `suspicious_orphan_film` (22) — single future screening + no TMDB ID

**Global cycle-start detection** (runs once when cursor is null):
- `cinema_screening_drop` (65) — cinema's 14d count <50% of 14d rolling avg

Each detector includes `metadata.suggestedFix` so the patrol's auto-fix loop can route on it.

## Why
Found during a 9hr autonomous quality-cleanup run: 26 dirty titles were sitting in production unnoticed because they were scraped *before* the relevant `EVENT_PREFIXES`/`decodeHtmlEntities` patterns existed. The patrol had no signal to surface them — only fresh scrape failures got reported. These detectors close that loop.

The `cinema_screening_drop` detector also gives the patrol its first scraper-degradation signal (previously a separate agent's job).

## Code review fixes applied
- ALL CAPS regex now requires length ≥10 + space, so it skips stylized single words (DUNE, BLADE, BOUND, WALL-E, STAR WARS) — 21/21 test cases pass.
- Cinema-drop SQL switched to LEFT JOIN + COALESCE so cinemas going N→0 (the worst case) aren't silently excluded.
- Added `#` to ALL CAPS char class so titles like "NICKELFEST #1" are caught.

## Test plan
- [x] `npx tsc --noEmit` clean (only pre-existing `.next/types` stubs)
- [x] `npx eslint scripts/data-check.ts` clean for new code (1 pre-existing `any` warning unrelated)
- [x] `npm run test:run` — 1580 passed
- [x] Standalone verifier confirms all 6 detectors fire correctly on live DB
- [x] ALL CAPS false-positive regression test: 21/21 cases pass
- [ ] Next patrol run will exercise these end-to-end in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)