### PR TITLE
feat(scrape): film-title-cleaner — regex non-film entries

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -117,6 +117,14 @@
 
 ---
 
+## 2026-05-19: film-title-cleaner — regex non-film entries (parity with data-check)
+**PR**: #570 | **Files**: `src/scrapers/utils/film-title-cleaner.ts`, `src/scrapers/utils/film-title-cleaner.test.ts`
+- Extends `getKnownNonFilmType` to support `{ regex: true, pattern: "<re>" }` entries in `knownNonFilmTitles`. Previously only exact-match worked, even though data-check's `buildNonFilmMatchers` already accepted both shapes — closing the gap so scraper-time classification matches patrol-time detection.
+- New exported helper `getKnownNonFilmTypeFromEntries(title, entries)` is the pure matching function (testable without the learnings file); `getKnownNonFilmType` is now a thin wrapper that loads + delegates.
+- 8 new vitest cases pin: empty entries, exact-match insensitivity, regex patterns, default `"event"` fallback, custom `live_broadcast` types, exact-wins-over-regex ordering, malformed-regex silent skip, and entries lacking both title and pattern.
+
+---
+
 ## 2026-05-18: Catch-up batch — RECENT_CHANGES entries for session test-coverage PRs
 **PR**: TBD | **Files**: `RECENT_CHANGES.md`
 - Adds canonical RECENT_CHANGES entries for the 6 test-coverage PRs (#521, #523, #524, #525, #526, #528) shipped earlier in the session that deliberately omitted the top-of-file entry to avoid the rebase-conflict cascade caused by multiple open PRs editing line 1.

--- a/changelogs/2026-05-19-cleaner-regex-non-film.md
+++ b/changelogs/2026-05-19-cleaner-regex-non-film.md
@@ -1,0 +1,31 @@
+# film-title-cleaner: support regex non-film entries (parity with data-check)
+
+**PR**: TBD
+**Date**: 2026-05-19
+
+## Changes
+
+Extends `getKnownNonFilmType` in `src/scrapers/utils/film-title-cleaner.ts` to support **regex** entries in `knownNonFilmTitles`, not just exact-match. Closes a gap where data-check's `buildNonFilmMatchers` already supported both shapes (`scripts/data-check.ts:367`) but the scraper-time classifier could only do exact-match.
+
+### What changed
+- `KnownNonFilm` interface gained `regex?: boolean` and `pattern?: string` fields (mirrors the shape data-check expects).
+- New exported helper `getKnownNonFilmTypeFromEntries(title, entries)` — pure matching function, testable without the learnings file.
+- `getKnownNonFilmType(title)` now delegates to `getKnownNonFilmTypeFromEntries` after loading the learnings file. Same external API, expanded matching.
+- 8 new vitest cases cover: empty/null entries, exact-match case-insensitivity, regex pattern matching, default `"event"` type fallback, `live_broadcast` and custom type preservation, exact-wins-over-regex ordering, silent skip on malformed regex, ignoring entries lacking both title and pattern.
+
+### Behaviour
+
+Before: scrapers could only auto-classify titles whose **exact** literal appeared in `knownNonFilmTitles`. Variable-format events ("Cafés philo anglais" vs "Cafe philo en français"; "NICKELFEST #1 - DAY ONE" vs "NICKELFEST #1 - DAY TWO") had to be enumerated as individual exact entries.
+
+After: a single regex entry like `{ regex: true, pattern: "^caf[eé]s? philo", type: "event" }` covers the whole family. Data-check already supported this shape; the scraper now matches.
+
+## Impact
+
+- **Scraper-side classification consistency** — the patrol can now write a regex entry to learnings and the next scrape will apply it at write time, not just at patrol time. Closes the loop documented in `.claude/rules/scrapers.md`.
+- **Fewer dirty rows at source** — pattern families like Cine Lumière's café-philo/baby-comptines programming (currently scraped as `content_type='film'`) will be classified correctly on next scrape after a single regex entry is added.
+- **Pure function makes testing safer** — `getKnownNonFilmTypeFromEntries` can be invoked directly with controlled inputs; no file-system mocking needed.
+
+## Testing
+- `npx tsc --noEmit` clean
+- `npx eslint` clean for new code
+- `npm run test:run` — 1588 passed (was 1580, +8 new in this PR)

--- a/src/scrapers/utils/film-title-cleaner.test.ts
+++ b/src/scrapers/utils/film-title-cleaner.test.ts
@@ -4,6 +4,7 @@ import {
   cleanFilmTitleWithMetadata,
   EVENT_PREFIXES,
   extractEnglishFromBracket,
+  getKnownNonFilmTypeFromEntries,
 } from "./film-title-cleaner";
 
 describe("cleanFilmTitle", () => {
@@ -460,5 +461,76 @@ describe("learnings.json integration (smoke)", () => {
     expect(cleanFilmTitle("Some Film That Isn't Stripped")).toBe(
       "Some Film That Isn't Stripped"
     );
+  });
+});
+
+describe("getKnownNonFilmTypeFromEntries", () => {
+  it("returns null when entries is empty or undefined", () => {
+    expect(getKnownNonFilmTypeFromEntries("Anything", undefined)).toBeNull();
+    expect(getKnownNonFilmTypeFromEntries("Anything", null)).toBeNull();
+    expect(getKnownNonFilmTypeFromEntries("Anything", [])).toBeNull();
+  });
+
+  it("matches exact title case-insensitively", () => {
+    const entries = [{ title: "The Big Ritzy Quiz", type: "event", exact: true }];
+    expect(getKnownNonFilmTypeFromEntries("The Big Ritzy Quiz", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("the big ritzy quiz", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("THE BIG RITZY QUIZ", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("The Big Ritzy", entries)).toBeNull();
+  });
+
+  it("matches regex pattern entries (mirrors data-check buildNonFilmMatchers)", () => {
+    const entries = [
+      { regex: true, pattern: "^caf[eé]s? philo", type: "event" },
+      { regex: true, pattern: "^baby comptines\\b", type: "event" },
+      { regex: true, pattern: "^nickelfest #\\d+", type: "event" },
+    ];
+    expect(getKnownNonFilmTypeFromEntries("Cafés philo anglais", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("Cafe philo en français", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("Baby Comptines 10/06/2026", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("NICKELFEST #1 - DAY ONE", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("Nickelfest #2 - Three Day Pass!", entries)).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("Something Else Entirely", entries)).toBeNull();
+  });
+
+  it("returns 'event' as default type when type field is missing", () => {
+    expect(getKnownNonFilmTypeFromEntries("X", [{ title: "X" }])).toBe("event");
+    expect(getKnownNonFilmTypeFromEntries("y", [{ regex: true, pattern: "^y$" }])).toBe("event");
+  });
+
+  it("preserves live_broadcast and other custom types", () => {
+    const entries = [
+      { title: "The Playboy of the Western World", type: "live_broadcast", exact: true },
+      { regex: true, pattern: "^andre rieu", type: "live_broadcast" },
+    ];
+    expect(getKnownNonFilmTypeFromEntries("The Playboy of the Western World", entries)).toBe("live_broadcast");
+    expect(getKnownNonFilmTypeFromEntries("Andre Rieu's 2026 Summer Concert", entries)).toBe("live_broadcast");
+  });
+
+  it("checks exact entries before regex entries", () => {
+    // If both an exact and a regex entry would match, exact wins.
+    const entries = [
+      { title: "Cafés philo anglais", type: "event", exact: true },
+      { regex: true, pattern: "^cafés? philo", type: "live_broadcast" },
+    ];
+    // Exact entry comes first in iteration, returns 'event' — regex never runs.
+    expect(getKnownNonFilmTypeFromEntries("Cafés philo anglais", entries)).toBe("event");
+  });
+
+  it("silently skips entries with malformed regex without breaking subsequent matches", () => {
+    const entries = [
+      { regex: true, pattern: "[invalid(regex", type: "event" }, // malformed
+      { regex: true, pattern: "^valid pattern$", type: "live_broadcast" },
+    ];
+    expect(getKnownNonFilmTypeFromEntries("valid pattern", entries)).toBe("live_broadcast");
+  });
+
+  it("ignores entries lacking both title and pattern", () => {
+    const entries = [
+      { type: "event" }, // neither title nor pattern
+      { exact: true, type: "event" }, // exact without title
+      { regex: true, type: "event" }, // regex without pattern
+    ];
+    expect(getKnownNonFilmTypeFromEntries("anything", entries)).toBeNull();
   });
 });

--- a/src/scrapers/utils/film-title-cleaner.ts
+++ b/src/scrapers/utils/film-title-cleaner.ts
@@ -23,9 +23,16 @@ import { resolve } from "node:path";
 // init of EVENT_PREFIXES below) -------------------------------------------------
 
 interface KnownNonFilm {
-  title: string;
-  type?: "event" | "live_broadcast" | string;
+  /** Literal title to match (case-insensitive when `exact: true`). */
+  title?: string;
+  /** Discriminator: when true, treat `pattern` as a regex source string. */
+  regex?: boolean;
+  /** Regex source string (used when `regex: true`). Compiled with case-insensitive flag. */
+  pattern?: string;
+  /** When true, match `title` exactly (case-insensitive). */
   exact?: boolean;
+  /** Content type to assign on match. Defaults to "event". */
+  type?: "event" | "live_broadcast" | string;
 }
 
 interface Learnings {
@@ -283,25 +290,58 @@ export const EVENT_PREFIXES = [
 const LEARNED_SUFFIX_REGEXES = loadLearnedSuffixRegexes();
 
 /**
- * Look up a known non-film title in the data-check learnings file. Returns
- * the recorded `content_type` (e.g. "event", "live_broadcast") when the title
- * matches exactly (case-insensitive), or `null` when it doesn't.
+ * Pure matching function — public for testability.
  *
- * Used by the pipeline to set the correct content_type BEFORE attempting film
- * resolution — avoids creating film rows for quiz nights, placeholders, and
- * recurring music events.
+ * Mirrors data-check's `buildNonFilmMatchers` so the scraper-time
+ * classification and patrol-time detection use the same rules.
+ *
+ *   - Exact (case-insensitive) literal match when entry has `title` and not `regex`.
+ *   - Regex match when entry has `regex: true` and `pattern: "<re-source>"`.
  */
-export function getKnownNonFilmType(title: string): string | null {
-  const data = loadLearnings();
-  if (!data?.knownNonFilmTitles?.length) return null;
+export function getKnownNonFilmTypeFromEntries(
+  title: string,
+  entries: KnownNonFilm[] | undefined | null,
+): string | null {
+  if (!entries?.length) return null;
   const norm = title.trim().toLowerCase();
-  for (const entry of data.knownNonFilmTitles) {
+  // Exact-match pass first (faster, deterministic).
+  for (const entry of entries) {
     if (!entry?.title) continue;
+    if (entry.regex) continue; // regex entries are handled below
     if (entry.title.trim().toLowerCase() === norm) {
       return entry.type ?? "event";
     }
   }
+  // Regex-match pass. Compile inline — caller is expected to be either the
+  // test path (small entry counts) or the cached scraper path below.
+  for (const entry of entries) {
+    if (!entry?.regex || !entry.pattern) continue;
+    try {
+      const re = new RegExp(entry.pattern, "i");
+      if (re.test(title)) return entry.type ?? "event";
+    } catch {
+      // Bad regex in learnings — skip silently rather than break all scrapes.
+    }
+  }
   return null;
+}
+
+/**
+ * Look up a known non-film title in the data-check learnings file. Returns
+ * the recorded `content_type` (e.g. "event", "live_broadcast") when the title
+ * matches, or `null` when it doesn't.
+ *
+ * Used by the pipeline to set the correct content_type BEFORE attempting film
+ * resolution — avoids creating film rows for quiz nights, placeholders, and
+ * recurring music events.
+ *
+ * Now supports BOTH exact-match and regex entries — see
+ * `getKnownNonFilmTypeFromEntries` for the matching contract. The previous
+ * implementation only handled exact-match, which left a gap vs. data-check.
+ */
+export function getKnownNonFilmType(title: string): string | null {
+  const data = loadLearnings();
+  return getKnownNonFilmTypeFromEntries(title, data?.knownNonFilmTitles);
 }
 
 /** Boolean convenience wrapper around getKnownNonFilmType. */


### PR DESCRIPTION
## Summary
Extends `getKnownNonFilmType` in `src/scrapers/utils/film-title-cleaner.ts` to support **regex** entries in `knownNonFilmTitles`, not just exact-match.

Closes a documented gap:
- `scripts/data-check.ts:367` (`buildNonFilmMatchers`) already supported `{ regex: true, pattern: ... }` entries.
- `src/scrapers/utils/film-title-cleaner.ts` (`getKnownNonFilmType`) supported exact-match only.

Patrol-time detection and scrape-time classification now use the same matching contract.

## Why
Variable-format events at the same venue (Cine Lumière's "Cafés philo anglais" / "Cafe philo en français"; Nickel's "NICKELFEST #1 - DAY ONE" / "DAY TWO" / "THREE DAY PASS!") previously had to be enumerated as individual exact entries. A single regex entry like `{ regex: true, pattern: "^caf[eé]s? philo", type: "event" }` now covers the whole family.

## Refactor
- `KnownNonFilm` interface: added `regex?: boolean` and `pattern?: string` fields.
- New exported `getKnownNonFilmTypeFromEntries(title, entries)` — the pure matching function. Testable without the learnings file.
- `getKnownNonFilmType(title)` is now a thin wrapper: load learnings, delegate. Same external API.

## Tests
8 new vitest cases cover: empty/null entries, exact-match insensitivity, regex patterns, default \`event\` fallback, custom \`live_broadcast\` types, exact-wins-over-regex ordering, malformed-regex silent skip, entries lacking both title and pattern.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean for new code
- [x] \`npm run test:run\` — 1588 passed (was 1580, +8 new)
- [ ] After merge: add regex entries to \`.claude/data-check-learnings.json\` (dev-only) for the recurring Cine Lumière event families

🤖 Generated with [Claude Code](https://claude.com/claude-code)