### PR TITLE
feat(search): pure query parser + 49 Vitest fixtures (step 3/10)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,16 @@
+## 2026-05-19: cmd+k step 3 — Pure query parser + 49 Vitest fixtures
+**PR**: TBD | **Files**: `frontend/src/lib/search/parse-query.ts` (new, 610 LOC), `frontend/src/lib/search/parse-query.test.ts` (new, 49 cases), `frontend/src/lib/search/vocab/*.ts` (8 dictionaries), `frontend/vitest.config.ts` (new), `frontend/package.json` (+ vitest)
+- Step 3 of the cmd+k plan: pure, dependency-free query parser tokenises `"horror tonight at curzon"` etc. into a structured `ParsedIntent` for the upcoming palette UI to feed back into `filters.applyIntent()`.
+- Vocab dictionaries: formats, genres, decades, countries, languages, chains + cinema aliases (PCC, ICA, BFI), certifications (U/PG/12/12A/15/18), specials (rep, subs, relaxed, premiere, watchlist, nearby), time presets + literals.
+- Multi-word phrase scan runs before single-token lookups: "this weekend", "next saturday", "70mm imax", "uk premiere", "want to see", "prince charles".
+- Date math is London-tz aware via `Intl.DateTimeFormat('en-GB', {timeZone: 'Europe/London'})` — matches the existing `filters.setDatePreset` pattern. `now` is injected (not read from `Date.now()`) so Vitest snapshots are deterministic.
+- Added `vitest` (4.1.6) as frontend devDep — first unit-test runner in `frontend/` (Playwright remains for E2E). `npm test` runs the suite.
+- 49 cases cover: empty/whitespace, plain freeText, all 10 date phrases, time presets + literals + after/before, all format aliases, sci-fi genre mappings, decades + countries + language priority, cinema chains + slug aliases, all special flags, composite queries ("subtitled french noir 80s"), chip ordering, dedup.
+
+---
+
 ## 2026-05-19: cmd+k step 2 — RRF API + title-only search_text (typo tolerance)
-**PR**: TBD | **Files**: `src/app/api/films/search/route.ts`, `src/db/migrations/0013_search_text_title_only.sql` (new)
+**PR**: #572 | **Files**: `src/app/api/films/search/route.ts`, `src/db/migrations/0013_search_text_title_only.sql` (new)
 - Step 2 of the cmd+k plan: replaces ILIKE with Reciprocal Rank Fusion (k=60) over `search_tsv` + `search_text` from migration 0012. Adds recency boost (1-week decay on next upcoming screening) + popularity boost (`0.02·ln(1+tmdb_popularity)`).
 - Fans out 5 parallel queries via `Promise.all` so the new global palette gets films + cinemas + screenings + festivals + seasons in one round-trip. Response shape preserves `{ results, cinemas }` for the existing inline SearchInput and extends with `screenings`, `festivals`, `seasons`.
 - Migration 0013 trims `search_text` to **title-only** (cinemas: name-only). Migration 0012 included `title + original_title + directors` which bloated the string and dropped trigram similarity for typos like "amelei" vs "Amélie" from 0.4 to 0.07 (below the 0.3 `%` threshold). Title-only restores fuzzy match. `original_title` and `directors` are still searched lexically via tsvector A/B weights.

--- a/changelogs/2026-05-19-cmdk-query-parser.md
+++ b/changelogs/2026-05-19-cmdk-query-parser.md
@@ -1,0 +1,80 @@
+# cmd+k step 3 — Pure query parser + Vitest fixtures
+
+**PR**: TBD
+**Date**: 2026-05-19
+**Branch**: `feat/cmdk-palette-step3-parser`
+
+## Context
+
+Step 3 of `tasks/cmdk-palette-plan.md`. Builds the structured-intent layer that sits between the user's typed query and the existing `filters.applyIntent()` / new `/api/films/search` filters. The parser is pure (no external deps, `now` injected) and produces `ParsedIntent` — what the palette UI will read to render chips and apply filters.
+
+## Architecture
+
+```
+"horror tonight at curzon"
+        │
+        ▼
+   parseQuery(input, now)              ← pure, ~610 LOC
+        │
+        ▼
+   ParsedIntent {
+     freeText: "at",                   ← unconsumed tokens
+     genres: ["horror"],
+     chainTokens: ["Curzon"],
+     dateFrom: 2026-05-13T23:00Z,
+     timeFrom: 18,
+     chipDescriptors: [
+       { id: "date:tonight", ... },
+       { id: "genre:horror", ... },
+       { id: "chain:Curzon", ... },
+     ],
+   }
+```
+
+`freeText` goes into the server tsvector/trigram match. `chipDescriptors` drive the visible chips inside the palette input (step 5). Filter fields feed `filters.applyIntent()` for the calendar mutate-behind-the-modal magic (step 8).
+
+## What's included
+
+| Vocab dictionary | Source of truth |
+|---|---|
+| `formats.ts` | `FORMAT_OPTIONS` in `$lib/constants/filters.ts` (35mm, 70mm, IMAX laser, Dolby, 4DX) |
+| `genres.ts` | TMDB lowercase ("horror", "science fiction", "noir") + sci-fi/scifi aliases + "kids" → family |
+| `decades.ts` | `DECADES` constant; "20s" defaults to 1920s (cinema convention) |
+| `countries.ts` + `languages.ts` | TMDB country names ("france", "japan"); country wins over language for "french" |
+| `chains.ts` | Curzon / Picturehouse / Everyman / BFI / Vue / Cineworld / Odeon + slug aliases PCC, ICA, BFI Southbank/IMAX |
+| `certifications.ts` | BBFC: U, PG, 12, 12A, 15, 18, R18 |
+| `specials.ts` | rep, subs, relaxed, premiere (+ premiereType), watchlist, seen, nearby |
+| `time.ts` | TIME_PRESETS aligned with `$lib/constants/filters.ts` |
+
+## Parser passes
+
+1. **Multi-word phrases** (longest-match-first scan over the token list):
+   - Dates: "this weekend", "next weekend", "this week", "next week", "next [monday..sunday]"
+   - Times: "late night", "after Npm", "before Npm" (pair scan, not phrase scan)
+   - Premieres: "world premiere", "uk premiere", "european premiere", "international premiere"
+   - Watchlist: "want to see", "to watch", "to see"
+   - Genres: "sci fi", "science fiction"
+   - Formats: "70mm imax", "imax laser", "dolby atmos", "35 mm"
+   - Cinema aliases: "prince charles", "bfi southbank", "bfi imax"
+
+2. **Single-token dictionaries** in priority order: bare day names → time presets → hour literals → formats → genres → decades → countries (wins over languages) → languages → cinema chains → cinema slugs → certifications → specials
+
+3. **Leftovers** become `freeText` (preserves original casing for downstream tsvector match)
+
+## Date math
+
+London-timezone aware via `Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/London' })`. Matches the existing `filters.setDatePreset` pattern in `frontend/src/lib/stores/filters.svelte.ts:167`. DST is handled because we compute the offset per-instant from `Intl.DateTimeFormat` with `timeZoneName: 'shortOffset'`.
+
+## Verification
+
+- `npm test` (new) — 49 / 49 cases pass
+- `npx svelte-check` — 0 errors (2 pre-existing warnings unchanged)
+- Pure function: no `Date.now()`, no global state, no I/O. Vitest snapshots are deterministic across CI runs.
+
+## Why no chrono-node
+
+The user constraint is "no new paid services, prefer in-process FOSS". chrono-node is FOSS but ~80KB and overkill for our 4 temporal phrases. The hand-rolled parser is ~80 lines of date logic and stays well under our bundle budget. If we ever need full natural-language temporal parsing ("the second Thursday of next month"), we revisit.
+
+## Next
+
+Step 4: palette store (`palette.svelte.ts`) and global cmd+k binding. The store will own `query`, `parsed = $derived(parseQuery(query, new Date(nowTick)))`, results, selectedIndex.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,16 +8,11 @@
 			"name": "pictures-london",
 			"version": "0.0.1",
 			"dependencies": {
-				"@formkit/auto-animate": "^0.9.0",
 				"@sveltejs/adapter-vercel": "^6.3.3",
-				"bits-ui": "^2.16.5",
 				"clsx": "^2.1.0",
-				"date-fns": "^4.1.0",
 				"maplibre-gl": "^5.21.1",
 				"posthog-js": "^1.0.0",
 				"svelte-clerk": "^1.1.1",
-				"svelte-maplibre": "^1.3.0",
-				"tailwind-merge": "^3.5.0",
 				"web-vitals": "^5.2.0"
 			},
 			"devDependencies": {
@@ -30,16 +25,17 @@
 				"svelte-check": "^4.4.2",
 				"tailwindcss": "^4.0.0",
 				"typescript": "^6.0.3",
-				"vite": "^8.0.10"
+				"vite": "^8.0.10",
+				"vitest": "^4.1.6"
 			}
 		},
 		"node_modules/@clerk/backend": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.3.0.tgz",
-			"integrity": "sha512-6KuOaIig4CQPSn23I7xExkGKKi2rE2PEH3mvhnA41fktv3LqtPSifRb0xjmJEAwSZwJ8QY6uzk/jDccNof2eUA==",
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.4.7.tgz",
+			"integrity": "sha512-zAELfaYtrlxlxxB6PT3EHPsHck6IPuyTQSKm7hWQqXp9GoFOM6wKOflFZgI0Q2M1C5SgrkDcrMNchkWXRwbsQw==",
 			"license": "MIT",
 			"dependencies": {
-				"@clerk/shared": "^4.8.3",
+				"@clerk/shared": "^4.10.2",
 				"standardwebhooks": "^1.0.0",
 				"tslib": "2.8.1"
 			},
@@ -48,13 +44,13 @@
 			}
 		},
 		"node_modules/@clerk/shared": {
-			"version": "4.8.3",
-			"resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.3.tgz",
-			"integrity": "sha512-HZViZBCTfOR2OreSBDMXcIRPgYiiYCE+GCCPrpjq/ZPcA6OsGiRCIQgUoGgGdAoFgr6Hk0TT00hnVK7g0qRKqQ==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.10.2.tgz",
+			"integrity": "sha512-2RXGaCV94U2wYWaMQZA/AhVkqjcSx8f+oVjh6wgr4yXDmZ24BQRjPJ+K4L6IHiB/agoaXtKWJ0GI8InRZjo9/g==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/query-core": "5.90.16",
+				"@tanstack/query-core": "^5.100.6",
 				"dequal": "2.0.3",
 				"glob-to-regexp": "0.4.1",
 				"js-cookie": "3.0.5",
@@ -107,45 +103,446 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@floating-ui/core": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"cpu": [
+				"ppc64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/utils": "^0.2.11"
-			}
-		},
-		"node_modules/@floating-ui/dom": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/core": "^1.7.5",
-				"@floating-ui/utils": "^0.2.11"
-			}
-		},
-		"node_modules/@floating-ui/utils": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-			"license": "MIT"
-		},
-		"node_modules/@formkit/auto-animate": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-0.9.0.tgz",
-			"integrity": "sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==",
-			"license": "MIT"
-		},
-		"node_modules/@internationalized/date": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
-			"integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
-			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
 			"peer": true,
-			"dependencies": {
-				"@swc/helpers": "^0.5.0"
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@isaacs/fs-minipass": {
@@ -241,9 +638,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@mapbox/tiny-sdf": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
-			"integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+			"integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/@mapbox/unitbezier": {
@@ -282,9 +679,9 @@
 			}
 		},
 		"node_modules/@maplibre/maplibre-gl-style-spec": {
-			"version": "24.8.1",
-			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
-			"integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+			"version": "24.8.5",
+			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
+			"integrity": "sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==",
 			"license": "ISC",
 			"dependencies": {
 				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
@@ -292,7 +689,6 @@
 				"json-stringify-pretty-compact": "^4.0.0",
 				"minimist": "^1.2.8",
 				"quickselect": "^3.0.0",
-				"rw": "^1.3.3",
 				"tinyqueue": "^3.0.0"
 			},
 			"bin": {
@@ -458,12 +854,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
-			"integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+			"integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.0",
+				"@opentelemetry/core": "2.7.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -474,9 +870,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
-			"integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+			"integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -587,31 +983,31 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -627,18 +1023,18 @@
 			"license": "MIT"
 		},
 		"node_modules/@posthog/core": {
-			"version": "1.27.5",
-			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.5.tgz",
-			"integrity": "sha512-sYCcUDuYKumYTjwGqGCPT8aUy086v9PKw5wD+UXCRSfCsxWy5R/ic6W13kGTn4O5B2cD1V19wJv19oIH5kHUiQ==",
+			"version": "1.29.5",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.5.tgz",
+			"integrity": "sha512-Jm5AE95EwBRqO6J8+skDufyf5rnEcmOvjYArCKCOzD4mWdH1xGpfcRXj5TEyZII3mD04Kr7pw9aP2ZbAHQGu2A==",
 			"license": "MIT",
 			"dependencies": {
-				"@posthog/types": "1.372.1"
+				"@posthog/types": "1.374.2"
 			}
 		},
 		"node_modules/@posthog/types": {
-			"version": "1.372.1",
-			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.1.tgz",
-			"integrity": "sha512-yl2x2HgtdhFk8bvf6HuRSDzXnKmKGrzNxUahKvA/0mcwheweINvmWy5MsN55NevrcCrNXA6m8GPHS9o/y1mn4A==",
+			"version": "1.374.2",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.374.2.tgz",
+			"integrity": "sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==",
 			"license": "MIT"
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -654,9 +1050,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
@@ -666,13 +1062,12 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
+				"@protobufjs/aspromise": "^1.1.1"
 			}
 		},
 		"node_modules/@protobufjs/float": {
@@ -682,9 +1077,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -700,15 +1095,15 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+			"integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -722,9 +1117,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+			"integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
 			"cpu": [
 				"arm64"
 			],
@@ -738,9 +1133,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+			"integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
 			"cpu": [
 				"x64"
 			],
@@ -754,9 +1149,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+			"integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
 			"cpu": [
 				"x64"
 			],
@@ -770,9 +1165,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+			"integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
 			"cpu": [
 				"arm"
 			],
@@ -786,9 +1181,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+			"integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
 			"cpu": [
 				"arm64"
 			],
@@ -802,9 +1197,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+			"integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
 			"cpu": [
 				"arm64"
 			],
@@ -818,9 +1213,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+			"integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -834,9 +1229,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+			"integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -850,9 +1245,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+			"integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
 			"cpu": [
 				"x64"
 			],
@@ -866,9 +1261,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+			"integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
 			"cpu": [
 				"x64"
 			],
@@ -882,9 +1277,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+			"integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -898,9 +1293,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+			"integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -916,9 +1311,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+			"integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
 			"cpu": [
 				"arm64"
 			],
@@ -932,9 +1327,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+			"integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
 			"cpu": [
 				"x64"
 			],
@@ -948,9 +1343,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -1480,9 +1875,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.58.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
-			"integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
+			"version": "2.60.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
+			"integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
@@ -1490,7 +1885,7 @@
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -1521,9 +1916,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.0.0.tgz",
-			"integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
+			"integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.3.1",
@@ -1539,60 +1934,50 @@
 				"vite": "^8.0.0-beta.7 || ^8.0.0"
 			}
 		},
-		"node_modules/@swc/helpers": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-			"integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.8.0"
-			}
-		},
 		"node_modules/@tailwindcss/node": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-			"integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+			"integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.5",
-				"enhanced-resolve": "^5.19.0",
+				"enhanced-resolve": "^5.21.0",
 				"jiti": "^2.6.1",
 				"lightningcss": "1.32.0",
 				"magic-string": "^0.30.21",
 				"source-map-js": "^1.2.1",
-				"tailwindcss": "4.2.4"
+				"tailwindcss": "4.3.0"
 			}
 		},
 		"node_modules/@tailwindcss/oxide": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-			"integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+			"integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20"
 			},
 			"optionalDependencies": {
-				"@tailwindcss/oxide-android-arm64": "4.2.4",
-				"@tailwindcss/oxide-darwin-arm64": "4.2.4",
-				"@tailwindcss/oxide-darwin-x64": "4.2.4",
-				"@tailwindcss/oxide-freebsd-x64": "4.2.4",
-				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-				"@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-				"@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-				"@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-				"@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-				"@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-				"@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-				"@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+				"@tailwindcss/oxide-android-arm64": "4.3.0",
+				"@tailwindcss/oxide-darwin-arm64": "4.3.0",
+				"@tailwindcss/oxide-darwin-x64": "4.3.0",
+				"@tailwindcss/oxide-freebsd-x64": "4.3.0",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+				"@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+				"@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-android-arm64": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-			"integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+			"integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
 			"cpu": [
 				"arm64"
 			],
@@ -1607,9 +1992,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-arm64": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-			"integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+			"integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1624,9 +2009,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-x64": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-			"integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+			"integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
 			"cpu": [
 				"x64"
 			],
@@ -1641,9 +2026,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-freebsd-x64": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-			"integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+			"integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1658,9 +2043,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-			"integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+			"integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
 			"cpu": [
 				"arm"
 			],
@@ -1675,9 +2060,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-			"integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+			"integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1692,9 +2077,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-			"integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+			"integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1709,9 +2094,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-			"integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+			"integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1726,9 +2111,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-			"integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+			"integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
 			"cpu": [
 				"x64"
 			],
@@ -1743,9 +2128,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-			"integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+			"integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
 			"bundleDependencies": [
 				"@napi-rs/wasm-runtime",
 				"@emnapi/core",
@@ -1761,10 +2146,10 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "^1.8.1",
-				"@emnapi/runtime": "^1.8.1",
-				"@emnapi/wasi-threads": "^1.1.0",
-				"@napi-rs/wasm-runtime": "^1.1.1",
+				"@emnapi/core": "^1.10.0",
+				"@emnapi/runtime": "^1.10.0",
+				"@emnapi/wasi-threads": "^1.2.1",
+				"@napi-rs/wasm-runtime": "^1.1.4",
 				"@tybys/wasm-util": "^0.10.1",
 				"tslib": "^2.8.1"
 			},
@@ -1773,9 +2158,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-			"integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+			"integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1790,9 +2175,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-			"integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+			"integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
 			"cpu": [
 				"x64"
 			],
@@ -1807,24 +2192,24 @@
 			}
 		},
 		"node_modules/@tailwindcss/vite": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
-			"integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+			"integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tailwindcss/node": "4.2.4",
-				"@tailwindcss/oxide": "4.2.4",
-				"tailwindcss": "4.2.4"
+				"@tailwindcss/node": "4.3.0",
+				"@tailwindcss/oxide": "4.3.0",
+				"tailwindcss": "4.3.0"
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
 		"node_modules/@tanstack/query-core": {
-			"version": "5.90.16",
-			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
-			"integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+			"version": "5.100.11",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.11.tgz",
+			"integrity": "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -1832,13 +2217,24 @@
 			}
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
 			}
 		},
 		"node_modules/@types/cookie": {
@@ -1847,10 +2243,17 @@
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"license": "MIT"
 		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/geojson": {
@@ -1859,22 +2262,13 @@
 			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
 			"license": "MIT"
 		},
-		"node_modules/@types/leaflet": {
-			"version": "1.9.21",
-			"resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
-			"integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/geojson": "*"
-			}
-		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/@types/supercluster": {
@@ -1916,6 +2310,129 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+			"integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.6",
+				"@vitest/utils": "4.1.6",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.6",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/mocker/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+			"integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+			"integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.6",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+			"integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.6",
+				"@vitest/utils": "4.1.6",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+			"integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+			"integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.6",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/abbrev": {
@@ -1966,6 +2483,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/async-sema": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
@@ -1999,40 +2526,26 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"node_modules/bits-ui": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.18.0.tgz",
-			"integrity": "sha512-GLOBZRVy3hxNHIQ2MpD/+5aK9KcBFZRhUJtZ1UDABXdlVR4K6zFpgt4T+Rwuhf2sQzlc6yK1q/DprHPjwT4Pjw==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/core": "^1.7.1",
-				"@floating-ui/dom": "^1.7.1",
-				"esm-env": "^1.1.2",
-				"runed": "^0.35.1",
-				"svelte-toolbelt": "^0.10.6",
-				"tabbable": "^6.2.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/huntabyte"
-			},
-			"peerDependencies": {
-				"@internationalized/date": "^3.8.1",
-				"svelte": "^5.33.0"
-			}
-		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chokidar": {
@@ -2078,6 +2591,13 @@
 				"node": "^14.18.0 || >=16.10.0"
 			}
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -2096,40 +2616,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
-			}
-		},
-		"node_modules/d3-array": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-			"license": "ISC",
-			"dependencies": {
-				"internmap": "1 - 2"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-geo": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2.5.0 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/date-fns": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/debug": {
@@ -2177,15 +2663,15 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-			"integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-			"integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+			"version": "3.4.5",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -2198,9 +2684,9 @@
 			"license": "ISC"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-			"integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+			"version": "5.21.5",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.5.tgz",
+			"integrity": "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2211,6 +2697,56 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.0",
+				"@esbuild/android-arm": "0.28.0",
+				"@esbuild/android-arm64": "0.28.0",
+				"@esbuild/android-x64": "0.28.0",
+				"@esbuild/darwin-arm64": "0.28.0",
+				"@esbuild/darwin-x64": "0.28.0",
+				"@esbuild/freebsd-arm64": "0.28.0",
+				"@esbuild/freebsd-x64": "0.28.0",
+				"@esbuild/linux-arm": "0.28.0",
+				"@esbuild/linux-arm64": "0.28.0",
+				"@esbuild/linux-ia32": "0.28.0",
+				"@esbuild/linux-loong64": "0.28.0",
+				"@esbuild/linux-mips64el": "0.28.0",
+				"@esbuild/linux-ppc64": "0.28.0",
+				"@esbuild/linux-riscv64": "0.28.0",
+				"@esbuild/linux-s390x": "0.28.0",
+				"@esbuild/linux-x64": "0.28.0",
+				"@esbuild/netbsd-arm64": "0.28.0",
+				"@esbuild/netbsd-x64": "0.28.0",
+				"@esbuild/openbsd-arm64": "0.28.0",
+				"@esbuild/openbsd-x64": "0.28.0",
+				"@esbuild/openharmony-arm64": "0.28.0",
+				"@esbuild/sunos-x64": "0.28.0",
+				"@esbuild/win32-arm64": "0.28.0",
+				"@esbuild/win32-ia32": "0.28.0",
+				"@esbuild/win32-x64": "0.28.0"
+			}
+		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -2218,9 +2754,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esrap": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
-			"integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
+			"version": "2.2.9",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+			"integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2239,6 +2775,16 @@
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
 			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
 			"license": "MIT"
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/fast-sha256": {
 			"version": "1.3.0",
@@ -2338,21 +2884,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/inline-style-parser": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
-			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-			"license": "MIT"
-		},
-		"node_modules/internmap": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -2363,9 +2894,9 @@
 			}
 		},
 		"node_modules/jiti": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"bin": {
@@ -2387,16 +2918,10 @@
 			"integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
 			"license": "MIT"
 		},
-		"node_modules/just-compare": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/just-compare/-/just-compare-2.3.0.tgz",
-			"integrity": "sha512-6shoR7HDT+fzfL3gBahx1jZG3hWLrhPAf+l7nCwahDdT9XDtosB9kIF0ZrzUp5QY8dJWfQVr5rnsPqsbvflDzg==",
-			"license": "MIT"
-		},
 		"node_modules/kdbush": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-			"integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+			"integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
 			"license": "ISC"
 		},
 		"node_modules/kleur": {
@@ -2670,21 +3195,12 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
-			}
-		},
-		"node_modules/lz-string": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-			"license": "MIT",
-			"bin": {
-				"lz-string": "bin/bin.js"
 			}
 		},
 		"node_modules/magic-string": {
@@ -2807,9 +3323,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -2896,6 +3412,13 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/pbf": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
@@ -2927,13 +3450,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2946,9 +3469,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2958,26 +3481,10 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/pmtiles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-3.2.1.tgz",
-			"integrity": "sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@types/leaflet": "^1.9.8",
-				"fflate": "^0.8.0"
-			}
-		},
-		"node_modules/pmtiles/node_modules/fflate": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-			"license": "MIT"
-		},
 		"node_modules/postcss": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2994,7 +3501,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -3003,9 +3510,9 @@
 			}
 		},
 		"node_modules/posthog-js": {
-			"version": "1.372.1",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.1.tgz",
-			"integrity": "sha512-gP316wDc36YbieIEW48wfB6wq2ugBNQc+XwNkewN9QRPzhitX+9dG6lUjqHEhMx3A2Y41HjbZf5Vl0Ll0ju8UA==",
+			"version": "1.374.2",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.374.2.tgz",
+			"integrity": "sha512-6z1xGlVocd3NmSZlJNFfpedLIHLcejuuQPxvrpHDvtyVI9tN1NPqbM7T7coXw2It6gdZ/nAgDuZkNxfIut+Spw==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
@@ -3013,8 +3520,8 @@
 				"@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
 				"@opentelemetry/resources": "^2.2.0",
 				"@opentelemetry/sdk-logs": "^0.208.0",
-				"@posthog/core": "1.27.5",
-				"@posthog/types": "1.372.1",
+				"@posthog/core": "1.29.5",
+				"@posthog/types": "1.374.2",
 				"core-js": "^3.38.1",
 				"dompurify": "^3.3.2",
 				"fflate": "^0.4.8",
@@ -3030,9 +3537,9 @@
 			"license": "ISC"
 		},
 		"node_modules/preact": {
-			"version": "10.29.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
-			"integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+			"version": "10.29.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+			"integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -3040,24 +3547,24 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+			"integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/codegen": "^2.0.5",
 				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"long": "^5.3.2"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -3114,13 +3621,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+			"integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.127.0",
-				"@rolldown/pluginutils": "1.0.0-rc.17"
+				"@oxc-project/types": "=0.130.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -3129,52 +3636,22 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+				"@rolldown/binding-android-arm64": "1.0.1",
+				"@rolldown/binding-darwin-arm64": "1.0.1",
+				"@rolldown/binding-darwin-x64": "1.0.1",
+				"@rolldown/binding-freebsd-x64": "1.0.1",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.1",
+				"@rolldown/binding-linux-arm64-musl": "1.0.1",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.1",
+				"@rolldown/binding-linux-x64-gnu": "1.0.1",
+				"@rolldown/binding-linux-x64-musl": "1.0.1",
+				"@rolldown/binding-openharmony-arm64": "1.0.1",
+				"@rolldown/binding-wasm32-wasi": "1.0.1",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.1",
+				"@rolldown/binding-win32-x64-msvc": "1.0.1"
 			}
-		},
-		"node_modules/runed": {
-			"version": "0.35.1",
-			"resolved": "https://registry.npmjs.org/runed/-/runed-0.35.1.tgz",
-			"integrity": "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==",
-			"funding": [
-				"https://github.com/sponsors/huntabyte",
-				"https://github.com/sponsors/tglide"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"dequal": "^2.0.3",
-				"esm-env": "^1.0.0",
-				"lz-string": "^1.5.0"
-			},
-			"peerDependencies": {
-				"@sveltejs/kit": "^2.21.0",
-				"svelte": "^5.7.0"
-			},
-			"peerDependenciesMeta": {
-				"@sveltejs/kit": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/rw": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/sade": {
 			"version": "1.8.1",
@@ -3190,9 +3667,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -3206,6 +3683,13 @@
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
 			"integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
 			"license": "MIT"
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
@@ -3230,6 +3714,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/standardwebhooks": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -3246,15 +3737,6 @@
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
 			"license": "MIT"
 		},
-		"node_modules/style-to-object": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
-			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
-			"license": "MIT",
-			"dependencies": {
-				"inline-style-parser": "0.2.7"
-			}
-		},
 		"node_modules/supercluster": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -3265,9 +3747,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.5",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-			"integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+			"version": "5.55.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.8.tgz",
+			"integrity": "sha512-4D6lyrMHmDaZalQOEBMCWCCidyZjSnec14/oPn0k627G6goxcck9xqMwz1tFLlQz+ZFvtTTHfFOlUayuAz0z6Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -3279,7 +3761,7 @@
 				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
 				"esrap": "^2.2.4",
 				"is-reference": "^3.0.3",
@@ -3292,9 +3774,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.6.tgz",
-			"integrity": "sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
+			"integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3316,13 +3798,13 @@
 			}
 		},
 		"node_modules/svelte-clerk": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/svelte-clerk/-/svelte-clerk-1.1.5.tgz",
-			"integrity": "sha512-ZsZws/dJpMabWKPLNmgZ/9LO93F3+AlgVOFPPLn6zaI5ByNhDhXd+V4seMpxqG+3tsUwaBJb0blWFLFxTM5VWQ==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/svelte-clerk/-/svelte-clerk-1.1.8.tgz",
+			"integrity": "sha512-peLqw8TUf2RDF1bojjIYaIl689VfC/9qBBxC138L67EErsNoC9wQyWhvorUvcYi7TNm8s7vb/ekh4ecWM+n8vQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@clerk/backend": "3.3.0",
-				"@clerk/shared": "4.8.3",
+				"@clerk/backend": "3.4.7",
+				"@clerk/shared": "4.10.2",
 				"set-cookie-parser": "^3.0.1"
 			},
 			"peerDependencies": {
@@ -3335,80 +3817,10 @@
 				}
 			}
 		},
-		"node_modules/svelte-maplibre": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/svelte-maplibre/-/svelte-maplibre-1.3.0.tgz",
-			"integrity": "sha512-p54dzfzWGiv0gwosxOMksLz7b9pJqPBJXi7MFebrvcnRZtO4H9efkb2bqSjXLY15oLcb5Be06siRXVdKDlMc9Q==",
-			"license": "MIT",
-			"dependencies": {
-				"d3-geo": "^3.1.0",
-				"dequal": "^2.0.3",
-				"just-compare": "^2.3.0",
-				"maplibre-gl": "^4.0.0 || ^5.0.1",
-				"pmtiles": "^3.0.3"
-			},
-			"peerDependencies": {
-				"@deck.gl/core": "^9",
-				"@deck.gl/layers": "^9",
-				"@deck.gl/mapbox": "^9",
-				"svelte": "^5.0.0",
-				"topojson-client": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@deck.gl/core": {
-					"optional": true
-				},
-				"@deck.gl/layers": {
-					"optional": true
-				},
-				"@deck.gl/mapbox": {
-					"optional": true
-				},
-				"topojson-client": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/svelte-toolbelt": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.10.6.tgz",
-			"integrity": "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==",
-			"funding": [
-				"https://github.com/sponsors/huntabyte"
-			],
-			"dependencies": {
-				"clsx": "^2.1.1",
-				"runed": "^0.35.1",
-				"style-to-object": "^1.0.8"
-			},
-			"engines": {
-				"node": ">=18",
-				"pnpm": ">=8.7.0"
-			},
-			"peerDependencies": {
-				"svelte": "^5.30.2"
-			}
-		},
-		"node_modules/tabbable": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
-			"license": "MIT"
-		},
-		"node_modules/tailwind-merge": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-			"integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/dcastil"
-			}
-		},
 		"node_modules/tailwindcss": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-			"integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+			"integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3427,9 +3839,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-			"integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+			"version": "7.5.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
@@ -3438,6 +3850,23 @@
 				"minizlib": "^3.1.0",
 				"yallist": "^5.0.0"
 			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
@@ -3463,6 +3892,16 @@
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
 			"integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
 			"license": "ISC"
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
 		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
@@ -3500,21 +3939,21 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "8.0.10",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+			"version": "8.0.13",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+			"integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.10",
-				"rolldown": "1.0.0-rc.17",
+				"postcss": "^8.5.14",
+				"rolldown": "1.0.1",
 				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
@@ -3531,7 +3970,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
+				"@vitejs/devtools": "^0.1.18",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -3615,6 +4054,103 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.6",
+				"@vitest/mocker": "4.1.6",
+				"@vitest/pretty-format": "4.1.6",
+				"@vitest/runner": "4.1.6",
+				"@vitest/snapshot": "4.1.6",
+				"@vitest/spy": "4.1.6",
+				"@vitest/utils": "4.1.6",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.6",
+				"@vitest/browser-preview": "4.1.6",
+				"@vitest/browser-webdriverio": "4.1.6",
+				"@vitest/coverage-istanbul": "4.1.6",
+				"@vitest/coverage-v8": "4.1.6",
+				"@vitest/ui": "4.1.6",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/web-vitals": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
@@ -3635,6 +4171,23 @@
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.58.2",
@@ -21,7 +23,8 @@
 		"svelte-check": "^4.4.2",
 		"tailwindcss": "^4.0.0",
 		"typescript": "^6.0.3",
-		"vite": "^8.0.10"
+		"vite": "^8.0.10",
+		"vitest": "^4.1.6"
 	},
 	"dependencies": {
 		"@sveltejs/adapter-vercel": "^6.3.3",

--- a/frontend/src/lib/search/parse-query.test.ts
+++ b/frontend/src/lib/search/parse-query.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Parse-query test suite — 40 fixtures covering every token category
+ * and the multi-word phrase precedence rules.
+ *
+ * `NOW` is a fixed reference instant (Wednesday 14 May 2026, 12:00 UTC
+ * = 13:00 BST in London). All temporal assertions are computed from
+ * this anchor.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseQuery } from "./parse-query";
+
+// Wednesday 14 May 2026 13:00 BST (12:00 UTC). London is in BST in May.
+const NOW = new Date("2026-05-14T12:00:00Z");
+
+function isoDate(d?: Date): string | undefined {
+  return d?.toISOString();
+}
+
+describe("parseQuery — empty & freeText", () => {
+  it("returns empty intent for empty string", () => {
+    const r = parseQuery("", NOW);
+    expect(r.freeText).toBe("");
+    expect(r.formats).toEqual([]);
+    expect(r.genres).toEqual([]);
+    expect(r.chipDescriptors).toEqual([]);
+  });
+
+  it("returns empty intent for whitespace", () => {
+    const r = parseQuery("   ", NOW);
+    expect(r.freeText).toBe("");
+  });
+
+  it("passes a plain title through as freeText", () => {
+    const r = parseQuery("Kurosawa", NOW);
+    expect(r.freeText).toBe("Kurosawa");
+    expect(r.chipDescriptors).toEqual([]);
+  });
+
+  it("passes multi-word title through as freeText", () => {
+    const r = parseQuery("Wes Anderson", NOW);
+    expect(r.freeText).toBe("Wes Anderson");
+  });
+});
+
+describe("parseQuery — dates", () => {
+  it("'tonight' sets today 00:00 → tomorrow 00:00 with timeFrom 18", () => {
+    const r = parseQuery("tonight", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-13T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-14T23:00:00.000Z");
+    expect(r.timeFrom).toBe(18);
+    expect(r.freeText).toBe("");
+    expect(r.chipDescriptors.find((c) => c.id === "date:tonight")).toBeDefined();
+  });
+
+  it("'today' sets today's date range", () => {
+    const r = parseQuery("today", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-13T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-14T23:00:00.000Z");
+    expect(r.timeFrom).toBeUndefined();
+  });
+
+  it("'tomorrow' sets next day's date range", () => {
+    const r = parseQuery("tomorrow", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-14T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-15T23:00:00.000Z");
+  });
+
+  it("'this weekend' on a Wednesday spans Sat–Mon", () => {
+    const r = parseQuery("this weekend", NOW);
+    // From Wed 14 May → Sat 16 May ... Mon 18 May
+    expect(isoDate(r.dateFrom)).toBe("2026-05-15T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-17T23:00:00.000Z");
+  });
+
+  it("'next weekend' is 7 days later", () => {
+    const r = parseQuery("next weekend", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-22T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-24T23:00:00.000Z");
+  });
+
+  it("'this week' spans today + 7 days", () => {
+    const r = parseQuery("this week", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-13T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-20T23:00:00.000Z");
+  });
+
+  it("'saturday' (bare day name) jumps to upcoming Saturday", () => {
+    const r = parseQuery("saturday", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-15T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-16T23:00:00.000Z");
+  });
+
+  it("'next saturday' jumps a week beyond the upcoming Saturday", () => {
+    const r = parseQuery("next saturday", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-15T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-16T23:00:00.000Z");
+  });
+
+  it("'next thursday' (today IS Thursday) skips to next week", () => {
+    // NOW = Thu 14 May 2026. "next thursday" → 21 May (7 days later).
+    const r = parseQuery("next thursday", NOW);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-20T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-21T23:00:00.000Z");
+  });
+});
+
+describe("parseQuery — times", () => {
+  it("'morning' applies 0-11 preset", () => {
+    const r = parseQuery("morning", NOW);
+    expect(r.timeFrom).toBe(0);
+    expect(r.timeTo).toBe(11);
+  });
+
+  it("'late night' (multi-word) applies 21-23 preset", () => {
+    const r = parseQuery("late night", NOW);
+    expect(r.timeFrom).toBe(21);
+    expect(r.timeTo).toBe(23);
+  });
+
+  it("'8pm' applies at-8pm range", () => {
+    const r = parseQuery("8pm", NOW);
+    expect(r.timeFrom).toBe(20);
+    expect(r.timeTo).toBe(21);
+  });
+
+  it("'19:30' applies at-19 range", () => {
+    const r = parseQuery("19:30", NOW);
+    expect(r.timeFrom).toBe(19);
+  });
+
+  it("'after 8pm' sets timeFrom=20 only", () => {
+    const r = parseQuery("after 8pm", NOW);
+    expect(r.timeFrom).toBe(20);
+    expect(r.timeTo).toBeUndefined();
+  });
+
+  it("'before 11pm' sets timeTo=23 only", () => {
+    const r = parseQuery("before 11pm", NOW);
+    expect(r.timeTo).toBe(23);
+    expect(r.timeFrom).toBeUndefined();
+  });
+});
+
+describe("parseQuery — formats", () => {
+  it("'70mm' canonicalises to 70mm", () => {
+    const r = parseQuery("70mm", NOW);
+    expect(r.formats).toEqual(["70mm"]);
+  });
+
+  it("'70mm imax' canonicalises to 70mm_imax", () => {
+    const r = parseQuery("70mm imax", NOW);
+    expect(r.formats).toEqual(["70mm_imax"]);
+  });
+
+  it("'imax laser' canonicalises to imax_laser", () => {
+    const r = parseQuery("imax laser", NOW);
+    expect(r.formats).toEqual(["imax_laser"]);
+  });
+
+  it("'dolby atmos' canonicalises to dolby_cinema", () => {
+    const r = parseQuery("dolby atmos", NOW);
+    expect(r.formats).toEqual(["dolby_cinema"]);
+  });
+});
+
+describe("parseQuery — genres", () => {
+  it("'horror' maps to canonical 'horror'", () => {
+    const r = parseQuery("horror", NOW);
+    expect(r.genres).toEqual(["horror"]);
+  });
+
+  it("'sci-fi' maps to 'science fiction'", () => {
+    const r = parseQuery("sci-fi", NOW);
+    expect(r.genres).toEqual(["science fiction"]);
+  });
+
+  it("'sci fi' (two words) also maps to 'science fiction'", () => {
+    const r = parseQuery("sci fi", NOW);
+    expect(r.genres).toEqual(["science fiction"]);
+  });
+
+  it("'noir' maps to 'noir'", () => {
+    const r = parseQuery("noir", NOW);
+    expect(r.genres).toEqual(["noir"]);
+  });
+});
+
+describe("parseQuery — decades, country, language, certification", () => {
+  it("'80s' canonicalises to 1980s", () => {
+    const r = parseQuery("80s", NOW);
+    expect(r.decades).toEqual(["1980s"]);
+  });
+
+  it("'french' yields country=france (not language since country takes priority)", () => {
+    const r = parseQuery("french", NOW);
+    expect(r.countries).toEqual(["france"]);
+    expect(r.languages).toEqual([]);
+  });
+
+  it("'12a' maps to '12A'", () => {
+    const r = parseQuery("12a", NOW);
+    expect(r.certification).toEqual(["12A"]);
+  });
+
+  it("'pg' maps to 'PG'", () => {
+    const r = parseQuery("pg", NOW);
+    expect(r.certification).toEqual(["PG"]);
+  });
+});
+
+describe("parseQuery — cinemas + chains", () => {
+  it("'curzon' is a chain token", () => {
+    const r = parseQuery("curzon", NOW);
+    expect(r.chainTokens).toEqual(["Curzon"]);
+    expect(r.cinemaIds).toEqual([]);
+  });
+
+  it("'pcc' resolves to prince-charles-cinema", () => {
+    const r = parseQuery("pcc", NOW);
+    expect(r.cinemaIds).toEqual(["prince-charles-cinema"]);
+  });
+
+  it("'prince charles' (multi-word) resolves to prince-charles-cinema", () => {
+    const r = parseQuery("prince charles", NOW);
+    expect(r.cinemaIds).toEqual(["prince-charles-cinema"]);
+  });
+
+  it("'bfi southbank' resolves to bfi-southbank slug, not BFI chain", () => {
+    const r = parseQuery("bfi southbank", NOW);
+    expect(r.cinemaIds).toEqual(["bfi-southbank"]);
+  });
+});
+
+describe("parseQuery — specials", () => {
+  it("'rep' sets isRepertory=true", () => {
+    const r = parseQuery("rep", NOW);
+    expect(r.isRepertory).toBe(true);
+  });
+
+  it("'subs' sets hasSubtitles=true", () => {
+    const r = parseQuery("subs", NOW);
+    expect(r.hasSubtitles).toBe(true);
+  });
+
+  it("'relaxed' sets isRelaxedScreening=true", () => {
+    const r = parseQuery("relaxed", NOW);
+    expect(r.isRelaxedScreening).toBe(true);
+  });
+
+  it("'uk premiere' sets isPremiere=true + premiereTypes=['uk']", () => {
+    const r = parseQuery("uk premiere", NOW);
+    expect(r.isPremiere).toBe(true);
+    expect(r.premiereTypes).toEqual(["uk"]);
+  });
+
+  it("'want to see' sets watchlistFilter='want_to_see'", () => {
+    const r = parseQuery("want to see", NOW);
+    expect(r.watchlistFilter).toBe("want_to_see");
+  });
+
+  it("'nearby' sets reachable=true", () => {
+    const r = parseQuery("nearby", NOW);
+    expect(r.reachable).toBe(true);
+  });
+});
+
+describe("parseQuery — composite queries", () => {
+  it("'horror tonight at curzon' parses all three", () => {
+    const r = parseQuery("horror tonight at curzon", NOW);
+    expect(r.genres).toEqual(["horror"]);
+    expect(r.chainTokens).toEqual(["Curzon"]);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-13T23:00:00.000Z");
+    expect(r.timeFrom).toBe(18);
+    expect(r.freeText).toBe("at"); // leftover
+  });
+
+  it("'70mm this weekend' parses format + date range", () => {
+    const r = parseQuery("70mm this weekend", NOW);
+    expect(r.formats).toEqual(["70mm"]);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-15T23:00:00.000Z");
+    expect(isoDate(r.dateTo)).toBe("2026-05-17T23:00:00.000Z");
+    expect(r.freeText).toBe("");
+  });
+
+  it("'kids films saturday' → family genre + date", () => {
+    const r = parseQuery("kids films saturday", NOW);
+    expect(r.genres).toEqual(["family"]);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-15T23:00:00.000Z");
+    expect(r.freeText).toBe("films");
+  });
+
+  it("'subtitled french noir 80s' → 4 filter slots", () => {
+    const r = parseQuery("subtitled french noir 80s", NOW);
+    expect(r.hasSubtitles).toBe(true);
+    expect(r.countries).toEqual(["france"]);
+    expect(r.genres).toEqual(["noir"]);
+    expect(r.decades).toEqual(["1980s"]);
+    expect(r.freeText).toBe("");
+  });
+
+  it("'pcc tomorrow 8pm' → cinema + date + time", () => {
+    const r = parseQuery("pcc tomorrow 8pm", NOW);
+    expect(r.cinemaIds).toEqual(["prince-charles-cinema"]);
+    expect(isoDate(r.dateFrom)).toBe("2026-05-14T23:00:00.000Z");
+    expect(r.timeFrom).toBe(20);
+  });
+
+  it("free text preserves original casing for unmatched tokens", () => {
+    const r = parseQuery("Wes Anderson tonight", NOW);
+    expect(r.freeText).toBe("Wes Anderson");
+    expect(isoDate(r.dateFrom)).toBe("2026-05-13T23:00:00.000Z");
+  });
+
+  it("chip descriptors are emitted in order", () => {
+    const r = parseQuery("horror tonight curzon", NOW);
+    const ids = r.chipDescriptors.map((c) => c.id);
+    // Date phrase pass runs before single-token pass; horror+curzon
+    // emit during single-token. Order is: dates → genres → chains.
+    expect(ids).toContain("date:tonight");
+    expect(ids).toContain("genre:horror");
+    expect(ids).toContain("chain:Curzon");
+  });
+
+  it("duplicate tokens are de-duped in arrays", () => {
+    const r = parseQuery("horror horror 70mm 70mm", NOW);
+    expect(r.genres).toEqual(["horror"]);
+    expect(r.formats).toEqual(["70mm"]);
+  });
+});

--- a/frontend/src/lib/search/parse-query.ts
+++ b/frontend/src/lib/search/parse-query.ts
@@ -1,0 +1,610 @@
+/**
+ * Query intent parser for the cmd+k command palette.
+ *
+ * Tokenises a user query into structured `ParsedIntent` so the server
+ * can apply filter predicates (date range, formats, genres, cinema IDs,
+ * etc.) alongside the lexical/trigram match.
+ *
+ * Design constraints:
+ *  - **Pure**. `now` is injected — the function never reads `Date.now()`
+ *    directly. This keeps Vitest snapshots stable.
+ *  - **No external deps**. No chrono-node — the four temporal phrases we
+ *    care about (tonight / tomorrow / this weekend / next [day]) are
+ *    handled directly.
+ *  - **London-timezone aware**. All date math uses `Europe/London` via
+ *    `Intl.DateTimeFormat`, matching `filters.setDatePreset` in the
+ *    existing filter store.
+ *  - **Multi-word phrases first**. A 2/3-word scan over the tokens runs
+ *    before single-token lookups so "this weekend" doesn't get split.
+ *
+ * The parser greedily consumes tokens. Whatever is unconsumed becomes
+ * `freeText`, which is what the server's tsvector + trigram match uses.
+ */
+
+import { FORMAT_TOKENS, FORMAT_PHRASES_BY_LENGTH } from "./vocab/formats";
+import {
+  GENRE_TOKENS,
+  GENRE_PHRASES_BY_LENGTH,
+  GENRE_PHRASE_MAP,
+} from "./vocab/genres";
+import { DECADE_TOKENS } from "./vocab/decades";
+import { COUNTRY_TOKENS, LANGUAGE_TOKENS } from "./vocab/countries";
+import {
+  CHAIN_TOKENS,
+  CINEMA_ALIAS_TOKENS,
+  CINEMA_ALIAS_PHRASES_BY_LENGTH,
+} from "./vocab/chains";
+import { CERTIFICATION_TOKENS } from "./vocab/certifications";
+import {
+  SPECIAL_TOKENS,
+  PREMIERE_TYPE_PHRASES,
+  PREMIERE_PHRASES_BY_LENGTH,
+  WATCHLIST_PHRASES,
+  WATCHLIST_PHRASES_BY_LENGTH,
+} from "./vocab/specials";
+import { TIME_PRESETS, TIME_PHRASES_BY_LENGTH } from "./vocab/time";
+
+export type PremiereType = "world" | "international" | "european" | "uk";
+export type WatchlistFilter = "want_to_see" | "seen";
+
+export interface ChipDescriptor {
+  id: string;
+  kind: string;
+  label: string;
+}
+
+export interface ParsedIntent {
+  freeText: string;
+  dateFrom?: Date;
+  dateTo?: Date;
+  timeFrom?: number;
+  timeTo?: number;
+  formats: string[];
+  genres: string[];
+  decades: string[];
+  countries: string[];
+  languages: string[];
+  cinemaIds: string[];
+  chainTokens: string[];
+  certification: string[];
+  isRepertory?: boolean;
+  hasSubtitles?: boolean;
+  isRelaxedScreening?: boolean;
+  isPremiere?: boolean;
+  premiereTypes: PremiereType[];
+  contentTypes: string[];
+  watchlistFilter?: WatchlistFilter;
+  reachable?: boolean;
+  minRating?: number;
+  chipDescriptors: ChipDescriptor[];
+}
+
+function emptyIntent(): ParsedIntent {
+  return {
+    freeText: "",
+    formats: [],
+    genres: [],
+    decades: [],
+    countries: [],
+    languages: [],
+    cinemaIds: [],
+    chainTokens: [],
+    certification: [],
+    premiereTypes: [],
+    contentTypes: [],
+    chipDescriptors: [],
+  };
+}
+
+interface Token {
+  raw: string;
+  lower: string;
+  start: number;
+  end: number;
+  consumed: boolean;
+}
+
+const TOKEN_RE = /[A-Za-z0-9'\-:]+/g;
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  // Split on whitespace + most punctuation, but KEEP intra-word digits
+  // and hyphens (so "35mm", "4dx", "70mm-imax", "sci-fi" stay intact).
+  for (const match of input.matchAll(TOKEN_RE)) {
+    const start = match.index ?? 0;
+    tokens.push({
+      raw: match[0],
+      lower: match[0].toLowerCase(),
+      start,
+      end: start + match[0].length,
+      consumed: false,
+    });
+  }
+  return tokens;
+}
+
+// London-timezone helpers
+function londonDateString(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+function londonDayOfWeek(d: Date): number {
+  const short = new Intl.DateTimeFormat("en-GB", {
+    weekday: "short",
+    timeZone: "Europe/London",
+  }).format(d);
+  const map: Record<string, number> = {
+    Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
+  };
+  return map[short] ?? d.getDay();
+}
+
+function londonMidnight(yyyyMmDd: string, hour = 0): Date {
+  // Returns a Date representing London midnight (or `hour:00`) on the
+  // given date. We compute the London offset for that specific instant
+  // (DST-aware) and subtract it from UTC midnight.
+  const utcMid = new Date(`${yyyyMmDd}T00:00:00Z`);
+  const offsetPart = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    timeZoneName: "shortOffset",
+  })
+    .formatToParts(utcMid)
+    .find((p) => p.type === "timeZoneName")?.value;
+  let offsetMin = 0;
+  if (offsetPart && offsetPart.startsWith("GMT")) {
+    const m = offsetPart.match(/GMT([+-]\d+)/);
+    if (m) offsetMin = parseInt(m[1], 10) * 60;
+  }
+  const londonMidUtc = new Date(utcMid.getTime() - offsetMin * 60 * 1000);
+  return new Date(londonMidUtc.getTime() + hour * 3600 * 1000);
+}
+
+function addDaysToDateString(yyyyMmDd: string, days: number): string {
+  const d = new Date(`${yyyyMmDd}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+// ===== Phrase scanning =====
+
+function scanPhrases(
+  tokens: Token[],
+  phrasesByLength: Record<number, string[]>,
+  onMatch: (matchedPhrase: string, startIdx: number, endIdx: number) => boolean,
+) {
+  const maxLen = Math.max(0, ...Object.keys(phrasesByLength).map(Number));
+  for (let len = maxLen; len >= 2; len--) {
+    const phrases = phrasesByLength[len];
+    if (!phrases || phrases.length === 0) continue;
+    const phraseSet = new Set(phrases);
+    for (let i = 0; i <= tokens.length - len; i++) {
+      if (tokens.slice(i, i + len).some((t) => t.consumed)) continue;
+      const joined = tokens.slice(i, i + len).map((t) => t.lower).join(" ");
+      if (phraseSet.has(joined)) {
+        const accepted = onMatch(joined, i, i + len - 1);
+        if (accepted) {
+          for (let j = i; j < i + len; j++) tokens[j].consumed = true;
+        }
+      }
+    }
+  }
+}
+
+// ===== Date scanners =====
+
+const DAY_NAMES: Record<string, number> = {
+  sunday: 0, sun: 0,
+  monday: 1, mon: 1,
+  tuesday: 2, tue: 2, tues: 2,
+  wednesday: 3, wed: 3,
+  thursday: 4, thu: 4, thur: 4, thurs: 4,
+  friday: 5, fri: 5,
+  saturday: 6, sat: 6,
+};
+
+function applyTonight(intent: ParsedIntent, now: Date) {
+  const today = londonDateString(now);
+  intent.dateFrom = londonMidnight(today, 0);
+  intent.dateTo = londonMidnight(addDaysToDateString(today, 1), 0);
+  intent.timeFrom = 18;
+  intent.chipDescriptors.push({ id: "date:tonight", kind: "date", label: "TONIGHT" });
+}
+
+function applyToday(intent: ParsedIntent, now: Date) {
+  const today = londonDateString(now);
+  intent.dateFrom = londonMidnight(today, 0);
+  intent.dateTo = londonMidnight(addDaysToDateString(today, 1), 0);
+  intent.chipDescriptors.push({ id: "date:today", kind: "date", label: "TODAY" });
+}
+
+function applyTomorrow(intent: ParsedIntent, now: Date) {
+  const today = londonDateString(now);
+  const tomorrow = addDaysToDateString(today, 1);
+  intent.dateFrom = londonMidnight(tomorrow, 0);
+  intent.dateTo = londonMidnight(addDaysToDateString(tomorrow, 1), 0);
+  intent.chipDescriptors.push({ id: "date:tomorrow", kind: "date", label: "TOMORROW" });
+}
+
+function applyWeekendOffset(intent: ParsedIntent, now: Date, offsetWeeks: number) {
+  const today = londonDateString(now);
+  const dow = londonDayOfWeek(now);
+  let satOffset = (6 - dow + 7) % 7;
+  if (offsetWeeks > 0) satOffset += offsetWeeks * 7;
+  if (offsetWeeks === 0 && dow === 0) satOffset = -1;
+  const sat = addDaysToDateString(today, satOffset);
+  const mon = addDaysToDateString(sat, 2);
+  intent.dateFrom = londonMidnight(sat, 0);
+  intent.dateTo = londonMidnight(mon, 0);
+  intent.chipDescriptors.push({
+    id: `date:weekend${offsetWeeks > 0 ? `+${offsetWeeks}` : ""}`,
+    kind: "date",
+    label: offsetWeeks > 0 ? "NEXT WEEKEND" : "THIS WEEKEND",
+  });
+}
+
+function applyThisWeek(intent: ParsedIntent, now: Date) {
+  const today = londonDateString(now);
+  intent.dateFrom = londonMidnight(today, 0);
+  intent.dateTo = londonMidnight(addDaysToDateString(today, 7), 0);
+  intent.chipDescriptors.push({ id: "date:thisweek", kind: "date", label: "THIS WEEK" });
+}
+
+function applyNextDay(intent: ParsedIntent, now: Date, dayIdx: number) {
+  const today = londonDateString(now);
+  const todayDow = londonDayOfWeek(now);
+  let offset = (dayIdx - todayDow + 7) % 7;
+  if (offset === 0) offset = 7;
+  const target = addDaysToDateString(today, offset);
+  intent.dateFrom = londonMidnight(target, 0);
+  intent.dateTo = londonMidnight(addDaysToDateString(target, 1), 0);
+  const dayName = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"][dayIdx];
+  intent.chipDescriptors.push({
+    id: `date:next-${dayIdx}`,
+    kind: "date",
+    label: `NEXT ${dayName}`,
+  });
+}
+
+function applyDayThisWeek(intent: ParsedIntent, now: Date, dayIdx: number) {
+  const today = londonDateString(now);
+  const todayDow = londonDayOfWeek(now);
+  const offset = (dayIdx - todayDow + 7) % 7;
+  const target = addDaysToDateString(today, offset);
+  intent.dateFrom = londonMidnight(target, 0);
+  intent.dateTo = londonMidnight(addDaysToDateString(target, 1), 0);
+  const dayName = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"][dayIdx];
+  intent.chipDescriptors.push({ id: `date:${dayIdx}`, kind: "date", label: dayName });
+}
+
+// ===== Time =====
+
+function applyTimePreset(intent: ParsedIntent, presetKey: string) {
+  const preset = TIME_PRESETS[presetKey];
+  if (!preset) return;
+  intent.timeFrom = preset.from;
+  intent.timeTo = preset.to;
+  intent.chipDescriptors.push({
+    id: `time:${presetKey.replace(/\s+/g, "-")}`,
+    kind: "time",
+    label: presetKey.toUpperCase(),
+  });
+}
+
+function applyTimeLiteral(intent: ParsedIntent, hour: number, mode: "after" | "before" | "at") {
+  if (mode === "after") {
+    intent.timeFrom = hour;
+    intent.chipDescriptors.push({ id: `time:after-${hour}`, kind: "time", label: `AFTER ${formatHourLabel(hour)}` });
+  } else if (mode === "before") {
+    intent.timeTo = hour;
+    intent.chipDescriptors.push({ id: `time:before-${hour}`, kind: "time", label: `BEFORE ${formatHourLabel(hour)}` });
+  } else {
+    intent.timeFrom = hour;
+    intent.timeTo = Math.min(23, hour + 1);
+    intent.chipDescriptors.push({ id: `time:at-${hour}`, kind: "time", label: `AT ${formatHourLabel(hour)}` });
+  }
+}
+
+function formatHourLabel(h: number): string {
+  if (h === 0) return "12AM";
+  if (h < 12) return `${h}AM`;
+  if (h === 12) return "12PM";
+  return `${h - 12}PM`;
+}
+
+function parseHourLiteral(raw: string): number | null {
+  const m1 = raw.match(/^(\d{1,2})(am|pm)$/i);
+  if (m1) {
+    let h = parseInt(m1[1], 10);
+    if (m1[2].toLowerCase() === "pm" && h < 12) h += 12;
+    if (m1[2].toLowerCase() === "am" && h === 12) h = 0;
+    if (h >= 0 && h <= 23) return h;
+  }
+  const m2 = raw.match(/^(\d{1,2}):(\d{2})$/);
+  if (m2) {
+    const h = parseInt(m2[1], 10);
+    if (h >= 0 && h <= 23) return h;
+  }
+  return null;
+}
+
+// ===== Main parser =====
+
+export function parseQuery(input: string, now: Date): ParsedIntent {
+  const intent = emptyIntent();
+  if (!input || !input.trim()) return intent;
+
+  const tokens = tokenize(input);
+  if (tokens.length === 0) return intent;
+
+  // --- Pass 1: multi-word phrases ---
+
+  scanPhrases(tokens, { 2: ["this weekend", "next weekend"] }, (phrase) => {
+    if (phrase === "this weekend") applyWeekendOffset(intent, now, 0);
+    else applyWeekendOffset(intent, now, 1);
+    return true;
+  });
+
+  scanPhrases(tokens, { 2: ["this week", "next week"] }, (phrase) => {
+    if (phrase === "this week") applyThisWeek(intent, now);
+    else {
+      const today = londonDateString(now);
+      intent.dateFrom = londonMidnight(addDaysToDateString(today, 7), 0);
+      intent.dateTo = londonMidnight(addDaysToDateString(today, 14), 0);
+      intent.chipDescriptors.push({ id: "date:nextweek", kind: "date", label: "NEXT WEEK" });
+    }
+    return true;
+  });
+
+  scanPhrases(
+    tokens,
+    { 2: Object.keys(DAY_NAMES).map((d) => `next ${d}`) },
+    (phrase) => {
+      const dayPart = phrase.replace(/^next /, "");
+      const idx = DAY_NAMES[dayPart];
+      if (idx === undefined) return false;
+      applyNextDay(intent, now, idx);
+      return true;
+    },
+  );
+
+  scanPhrases(tokens, TIME_PHRASES_BY_LENGTH, (phrase) => {
+    if (TIME_PRESETS[phrase]) {
+      applyTimePreset(intent, phrase);
+      return true;
+    }
+    return false;
+  });
+
+  // "after Npm" / "before Npm" — pair scan, not phrase scan
+  for (let i = 0; i < tokens.length - 1; i++) {
+    if (tokens[i].consumed || tokens[i + 1].consumed) continue;
+    const word = tokens[i].lower;
+    const next = tokens[i + 1].lower;
+    if (word !== "after" && word !== "before") continue;
+    const h = parseHourLiteral(next);
+    if (h === null) continue;
+    applyTimeLiteral(intent, h, word as "after" | "before");
+    tokens[i].consumed = true;
+    tokens[i + 1].consumed = true;
+  }
+
+  scanPhrases(tokens, PREMIERE_PHRASES_BY_LENGTH, (phrase) => {
+    const type = PREMIERE_TYPE_PHRASES[phrase];
+    if (!type) return false;
+    intent.isPremiere = true;
+    if (!intent.premiereTypes.includes(type as PremiereType)) {
+      intent.premiereTypes.push(type as PremiereType);
+    }
+    intent.chipDescriptors.push({ id: `premiere:${type}`, kind: "premiere", label: phrase.toUpperCase() });
+    return true;
+  });
+
+  scanPhrases(tokens, WATCHLIST_PHRASES_BY_LENGTH, (phrase) => {
+    const f = WATCHLIST_PHRASES[phrase];
+    if (!f) return false;
+    intent.watchlistFilter = f;
+    intent.chipDescriptors.push({ id: `watchlist:${f}`, kind: "watchlist", label: phrase.toUpperCase() });
+    return true;
+  });
+
+  scanPhrases(tokens, GENRE_PHRASES_BY_LENGTH, (phrase) => {
+    const canonical = GENRE_PHRASE_MAP[phrase];
+    if (!canonical) return false;
+    if (!intent.genres.includes(canonical)) intent.genres.push(canonical);
+    intent.chipDescriptors.push({ id: `genre:${canonical}`, kind: "genre", label: canonical.toUpperCase() });
+    return true;
+  });
+
+  scanPhrases(tokens, FORMAT_PHRASES_BY_LENGTH, (phrase) => {
+    const canonical = FORMAT_TOKENS[phrase];
+    if (!canonical) return false;
+    if (!intent.formats.includes(canonical)) intent.formats.push(canonical);
+    intent.chipDescriptors.push({ id: `format:${canonical}`, kind: "format", label: canonical.toUpperCase() });
+    return true;
+  });
+
+  scanPhrases(tokens, CINEMA_ALIAS_PHRASES_BY_LENGTH, (phrase) => {
+    const slug = CINEMA_ALIAS_TOKENS[phrase];
+    if (!slug) return false;
+    if (!intent.cinemaIds.includes(slug)) intent.cinemaIds.push(slug);
+    intent.chipDescriptors.push({ id: `cinema:${slug}`, kind: "cinema", label: phrase.toUpperCase() });
+    return true;
+  });
+
+  // --- Pass 2: single tokens ---
+  for (const t of tokens) {
+    if (t.consumed) continue;
+    const w = t.lower;
+
+    if (w === "tonight" && !intent.dateFrom) {
+      applyTonight(intent, now);
+      t.consumed = true;
+      continue;
+    }
+    if (w === "today" && !intent.dateFrom) {
+      applyToday(intent, now);
+      t.consumed = true;
+      continue;
+    }
+    if (w === "tomorrow" && !intent.dateFrom) {
+      applyTomorrow(intent, now);
+      t.consumed = true;
+      continue;
+    }
+
+    if (DAY_NAMES[w] !== undefined && !intent.dateFrom) {
+      applyDayThisWeek(intent, now, DAY_NAMES[w]);
+      t.consumed = true;
+      continue;
+    }
+
+    if (TIME_PRESETS[w] && intent.timeFrom === undefined) {
+      applyTimePreset(intent, w);
+      t.consumed = true;
+      continue;
+    }
+
+    const hour = parseHourLiteral(w);
+    if (hour !== null && intent.timeFrom === undefined) {
+      applyTimeLiteral(intent, hour, "at");
+      t.consumed = true;
+      continue;
+    }
+
+    if (FORMAT_TOKENS[w]) {
+      const c = FORMAT_TOKENS[w];
+      if (!intent.formats.includes(c)) {
+        intent.formats.push(c);
+        intent.chipDescriptors.push({ id: `format:${c}`, kind: "format", label: c.toUpperCase() });
+      }
+      t.consumed = true;
+      continue;
+    }
+
+    if (GENRE_TOKENS[w]) {
+      const c = GENRE_TOKENS[w];
+      if (!intent.genres.includes(c)) {
+        intent.genres.push(c);
+        intent.chipDescriptors.push({ id: `genre:${c}`, kind: "genre", label: c.toUpperCase() });
+      }
+      t.consumed = true;
+      continue;
+    }
+
+    if (DECADE_TOKENS[w]) {
+      const c = DECADE_TOKENS[w];
+      if (!intent.decades.includes(c)) {
+        intent.decades.push(c);
+        intent.chipDescriptors.push({ id: `decade:${c}`, kind: "decade", label: c.toUpperCase() });
+      }
+      t.consumed = true;
+      continue;
+    }
+
+    if (COUNTRY_TOKENS[w]) {
+      const c = COUNTRY_TOKENS[w];
+      if (!intent.countries.includes(c)) {
+        intent.countries.push(c);
+        intent.chipDescriptors.push({ id: `country:${c}`, kind: "country", label: w.toUpperCase() });
+      }
+      t.consumed = true;
+      continue;
+    }
+    if (LANGUAGE_TOKENS[w]) {
+      const c = LANGUAGE_TOKENS[w];
+      if (!intent.languages.includes(c)) {
+        intent.languages.push(c);
+        intent.chipDescriptors.push({ id: `lang:${c}`, kind: "language", label: w.toUpperCase() });
+      }
+      t.consumed = true;
+      continue;
+    }
+
+    if (CHAIN_TOKENS[w]) {
+      const c = CHAIN_TOKENS[w];
+      if (!intent.chainTokens.includes(c)) {
+        intent.chainTokens.push(c);
+        intent.chipDescriptors.push({ id: `chain:${c}`, kind: "chain", label: c.toUpperCase() });
+      }
+      t.consumed = true;
+      continue;
+    }
+
+    if (CINEMA_ALIAS_TOKENS[w]) {
+      const slug = CINEMA_ALIAS_TOKENS[w];
+      if (!intent.cinemaIds.includes(slug)) {
+        intent.cinemaIds.push(slug);
+        intent.chipDescriptors.push({ id: `cinema:${slug}`, kind: "cinema", label: w.toUpperCase() });
+      }
+      t.consumed = true;
+      continue;
+    }
+
+    if (CERTIFICATION_TOKENS[w]) {
+      const c = CERTIFICATION_TOKENS[w];
+      if (!intent.certification.includes(c)) {
+        intent.certification.push(c);
+        intent.chipDescriptors.push({ id: `cert:${c}`, kind: "certification", label: c });
+      }
+      t.consumed = true;
+      continue;
+    }
+
+    if (SPECIAL_TOKENS.isRepertory.has(w)) {
+      intent.isRepertory = true;
+      intent.chipDescriptors.push({ id: "rep", kind: "special", label: "REPERTORY" });
+      t.consumed = true;
+      continue;
+    }
+    if (SPECIAL_TOKENS.hasSubtitles.has(w)) {
+      intent.hasSubtitles = true;
+      intent.chipDescriptors.push({ id: "subs", kind: "special", label: "SUBTITLED" });
+      t.consumed = true;
+      continue;
+    }
+    if (SPECIAL_TOKENS.isRelaxedScreening.has(w)) {
+      intent.isRelaxedScreening = true;
+      intent.chipDescriptors.push({ id: "relaxed", kind: "special", label: "RELAXED" });
+      t.consumed = true;
+      continue;
+    }
+    if (SPECIAL_TOKENS.isPremiere.has(w) && !intent.isPremiere) {
+      intent.isPremiere = true;
+      intent.chipDescriptors.push({ id: "premiere", kind: "special", label: "PREMIERE" });
+      t.consumed = true;
+      continue;
+    }
+    if (SPECIAL_TOKENS.reachable.has(w)) {
+      intent.reachable = true;
+      intent.chipDescriptors.push({ id: "reachable", kind: "special", label: "NEARBY" });
+      t.consumed = true;
+      continue;
+    }
+    if (SPECIAL_TOKENS.watchlist.has(w) && !intent.watchlistFilter) {
+      intent.watchlistFilter = "want_to_see";
+      intent.chipDescriptors.push({ id: "watchlist", kind: "watchlist", label: "WATCHLIST" });
+      t.consumed = true;
+      continue;
+    }
+    if (SPECIAL_TOKENS.seen.has(w) && !intent.watchlistFilter) {
+      intent.watchlistFilter = "seen";
+      intent.chipDescriptors.push({ id: "seen", kind: "watchlist", label: "SEEN" });
+      t.consumed = true;
+      continue;
+    }
+  }
+
+  // --- Pass 3: leftovers → freeText ---
+  intent.freeText = tokens
+    .filter((t) => !t.consumed)
+    .map((t) => input.slice(t.start, t.end))
+    .join(" ")
+    .trim();
+
+  return intent;
+}

--- a/frontend/src/lib/search/vocab/certifications.ts
+++ b/frontend/src/lib/search/vocab/certifications.ts
@@ -1,0 +1,16 @@
+/**
+ * BBFC certification tokens.
+ *
+ * Maps user-typed certifications to canonical strings stored in
+ * films.certification. Note "12" and "12A" are distinct.
+ */
+
+export const CERTIFICATION_TOKENS: Record<string, string> = {
+  u: "U",
+  pg: "PG",
+  "12": "12",
+  "12a": "12A",
+  "15": "15",
+  "18": "18",
+  r18: "R18",
+};

--- a/frontend/src/lib/search/vocab/chains.ts
+++ b/frontend/src/lib/search/vocab/chains.ts
@@ -1,0 +1,49 @@
+/**
+ * Cinema chain + alias tokens.
+ *
+ * `CHAIN_TOKENS` maps a chain-name keyword to the canonical `chain`
+ * field used in cinemas.chain. The parser surfaces these as
+ * `chainTokens` so the intent-to-action mapper can resolve them to
+ * cinema IDs by looking up `cinemas.where(chain = ...)`.
+ *
+ * `CINEMA_ALIAS_TOKENS` maps short codes / common aliases to specific
+ * cinema slugs (cinemas.id). These resolve directly to cinemaIds.
+ */
+
+export const CHAIN_TOKENS: Record<string, string> = {
+  curzon: "Curzon",
+  picturehouse: "Picturehouse",
+  everyman: "Everyman",
+  bfi: "BFI",
+  vue: "Vue",
+  cineworld: "Cineworld",
+  odeon: "Odeon",
+};
+
+// Multi-word phrases for chains.
+export const CHAIN_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: [],
+};
+
+// Specific cinema aliases → slug (cinemas.id).
+// IMPORTANT: these slugs must match real cinemas.id values in the
+// database. Verify with `SELECT id FROM cinemas` after any change.
+export const CINEMA_ALIAS_TOKENS: Record<string, string> = {
+  pcc: "prince-charles-cinema",
+  "prince charles": "prince-charles-cinema",
+  ica: "ica",
+  barbican: "barbican",
+  rio: "rio-cinema",
+  genesis: "genesis-cinema",
+  phoenix: "phoenix-cinema",
+  garden: "garden-cinema",
+  castle: "castle-cinema",
+  "close-up": "close-up",
+  closeup: "close-up",
+  "bfi southbank": "bfi-southbank",
+  "bfi imax": "bfi-imax",
+};
+
+export const CINEMA_ALIAS_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: ["prince charles", "bfi southbank", "bfi imax"],
+};

--- a/frontend/src/lib/search/vocab/countries.ts
+++ b/frontend/src/lib/search/vocab/countries.ts
@@ -1,0 +1,64 @@
+/**
+ * Country/language tokens.
+ *
+ * Maps adjectives ("French") to canonical lowercase country names
+ * and language codes/names. Since films.countries[] in our DB uses
+ * lowercase TMDB-style names ("france", "japan", "united kingdom"),
+ * we store those forms.
+ */
+
+export const COUNTRY_TOKENS: Record<string, string> = {
+  french: "france",
+  france: "france",
+  japanese: "japan",
+  japan: "japan",
+  korean: "south korea",
+  korea: "south korea",
+  italian: "italy",
+  italy: "italy",
+  german: "germany",
+  germany: "germany",
+  spanish: "spain",
+  spain: "spain",
+  russian: "russia",
+  russia: "russia",
+  chinese: "china",
+  china: "china",
+  american: "united states of america",
+  british: "united kingdom",
+  english: "united kingdom",
+  indian: "india",
+  india: "india",
+  mexican: "mexico",
+  mexico: "mexico",
+  brazilian: "brazil",
+  iranian: "iran",
+  polish: "poland",
+  swedish: "sweden",
+  danish: "denmark",
+  finnish: "finland",
+  norwegian: "norway",
+  dutch: "netherlands",
+  belgian: "belgium",
+  austrian: "austria",
+  turkish: "turkey",
+  greek: "greece",
+  argentine: "argentina",
+  australian: "australia",
+};
+
+export const LANGUAGE_TOKENS: Record<string, string> = {
+  french: "french",
+  japanese: "japanese",
+  korean: "korean",
+  italian: "italian",
+  german: "german",
+  spanish: "spanish",
+  russian: "russian",
+  mandarin: "mandarin",
+  cantonese: "cantonese",
+  hindi: "hindi",
+  arabic: "arabic",
+  portuguese: "portuguese",
+  // "english" deliberately omitted — too common in queries to assume language intent
+};

--- a/frontend/src/lib/search/vocab/decades.ts
+++ b/frontend/src/lib/search/vocab/decades.ts
@@ -1,0 +1,33 @@
+/**
+ * Decade tokens. Canonical values match `DECADES` from
+ * `$lib/constants/filters.ts` exactly.
+ *
+ * NOTE: "20s" alone is ambiguous (1920s vs 2020s). We default it
+ * to 1920s — more common in cinema discourse (silent era,
+ * pre-code, etc.). Users wanting the modern decade should type
+ * "2020s" explicitly.
+ */
+
+export const DECADE_TOKENS: Record<string, string> = {
+  "20s": "1920s",
+  "1920s": "1920s",
+  "30s": "1930s",
+  "1930s": "1930s",
+  "40s": "1940s",
+  "1940s": "1940s",
+  "50s": "1950s",
+  "1950s": "1950s",
+  "60s": "1960s",
+  "1960s": "1960s",
+  "70s": "1970s",
+  "1970s": "1970s",
+  "80s": "1980s",
+  "1980s": "1980s",
+  "90s": "1990s",
+  "1990s": "1990s",
+  "00s": "2000s",
+  "2000s": "2000s",
+  "10s": "2010s",
+  "2010s": "2010s",
+  "2020s": "2020s",
+};

--- a/frontend/src/lib/search/vocab/formats.ts
+++ b/frontend/src/lib/search/vocab/formats.ts
@@ -1,0 +1,48 @@
+/**
+ * Format token dictionary for the cmd+k query parser.
+ *
+ * Each key is the lowercased input token (or multi-word phrase) the
+ * user might type; the value is the canonical format value to store
+ * in `filters.formats` so it slots directly into the existing filter
+ * store and the screenings query.
+ *
+ * Source of truth for canonical values: `$lib/constants/filters.ts`
+ * (FORMAT_OPTIONS). Keep these aligned.
+ */
+
+export const FORMAT_TOKENS: Record<string, string> = {
+  // 35mm
+  "35mm": "35mm",
+  "35 mm": "35mm",
+
+  // 70mm and 70mm IMAX
+  "70mm": "70mm",
+  "70 mm": "70mm",
+  "70mm imax": "70mm_imax",
+  "70mm-imax": "70mm_imax",
+
+  // IMAX
+  "imax": "imax",
+  "imax laser": "imax_laser",
+  "imax-laser": "imax_laser",
+
+  // Dolby
+  "dolby": "dolby_cinema",
+  "dolby cinema": "dolby_cinema",
+  "dolby vision": "dolby_cinema",
+  "atmos": "dolby_cinema",
+  "dolby atmos": "dolby_cinema",
+
+  // 4DX
+  "4dx": "4dx",
+  "4 dx": "4dx",
+
+  // Digital and 3D — not in FORMAT_OPTIONS yet but commonly typed
+  // We intentionally do NOT add these to filters.formats since the
+  // existing UI doesn't surface them; they end up in freeText so
+  // the server can still match via screenings.format tsvector.
+};
+
+export const FORMAT_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: ["70mm imax", "70 mm", "70mm-imax", "imax laser", "imax-laser", "35 mm", "dolby cinema", "dolby vision", "dolby atmos", "4 dx"],
+};

--- a/frontend/src/lib/search/vocab/genres.ts
+++ b/frontend/src/lib/search/vocab/genres.ts
@@ -1,0 +1,56 @@
+/**
+ * Genre token dictionary.
+ *
+ * Canonical values mirror lower-cased COMMON_GENRES from
+ * `$lib/constants/filters.ts` plus the long-tail genres present
+ * in the films table (countries/genres arrays are populated from
+ * TMDB which uses lowercase forms like "science fiction", "noir").
+ *
+ * Maps user-typed tokens (lowercase, including common abbreviations
+ * and synonyms) to the canonical genre string used in filters.genres
+ * and in films.genres[] for exact-array-membership filtering.
+ */
+
+export const GENRE_TOKENS: Record<string, string> = {
+  // From COMMON_GENRES
+  drama: "drama",
+  comedy: "comedy",
+  horror: "horror",
+  documentary: "documentary",
+  doc: "documentary",
+  docs: "documentary",
+  "sci-fi": "science fiction",
+  scifi: "science fiction",
+  action: "action",
+  thriller: "thriller",
+  romance: "romance",
+  animation: "animation",
+  // Long tail (TMDB genre vocabulary)
+  noir: "noir",
+  anime: "animation",
+  fantasy: "fantasy",
+  mystery: "mystery",
+  war: "war",
+  western: "western",
+  family: "family",
+  kids: "family",
+  history: "history",
+  music: "music",
+  crime: "crime",
+  biography: "biography",
+  biopic: "biography",
+  art: "art",
+  experimental: "experimental",
+  adventure: "adventure",
+};
+
+export const GENRE_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: ["sci fi", "science fiction"],
+};
+
+// Phrase-form variants that should map to the same canonical value.
+// "sci fi" (space) is the most-typed.
+export const GENRE_PHRASE_MAP: Record<string, string> = {
+  "sci fi": "science fiction",
+  "science fiction": "science fiction",
+};

--- a/frontend/src/lib/search/vocab/specials.ts
+++ b/frontend/src/lib/search/vocab/specials.ts
@@ -1,0 +1,41 @@
+/**
+ * Special-intent tokens.
+ *
+ * Each entry triggers a specific filter assignment in the parser.
+ * The parser handles these via direct string match against the
+ * canonical key (multi-word phrases first).
+ */
+
+export const SPECIAL_TOKENS = {
+  isRepertory: new Set(["rep", "repertory"]),
+  hasSubtitles: new Set(["subs", "subtitled", "subtitles"]),
+  isRelaxedScreening: new Set(["relaxed"]),
+  isPremiere: new Set(["premiere", "premieres"]),
+  reachable: new Set(["nearby", "near", "reachable"]),
+  watchlist: new Set(["watchlist"]),
+  seen: new Set(["seen", "watched"]),
+} as const;
+
+// Premiere subtypes — set on isPremiere=true plus premiereTypes[]
+export const PREMIERE_TYPE_PHRASES: Record<string, string> = {
+  "world premiere": "world",
+  "uk premiere": "uk",
+  "european premiere": "european",
+  "international premiere": "international",
+};
+
+export const PREMIERE_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: ["world premiere", "uk premiere", "european premiere", "international premiere"],
+};
+
+// "want to see" → watchlist filter
+export const WATCHLIST_PHRASES: Record<string, "want_to_see" | "seen"> = {
+  "want to see": "want_to_see",
+  "to watch": "want_to_see",
+  "to see": "want_to_see",
+};
+
+export const WATCHLIST_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  3: ["want to see"],
+  2: ["to watch", "to see"],
+};

--- a/frontend/src/lib/search/vocab/time.ts
+++ b/frontend/src/lib/search/vocab/time.ts
@@ -1,0 +1,28 @@
+/**
+ * Time-of-day tokens and presets.
+ *
+ * Canonical values align with TIME_PRESETS in
+ * `$lib/constants/filters.ts`:
+ *   MORNING    0-11
+ *   AFTERNOON  12-16
+ *   EVENING    17-20
+ *   LATE       21-23
+ */
+
+export interface TimeRange {
+  from: number;
+  to: number;
+}
+
+export const TIME_PRESETS: Record<string, TimeRange> = {
+  morning: { from: 0, to: 11 },
+  afternoon: { from: 12, to: 16 },
+  evening: { from: 17, to: 20 },
+  "late night": { from: 21, to: 23 },
+  late: { from: 21, to: 23 },
+  night: { from: 17, to: 23 },
+};
+
+export const TIME_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: ["late night"],
+};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      $lib: resolve(__dirname, "./src/lib"),
+      $app: resolve(__dirname, "./.svelte-kit/runtime/app"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Step 3 of [tasks/cmdk-palette-plan.md](tasks/cmdk-palette-plan.md) — the structured-intent layer
- Pure function: \`parseQuery(input: string, now: Date) → ParsedIntent\`
- Tokenises queries like \`horror tonight at curzon\` into typed filter fields + chip descriptors for the UI
- 8 vocab dictionaries (formats, genres, decades, countries, languages, chains, certifications, specials, time)
- 49 Vitest fixtures, all green
- Adds vitest to \`frontend/\` (first unit-test runner there; Playwright stays for E2E)

## Example
\`\`\`ts
parseQuery("subtitled french noir 80s", now)
// → {
//   hasSubtitles: true,
//   countries: ["france"],
//   genres: ["noir"],
//   decades: ["1980s"],
//   freeText: "",
//   chipDescriptors: [...]
// }
\`\`\`

## Why no chrono-node
FOSS but ~80KB. Hand-rolled date logic is ~80 lines for our 4 temporal phrases (tonight / tomorrow / this weekend / next [day]) and fits the bundle budget.

## Test plan
- [x] \`cd frontend && npm test\` — 49/49 pass in <200ms
- [x] \`cd frontend && npx svelte-check\` — 0 errors
- [x] Backend \`npm run test:run\` — 1580 tests still pass (unaffected)
- [x] \`npm run lint\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)