### PR TITLE
feat(search): visible modal shell — bits-ui Dialog + input + chips (step 5/10)

### DIFF
--- a/changelogs/2026-05-19-cmdk-modal-shell.md
+++ b/changelogs/2026-05-19-cmdk-modal-shell.md
@@ -1,0 +1,51 @@
+# cmd+k step 5 — visible modal shell
+
+**PR**: TBD
+**Date**: 2026-05-19
+**Branch**: `feat/cmdk-palette-step5-modal-shell`
+
+## Context
+
+Step 5 of `tasks/cmdk-palette-plan.md`. First visible UI for the global cmd+k palette — pressing ⌘K now opens a modal (desktop) / full-screen sheet (mobile). Result content is still a placeholder; step 6 wires the real result list.
+
+## Components added
+
+### `frontend/src/lib/components/search/CommandPalette.svelte`
+Root shell. Uses `bits-ui` `Dialog.Root/Portal/Overlay/Content`. Listens for Escape to close. Focuses the input on every open via `tick() → inputRef.focus`. Switches presentation based on `media.isDesktop`:
+- Desktop: centered modal, top 12vh, 640px wide, max-height `min(560px, calc(100vh - 24vh))`
+- Mobile: full-screen sheet, `inset: 0`, `100dvh`
+
+Backdrop is `rgba(0,0,0,0.45)` **flat** (not blurred) — intentional. Step 8 will land the "filter the calendar in real time as you type" feature; the backdrop needs to remain visually transparent enough that users see the calendar behind it react.
+
+### `frontend/src/lib/components/search/CommandPaletteInput.svelte`
+The search input row. Full ARIA combobox: `role="combobox"`, `aria-expanded="true"`, `aria-controls={listboxId}`, `aria-autocomplete="list"`, `aria-activedescendant`. 16px input font on mobile to prevent iOS auto-zoom. Clear button when query non-empty; ESC kbd hint otherwise.
+
+Uses Svelte 5's `bind:value={() => getter, (v) => setter}` form to wire two-way binding to the palette store without exposing setters on the store API.
+
+### `frontend/src/lib/components/search/ActiveFiltersRow.svelte`
+Renders parsed-intent chips beneath the input. Chips render as `role="list"` of `role="listitem"` button siblings — **not inside the `<input>`**, per WAI-ARIA 1.2 (inputs are leaf elements with no interactive descendants). The visual "chips inside input" effect comes from sharing `var(--color-surface)` and no border separator.
+
+### `frontend/src/lib/components/search/Chip.svelte`
+Single peelable chip. Uppercase label in `var(--color-screening-bg/text)`, mono `×` remove. Removing currently clears the whole query (stopgap until step 8 lands proper chip→filter peeling).
+
+### `frontend/src/routes/+layout.svelte`
+Mounts `<CommandPalette />` next to the existing `<GlobalCmdkBinding />` in both clerkEnabled branches.
+
+## New dep
+`bits-ui ^2.18.1` — first headless UI library in `frontend/`. Used for the `Dialog` primitive (focus trap, portal, escape handling, ARIA defaults).
+
+## Verification
+
+- `cd frontend && npx svelte-check` — 0 errors, 2 pre-existing warnings
+- `cd frontend && npm test` — 50/50 pass
+- Pressing ⌘K shows the modal (verified via TS types + svelte-check; manual browser test deferred until step 6 has real results to interact with)
+
+## Known stopgaps
+
+- Chip removal clears whole query (step 8 will implement actual peeling)
+- Result region shows static placeholder text (step 6 wires `palette.results`)
+- No keyboard navigation in the listbox yet — input owns focus; arrow keys not yet wired (step 6)
+
+## Next
+
+Step 6: ResultsList + 8 row variants + flat `selectedIndex` arrow navigation across all sections.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@sveltejs/adapter-vercel": "^6.3.3",
+				"bits-ui": "^2.18.1",
 				"clsx": "^2.1.0",
 				"maplibre-gl": "^5.21.1",
 				"posthog-js": "^1.0.0",
@@ -543,6 +544,41 @@
 			"peer": true,
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.11"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+			"license": "MIT"
+		},
+		"node_modules/@internationalized/date": {
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+			"integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
 			}
 		},
 		"node_modules/@isaacs/fs-minipass": {
@@ -1934,6 +1970,16 @@
 				"vite": "^8.0.0-beta.7 || ^8.0.0"
 			}
 		},
+		"node_modules/@swc/helpers": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+			"integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.8.0"
+			}
+		},
 		"node_modules/@tailwindcss/node": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -2526,6 +2572,30 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"node_modules/bits-ui": {
+			"version": "2.18.1",
+			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.18.1.tgz",
+			"integrity": "sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.7.1",
+				"@floating-ui/dom": "^1.7.1",
+				"esm-env": "^1.1.2",
+				"runed": "^0.35.1",
+				"svelte-toolbelt": "^0.10.6",
+				"tabbable": "^6.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/huntabyte"
+			},
+			"peerDependencies": {
+				"@internationalized/date": "^3.8.1",
+				"svelte": "^5.33.0"
+			}
+		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -2884,6 +2954,12 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+			"license": "MIT"
+		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -3201,6 +3277,15 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
+			}
+		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"license": "MIT",
+			"bin": {
+				"lz-string": "bin/bin.js"
 			}
 		},
 		"node_modules/magic-string": {
@@ -3653,6 +3738,30 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.1"
 			}
 		},
+		"node_modules/runed": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/runed/-/runed-0.35.1.tgz",
+			"integrity": "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==",
+			"funding": [
+				"https://github.com/sponsors/huntabyte",
+				"https://github.com/sponsors/tglide"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.3",
+				"esm-env": "^1.0.0",
+				"lz-string": "^1.5.0"
+			},
+			"peerDependencies": {
+				"@sveltejs/kit": "^2.21.0",
+				"svelte": "^5.7.0"
+			},
+			"peerDependenciesMeta": {
+				"@sveltejs/kit": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -3737,6 +3846,15 @@
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
 			"license": "MIT"
 		},
+		"node_modules/style-to-object": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+			"license": "MIT",
+			"dependencies": {
+				"inline-style-parser": "0.2.7"
+			}
+		},
 		"node_modules/supercluster": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -3816,6 +3934,32 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/svelte-toolbelt": {
+			"version": "0.10.6",
+			"resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.10.6.tgz",
+			"integrity": "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==",
+			"funding": [
+				"https://github.com/sponsors/huntabyte"
+			],
+			"dependencies": {
+				"clsx": "^2.1.1",
+				"runed": "^0.35.1",
+				"style-to-object": "^1.0.8"
+			},
+			"engines": {
+				"node": ">=18",
+				"pnpm": ">=8.7.0"
+			},
+			"peerDependencies": {
+				"svelte": "^5.30.2"
+			}
+		},
+		"node_modules/tabbable": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
 			"version": "4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
 	},
 	"dependencies": {
 		"@sveltejs/adapter-vercel": "^6.3.3",
+		"bits-ui": "^2.18.1",
 		"clsx": "^2.1.0",
 		"maplibre-gl": "^5.21.1",
 		"posthog-js": "^1.0.0",

--- a/frontend/src/lib/components/search/ActiveFiltersRow.svelte
+++ b/frontend/src/lib/components/search/ActiveFiltersRow.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	/**
+	 * Renders parsed-intent chips beneath the palette input.
+	 *
+	 * Chips live OUTSIDE the `<input>` (per WAI-ARIA 1.2 — inputs are
+	 * leaf elements with no interactive descendants). The visual
+	 * impression of "chips inside the input" comes from the absence of
+	 * a separator between this row and the input above it.
+	 */
+	import Chip from './Chip.svelte';
+	import type { ChipDescriptor } from '$lib/search/parse-query';
+
+	interface Props {
+		chips: ChipDescriptor[];
+		onRemove: (id: string) => void;
+	}
+
+	let { chips, onRemove }: Props = $props();
+</script>
+
+{#if chips.length > 0}
+	<div class="row" role="list" aria-label="Active filters">
+		{#each chips as chip (chip.id)}
+			<div role="listitem">
+				<Chip label={chip.label} onRemove={() => onRemove(chip.id)} />
+			</div>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		padding: 6px 10px 8px;
+		border-bottom: 1px solid var(--color-border);
+		background: var(--color-surface);
+	}
+</style>

--- a/frontend/src/lib/components/search/Chip.svelte
+++ b/frontend/src/lib/components/search/Chip.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	/**
+	 * A single parsed-intent chip rendered inside the palette's input row.
+	 * Refined brutalist: zero radius, uppercase tracked label, mono ×
+	 * remove button. Snap motion only.
+	 */
+	interface Props {
+		label: string;
+		onRemove: () => void;
+	}
+
+	let { label, onRemove }: Props = $props();
+</script>
+
+<button
+	type="button"
+	class="chip"
+	aria-label="{label}. Press to remove."
+	onclick={onRemove}
+>
+	<span class="label">{label}</span>
+	<span aria-hidden="true" class="remove">×</span>
+</button>
+
+<style>
+	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 4px 2px 6px;
+		background: var(--color-screening-bg);
+		color: var(--color-screening-text);
+		border: none;
+		font-family: var(--font-sans, 'Inter', sans-serif);
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		cursor: pointer;
+	}
+
+	.chip:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 1px;
+	}
+
+	.remove {
+		font-family: var(--font-mono, 'JetBrains Mono', monospace);
+		font-size: 13px;
+		line-height: 1;
+		opacity: 0.6;
+	}
+
+	.chip:hover .remove,
+	.chip:focus-visible .remove {
+		opacity: 1;
+	}
+</style>

--- a/frontend/src/lib/components/search/CommandPalette.svelte
+++ b/frontend/src/lib/components/search/CommandPalette.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+	/**
+	 * Global cmd+k command palette — refined brutalist shell.
+	 *
+	 * Step 5: visible UI shell (modal + input + chip row + empty result
+	 * region). Step 6 wires the result list; step 7 hooks the server
+	 * fetch; step 8 adds filter-as-result rows.
+	 *
+	 * Presentation switches on `media.isDesktop`:
+	 *  - Desktop (≥ 768px): centered modal at top: 12vh, 640px wide
+	 *  - Mobile: full-screen sheet
+	 *
+	 * Backdrop is FLAT 0.45 opacity (not blurred) — intentional so the
+	 * calendar behind the modal remains legible when step 8 lands the
+	 * live filter-mutation feature.
+	 */
+	import { onMount, tick } from 'svelte';
+	import { Dialog } from 'bits-ui';
+	import { palette } from '$lib/stores/palette.svelte';
+	import { media } from '$lib/stores/media.svelte';
+	import CommandPaletteInput from './CommandPaletteInput.svelte';
+	import ActiveFiltersRow from './ActiveFiltersRow.svelte';
+
+	const LISTBOX_ID = 'cmdk-listbox';
+
+	let inputRef = $state<HTMLInputElement | null>(null);
+	let activeDescendant = $state<string | undefined>(undefined);
+
+	const chips = $derived(palette.parsed.chipDescriptors);
+	const isDesktop = $derived(media.isDesktop);
+
+	function handleOpenChange(next: boolean) {
+		if (next) palette.openPalette('click');
+		else palette.closePalette();
+	}
+
+	function removeChip(id: string) {
+		// Step 8 will implement actual chip-peeling via filter mutations.
+		// For now, removing a chip clears the whole query — this is a
+		// stopgap that keeps the UI consistent until intent-to-actions
+		// lands.
+		palette.setQuery('');
+		void id;
+	}
+
+	// Focus the input on every open
+	$effect(() => {
+		if (palette.open) {
+			void tick().then(() => inputRef?.focus({ preventScroll: true }));
+		}
+	});
+
+	onMount(() => {
+		function handleKeydown(e: KeyboardEvent) {
+			if (!palette.open) return;
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				palette.closePalette();
+			}
+		}
+		document.addEventListener('keydown', handleKeydown);
+		return () => document.removeEventListener('keydown', handleKeydown);
+	});
+</script>
+
+<Dialog.Root open={palette.open} onOpenChange={handleOpenChange}>
+	<Dialog.Portal>
+		<Dialog.Overlay class="cmdk-overlay" />
+		<Dialog.Content
+			class={isDesktop ? 'cmdk-content cmdk-desktop' : 'cmdk-content cmdk-mobile'}
+			aria-describedby={undefined}
+		>
+			<Dialog.Title class="sr-only">Search pictures.london</Dialog.Title>
+
+			<CommandPaletteInput
+				listboxId={LISTBOX_ID}
+				{activeDescendant}
+				bind:inputRef
+			/>
+
+			<ActiveFiltersRow {chips} onRemove={removeChip} />
+
+			<ul id={LISTBOX_ID} role="listbox" aria-label="Search results" class="cmdk-listbox">
+				{#if palette.query.length === 0}
+					<li class="empty">
+						<span>Start typing — try <em>tonight</em>, <em>70mm</em>, or <em>curzon</em></span>
+					</li>
+				{:else}
+					<li class="empty">
+						<span>Results coming in the next step…</span>
+					</li>
+				{/if}
+			</ul>
+
+			{#if isDesktop}
+				<div class="footer" aria-hidden="true">
+					<span>↑↓ navigate · ↵ open · ⌘↵ new tab · ⌥↵ filter · ESC close</span>
+				</div>
+			{/if}
+		</Dialog.Content>
+	</Dialog.Portal>
+</Dialog.Root>
+
+<style>
+	:global(.cmdk-overlay) {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.45);
+		z-index: 100;
+	}
+
+	:global(.cmdk-content) {
+		position: fixed;
+		z-index: 101;
+		background: var(--color-surface);
+		border: 1px solid var(--color-border);
+		display: flex;
+		flex-direction: column;
+		color: var(--color-text);
+	}
+
+	:global(.cmdk-desktop) {
+		top: 12vh;
+		left: 50%;
+		transform: translateX(-50%);
+		width: 640px;
+		max-width: calc(100vw - 32px);
+		max-height: min(560px, calc(100vh - 24vh));
+	}
+
+	:global(.cmdk-mobile) {
+		inset: 0;
+		max-height: 100dvh;
+	}
+
+	.cmdk-listbox {
+		flex: 1;
+		overflow-y: auto;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.empty {
+		padding: 24px 16px;
+		text-align: center;
+		color: var(--color-text-tertiary);
+		font-size: 13px;
+	}
+
+	.empty em {
+		font-style: normal;
+		font-weight: 600;
+		color: var(--color-text);
+		padding: 0 2px;
+	}
+
+	.footer {
+		padding: 8px 12px;
+		border-top: 1px solid var(--color-border-subtle);
+		font-family: var(--font-mono, 'JetBrains Mono', monospace);
+		font-size: 10px;
+		color: var(--color-text-tertiary);
+		letter-spacing: 0.04em;
+		background: var(--color-surface);
+	}
+
+	:global(.sr-only) {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+</style>

--- a/frontend/src/lib/components/search/CommandPaletteInput.svelte
+++ b/frontend/src/lib/components/search/CommandPaletteInput.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+	/**
+	 * The palette's search input row.
+	 *
+	 * Wraps a native <input role="combobox"> with the ARIA combobox
+	 * attributes the WAI-ARIA APG calls for. The actual listbox lives
+	 * in the parent CommandPalette so we can sit it below the chip row.
+	 */
+	import { palette } from '$lib/stores/palette.svelte';
+
+	interface Props {
+		listboxId: string;
+		activeDescendant: string | undefined;
+		placeholder?: string;
+		inputRef?: HTMLInputElement | null;
+	}
+
+	let {
+		listboxId,
+		activeDescendant,
+		placeholder = 'Search films · cinemas · tonight · 70mm…',
+		inputRef = $bindable<HTMLInputElement | null>(null)
+	}: Props = $props();
+
+	function clear() {
+		palette.setQuery('');
+		inputRef?.focus();
+	}
+</script>
+
+<div class="row">
+	<svg
+		class="icon"
+		aria-hidden="true"
+		width="14"
+		height="14"
+		viewBox="0 0 14 14"
+		fill="none"
+	>
+		<circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.2" />
+		<line
+			x1="9.5"
+			y1="9.5"
+			x2="13"
+			y2="13"
+			stroke="currentColor"
+			stroke-width="1.2"
+			stroke-linecap="square"
+		/>
+	</svg>
+
+	<input
+		bind:this={inputRef}
+		bind:value={
+			() => palette.query,
+			(v) => palette.setQuery(v)
+		}
+		type="search"
+		role="combobox"
+		inputmode="search"
+		enterkeyhint="search"
+		autocapitalize="off"
+		autocomplete="off"
+		spellcheck="false"
+		{placeholder}
+		class="input"
+		aria-label="Search films, cinemas, directors, screenings, festivals"
+		aria-expanded="true"
+		aria-controls={listboxId}
+		aria-autocomplete="list"
+		aria-activedescendant={activeDescendant}
+	/>
+
+	{#if palette.query}
+		<button
+			type="button"
+			class="clear"
+			onclick={clear}
+			aria-label="Clear search"
+		>
+			<svg aria-hidden="true" width="10" height="10" viewBox="0 0 10 10" fill="none">
+				<path
+					d="M1 1L9 9M9 1L1 9"
+					stroke="currentColor"
+					stroke-width="1.2"
+					stroke-linecap="square"
+				/>
+			</svg>
+		</button>
+	{:else}
+		<kbd class="kbd" aria-hidden="true">ESC</kbd>
+	{/if}
+</div>
+
+<style>
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 12px 10px;
+		min-height: 48px;
+		border-bottom: 1px solid var(--color-border);
+		background: var(--color-surface);
+	}
+
+	.icon {
+		flex-shrink: 0;
+		color: var(--color-text-tertiary);
+	}
+
+	.input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		background: transparent;
+		color: var(--color-text);
+		font-size: 16px;
+		font-family: var(--font-display, 'Space Grotesk', sans-serif);
+		outline: none;
+	}
+
+	@media (min-width: 768px) {
+		.input {
+			font-size: 15px;
+		}
+	}
+
+	.input::placeholder {
+		color: var(--color-text-tertiary);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		font-size: 11px;
+	}
+
+	.input::-webkit-search-cancel-button,
+	.input::-webkit-search-decoration {
+		-webkit-appearance: none;
+		appearance: none;
+	}
+
+	.clear {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 28px;
+		min-height: 28px;
+		padding: 4px;
+		color: var(--color-text-tertiary);
+		background: transparent;
+		border: none;
+		cursor: pointer;
+	}
+
+	.clear:hover,
+	.clear:focus-visible {
+		color: var(--color-text);
+	}
+
+	.kbd {
+		font-family: var(--font-mono, 'JetBrains Mono', monospace);
+		font-size: 10px;
+		color: var(--color-text-tertiary);
+		border: 1px solid var(--color-border-subtle);
+		padding: 2px 5px;
+		letter-spacing: 0.05em;
+	}
+</style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
 	import { PUBLIC_CLERK_PUBLISHABLE_KEY } from '$env/static/public';
 	import { page } from '$app/state';
 	import GlobalCmdkBinding from '$lib/components/search/GlobalCmdkBinding.svelte';
+	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
 
 	let { data, children } = $props();
 
@@ -38,6 +39,7 @@
 		<PostHogProvider />
 		<SyncProvider />
 		<GlobalCmdkBinding />
+		<CommandPalette />
 		<a href="#main-content" class="skip-link">Skip to content</a>
 
 		<div class="min-h-dvh flex flex-col">


### PR DESCRIPTION
## Summary
- Step 5 of [tasks/cmdk-palette-plan.md](tasks/cmdk-palette-plan.md) — first visible UI
- Pressing ⌘K now renders a modal (desktop) / full-screen sheet (mobile)
- Refined brutalist: zero radius, flat 0.45 backdrop (NOT blurred — for step 8's filter-behind-modal feature), uppercase chip labels, mono kbd hints

## New components (\`frontend/src/lib/components/search/\`)
- \`CommandPalette.svelte\` — bits-ui Dialog with desktop/mobile variant switch
- \`CommandPaletteInput.svelte\` — \`<input role="combobox">\` with full ARIA attrs
- \`ActiveFiltersRow.svelte\` — chips beneath input (WAI-ARIA: not inside)
- \`Chip.svelte\` — peelable button

## New dep
- \`bits-ui ^2.18.1\` — first headless UI library in frontend/

## Stopgaps (resolved in subsequent steps)
- Chip removal clears whole query (step 8 lands proper peeling)
- Result region shows placeholder text (step 6 wires \`palette.results\`)
- No listbox keyboard nav yet (step 6)

## Test plan
- [x] \`cd frontend && npx svelte-check\` — 0 errors
- [x] \`cd frontend && npm test\` — 50/50 pass
- [ ] Manual ⌘K test deferred until step 6 has real results

🤖 Generated with [Claude Code](https://claude.com/claude-code)