### PR TITLE
fix(scrapers): BST timezone bug — bfi, rich-mix off by +1h

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-05-26: BST timezone fix — bfi.ts, rich-mix.ts, rich-mix-v2.ts off by +1h
+**PR**: TBD | **Files**: `src/scrapers/cinemas/bfi.ts`, `src/scrapers/cinemas/rich-mix.ts`, `src/scrapers/cinemas/rich-mix-v2.ts`, `src/scrapers/cinemas/bst-regression.test.ts` (new), `scripts/verify-bst-fix.ts` (new), `scripts/diagnose-bst-bug.ts` (new)
+- Customer-reported bug: site displayed showtimes 1 hour ahead of reality during BST. Three scrapers were using `new Date(y, m, d, h, mi)` (local-TZ constructor); on the UTC server this stored BST clock-face times as UTC, and the frontend's UTC→Europe/London render added +1h on top. Verified end-to-end against Rich Mix's Spektrix API.
+- Fix: route all three through `ukLocalToUTC()` — the project's existing BST-safe helper that Curzon/Picturehouse/Everyman already use.
+- Data backfill: 5 BFI duplicates deleted (rows where a correct PDF-source twin existed at -1h) + 210 BFI rows shifted -1h + 79 Rich Mix rows shifted -1h. 294 rows total. Scoped strictly by `source_id` prefix; bfi-pdf and bfi-changes data left untouched.
+- Regression test added at `src/scrapers/cinemas/bst-regression.test.ts` (vitest worker hangs in this checkout — pre-existing infra issue, not from this change; manual verify via `TZ=UTC npx tsx scripts/verify-bst-fix.ts` passes 7/7).
+
+---
+
 ## 2026-05-20: cmd+k step 10 — E2E spec + production alias promotion + step-9 deferred
 **PR**: TBD | **Files**: `frontend/tests/command-palette.spec.ts` (new), `changelogs/2026-05-19-cmdk-step9-deferred.md` (new)
 - Step 10: 5-case Playwright spec locks in the cmd+k contract — ⌘K opens / Esc closes, fuzzy query renders Amélie via trigram, Enter on a film row navigates to `/film/[id]`, composite filter-action surfaces for multi-slice queries, Enter on it mutates the calendar (`70mm` + `Horror` pressed in sidebar). All 5 pass cleanly in 15.3s on chromium.

--- a/changelogs/2026-05-26-bst-scraper-timezone-fix.md
+++ b/changelogs/2026-05-26-bst-scraper-timezone-fix.md
@@ -1,0 +1,82 @@
+# BST timezone fix — bfi.ts, rich-mix.ts, rich-mix-v2.ts off by +1h
+
+**PR**: TBD
+**Date**: 2026-05-26
+
+## Customer report
+
+A user reported on 2026-05-26 (mid-BST):
+
+> Ur website has failed me. Was wanting to escape the heat, so found Devil Wears Prada 2 at the near cinema at 6:30. And gets here. The film was on at 5:30. And realized all the times on the site have not accounted for daylight savings.
+
+i.e. pictures.london was showing showtimes 1 hour ahead of the actual cinema times during BST.
+
+## Root cause
+
+Three scrapers constructed `Date` objects with the local-timezone constructor:
+
+```ts
+new Date(year, month, day, hours, minutes); // ❌ depends on host TZ
+```
+
+On the UTC server (Vercel / cloud orchestrator) this interprets the components as UTC, so a cinema's "18:10 BST" gets stored as `2026-05-26T18:10:00Z`. The frontend then correctly renders UTC → Europe/London (which adds +1h during BST), producing `19:10 BST` — one hour ahead of the actual showtime.
+
+Verified end-to-end against Rich Mix's Spektrix API, which conveniently emits both `start` (UK local) and `startUtc`:
+
+```
+API:  start = "2026-05-26 18:10:00"   startUtc = "2026-05-26 17:10:00"
+DB (pre-fix):  2026-05-26 18:10:00+00  →  displayed 19:10 BST  (WRONG, +1h)
+DB (post-fix): 2026-05-26 17:10:00+00  →  displayed 18:10 BST  (matches API)
+```
+
+The project already has a `ukLocalToUTC()` helper specifically for this. Curzon, Picturehouse, and Everyman were fixed previously; these three slipped through.
+
+## Code changes
+
+| File | Change |
+|---|---|
+| `src/scrapers/cinemas/bfi.ts` | `parseBFIDateTime` now routes through `ukLocalToUTC` |
+| `src/scrapers/cinemas/rich-mix.ts` | `parseDateTime` now routes through `ukLocalToUTC` |
+| `src/scrapers/cinemas/rich-mix-v2.ts` | `parseDateTime` now routes through `ukLocalToUTC` |
+| `src/scrapers/cinemas/bst-regression.test.ts` (new) | Locks in BST behaviour for all three parsers |
+| `scripts/verify-bst-fix.ts` (new) | Manual verification harness — algorithm mirror under TZ=UTC, 7/7 pass |
+| `scripts/diagnose-bst-bug.ts` (new) | Diagnostic harness used during root-cause investigation |
+
+## Data backfill
+
+BFI turned out to have three data sources writing to the same table:
+
+| source_id prefix | Source | Bug status |
+|---|---|---|
+| `bfi-southbank-*` / `bfi-imax-*` | `bfi.ts` website scraper | BUGGY |
+| `bfi-pdf-*` | `bfi-pdf` PDF importer | Correct (uses `ukLocalToUTC`) |
+| `bfi-changes-*` | `programme-changes-parser` | Correct (uses `ukLocalToUTC`) |
+| `richmix-*` (cinema_id `rich-mix`) | `rich-mix.ts` / `-v2.ts` | BUGGY |
+
+Surgical backfill, scoped strictly by `source_id`:
+
+- **DELETE 5** BFI rows where a correct twin existed at `-1h` (would have collided on the `(film_id, cinema_id, datetime)` unique index)
+- **UPDATE 210** other BFI buggy rows, shifted `-1h`
+- **UPDATE 79** Rich Mix buggy rows, shifted `-1h`
+
+Total: 294 row changes. Correct sources (`bfi-pdf-*`, `bfi-changes-*`) untouched.
+
+## Verification
+
+Cross-checked DB against Rich Mix Spektrix API after backfill:
+
+| Showtime | API (truth) | DB after fix | Match |
+|---|---|---|---|
+| Wed 27 May | UTC 14:30 / UK 15:30 | UTC 14:30 / Lon 15:30 | ✅ |
+| Thu 28 May | UTC 14:15 / UK 15:15 | UTC 14:15 / Lon 15:15 | ✅ |
+
+## Impact
+
+- Affected venues: BFI Southbank, BFI IMAX, Rich Mix (and any other cinema scraped through `bfi.ts` / `rich-mix.ts` / `rich-mix-v2.ts` during BST 2026-03-29 → present).
+- Affected users: anyone planning a screening at those venues using pictures.london during BST. Customer-reported impact: arriving an hour late.
+- Side effects: none on correctly-stored data; all changes scoped to known-buggy `source_id` prefixes.
+
+## Known follow-ups
+
+- Vitest workers hang in this checkout (pre-existing, not from this change). Manual verify via `TZ=UTC npx tsx scripts/verify-bst-fix.ts` passes 7/7.
+- Discussed guardrail options to prevent recurrence (ESLint rule banning the local-TZ `Date` constructor in `src/scrapers/**`); deferred until after this customer-facing fix lands.

--- a/scripts/diagnose-bst-bug.ts
+++ b/scripts/diagnose-bst-bug.ts
@@ -1,0 +1,84 @@
+/**
+ * Diagnose the BST bug reported by a customer on 2026-05-26.
+ *
+ * Symptom: Site shows showtime 1 hour ahead of the actual cinema time.
+ * Hypothesis: Some scrapers store BST clock-face times as UTC, so the
+ * frontend's UTC->London conversion adds +1 hour on top of an already-wrong
+ * value. Affected scrapers (suspected): bfi, rich-mix, rich-mix-v2.
+ *
+ * This script: for each cinema, print the next 3 upcoming screenings'
+ * datetime field as both UTC and Europe/London, plus how it would APPEAR
+ * to the user vs what the cinema's own website would say. If the rendered
+ * London time equals the original UK clock-face value the scraper read,
+ * the data is correct. If it's 1 hour AHEAD, the bug is confirmed.
+ */
+import "dotenv/config";
+import { db } from "../src/db";
+import { screenings, cinemas, films } from "../src/db/schema";
+import { and, eq, gte, asc } from "drizzle-orm";
+
+// Match by name pattern instead of slug since slug conventions vary.
+const SUSPECT_NAME_PATTERNS = [
+  /^bfi\b/i,
+  /rich.?mix/i,
+  /regent.?street/i,
+  /everyman/i, // chain control: should be CORRECT
+  /curzon/i,   // chain control: should be CORRECT
+  /riverside/i,
+];
+
+const londonFmt = new Intl.DateTimeFormat("en-GB", {
+  weekday: "short",
+  day: "2-digit",
+  month: "short",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+  timeZone: "Europe/London",
+});
+
+async function main() {
+  console.error(`Today (UK): ${new Intl.DateTimeFormat("en-GB", { timeZone: "Europe/London", dateStyle: "full" }).format(new Date())}`);
+  console.error(`BST active: yes (UTC+1, until last Sunday of October)`);
+  console.error(`Connecting to DB...`);
+
+  const allCinemas = await db.select({ id: cinemas.id, name: cinemas.name }).from(cinemas);
+  console.error(`Loaded ${allCinemas.length} cinemas\n`);
+  const now = new Date();
+
+  const targets = allCinemas.filter((c) =>
+    SUSPECT_NAME_PATTERNS.some((re) => re.test(c.name))
+  );
+  console.log(`Inspecting ${targets.length} cinemas matching suspect/control patterns:\n`);
+
+  for (const cinema of targets) {
+    const rows = await db
+      .select({ id: screenings.id, datetime: screenings.datetime, title: films.title, bookingUrl: screenings.bookingUrl })
+      .from(screenings)
+      .innerJoin(films, eq(films.id, screenings.filmId))
+      .where(and(eq(screenings.cinemaId, cinema.id), gte(screenings.datetime, now)))
+      .orderBy(asc(screenings.datetime))
+      .limit(3);
+
+    console.log(`▶ ${cinema.name} (${cinema.id})`);
+    if (rows.length === 0) {
+      console.log("  (no upcoming screenings)\n");
+      continue;
+    }
+    for (const r of rows) {
+      const dt = r.datetime instanceof Date ? r.datetime : new Date(r.datetime as unknown as string);
+      console.log(`  DB UTC: ${dt.toISOString()}`);
+      console.log(`  Rendered to user: ${londonFmt.format(dt)}`);
+      console.log(`  Film: ${r.title}`);
+      console.log(`  Booking: ${r.bookingUrl}\n`);
+    }
+  }
+
+  process.exit(0);
+}
+
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/verify-bst-fix.ts
+++ b/scripts/verify-bst-fix.ts
@@ -1,0 +1,109 @@
+/**
+ * Manual verification of the BST scraper fix.
+ *
+ * Vitest workers hang on this checkout (pre-existing infra issue) and the
+ * scraper classes pull in the DB at module-load via FestivalDetector, so we
+ * can't import them in a one-shot script either. Instead we mirror the exact
+ * algorithm now used by rich-mix.ts, rich-mix-v2.ts, and bfi.ts — all three
+ * resolve to `ukLocalToUTC(...)`. Run with TZ=UTC to simulate prod.
+ *
+ *   TZ=UTC npx tsx scripts/verify-bst-fix.ts
+ */
+import { ukLocalToUTC } from "../src/scrapers/utils/date-parser";
+
+let passed = 0;
+let failed = 0;
+function check(name: string, actual: string | undefined, expected: string) {
+  if (actual === expected) {
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        expected: ${expected}`);
+    console.log(`        actual:   ${actual}`);
+    failed++;
+  }
+}
+
+console.log(`TZ at runtime: ${process.env.TZ ?? "(not set)"}\n`);
+
+// Algorithm mirror for rich-mix.ts / rich-mix-v2.ts parseDateTime
+function richMixParse(dateStr: string): Date | null {
+  const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/);
+  if (!match) return null;
+  const [, year, month, day, hour, minute] = match;
+  return ukLocalToUTC(
+    parseInt(year, 10),
+    parseInt(month, 10) - 1,
+    parseInt(day, 10),
+    parseInt(hour, 10),
+    parseInt(minute, 10),
+  );
+}
+
+// Algorithm mirror for bfi.ts parseBFIDateTime
+const MONTHS: Record<string, number> = {
+  January: 0, February: 1, March: 2, April: 3,
+  May: 4, June: 5, July: 6, August: 7,
+  September: 8, October: 9, November: 10, December: 11,
+};
+function bfiParse(text: string): Date | null {
+  const match = text.match(/(\d{1,2})\s+(\w+)\s+(\d{4})\s+(\d{1,2}):(\d{2})/);
+  if (!match) return null;
+  const [, day, monthName, year, hours, minutes] = match;
+  const month = MONTHS[monthName];
+  if (month === undefined) return null;
+  return ukLocalToUTC(
+    parseInt(year),
+    month,
+    parseInt(day),
+    parseInt(hours),
+    parseInt(minutes),
+  );
+}
+
+console.log("rich-mix.ts / rich-mix-v2.ts parseDateTime");
+check(
+  "BST: 2026-05-26 18:10:00 → 17:10 UTC",
+  richMixParse("2026-05-26 18:10:00")?.toISOString(),
+  "2026-05-26T17:10:00.000Z",
+);
+check(
+  "GMT: 2026-01-15 18:10:00 → 18:10 UTC (no offset)",
+  richMixParse("2026-01-15 18:10:00")?.toISOString(),
+  "2026-01-15T18:10:00.000Z",
+);
+
+console.log("\nbfi.ts parseBFIDateTime");
+check(
+  "BST: 'Tuesday 26 May 2026 18:10' → 17:10 UTC",
+  bfiParse("Tuesday 26 May 2026 18:10")?.toISOString(),
+  "2026-05-26T17:10:00.000Z",
+);
+check(
+  "GMT: 'Thursday 15 January 2026 18:10' → 18:10 UTC (no offset)",
+  bfiParse("Thursday 15 January 2026 18:10")?.toISOString(),
+  "2026-01-15T18:10:00.000Z",
+);
+
+// BST boundary checks. Project convention (per date-parser.ts isUKSummerTime):
+// the ambiguous 01:xx hour on BST-end Sunday is treated as still-BST.
+console.log("\nDST boundaries");
+check(
+  "BST end Sunday 01:30 (treated as BST per project convention) → 00:30 UTC",
+  ukLocalToUTC(2026, 9, 25, 1, 30).toISOString(),
+  "2026-10-25T00:30:00.000Z",
+);
+check(
+  "BST end Sunday 02:30 (GMT) → 02:30 UTC",
+  ukLocalToUTC(2026, 9, 25, 2, 30).toISOString(),
+  "2026-10-25T02:30:00.000Z",
+);
+check(
+  "BST start Sunday 02:30 (BST) → 01:30 UTC",
+  ukLocalToUTC(2026, 2, 29, 2, 30).toISOString(),
+  "2026-03-29T01:30:00.000Z",
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/src/scrapers/cinemas/bfi.ts
+++ b/src/scrapers/cinemas/bfi.ts
@@ -11,6 +11,7 @@ import type { BrowserContext, Page } from "rebrowser-playwright";
 import { parseFilmMetadata } from "../utils/metadata-parser";
 import { FestivalDetector } from "../festivals/festival-detector";
 import { loadBFIScreenings, getBFIVenueKey } from "../bfi-pdf";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 interface BFIVenueConfig {
   id: "bfi-southbank" | "bfi-imax";
@@ -418,7 +419,7 @@ export class BFIScraper {
   }
 
   private parseBFIDateTime(text: string): Date | null {
-    // Format: "Friday 19 December 2025 14:30"
+    // Format: "Friday 19 December 2025 14:30" — UK local time on the cinema page.
     const match = text.match(/(\d{1,2})\s+(\w+)\s+(\d{4})\s+(\d{1,2}):(\d{2})/);
     if (!match) return null;
 
@@ -433,12 +434,15 @@ export class BFIScraper {
     const month = months[monthName];
     if (month === undefined) return null;
 
-    return new Date(
+    // Use ukLocalToUTC to apply BST explicitly — `new Date(y,m,d,h,mi)`
+    // depends on the runtime's local TZ and silently stored BST clock-face
+    // times as UTC on the UTC server (rendering 1h ahead of reality).
+    return ukLocalToUTC(
       parseInt(year),
       month,
       parseInt(day),
       parseInt(hours),
-      parseInt(minutes)
+      parseInt(minutes),
     );
   }
 

--- a/src/scrapers/cinemas/bst-regression.test.ts
+++ b/src/scrapers/cinemas/bst-regression.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression test for the BST timezone bug surfaced by customer feedback on
+ * 2026-05-26: scrapers using `new Date(y, m, d, h, mi)` (local-TZ constructor)
+ * were storing BST clock-face times as UTC on the UTC server (Vercel), causing
+ * the frontend's UTC→Europe/London conversion to render times 1 hour ahead of
+ * reality.
+ *
+ * Each scraper's `parseDateTime` must:
+ *   - return a Date that is exactly 1 hour BEFORE the clock-face hour for BST
+ *     input dates (last Sun of March → last Sun of October, 01:00 UTC).
+ *   - return a Date matching the clock-face hour exactly for GMT input dates.
+ *
+ * Methods under test are `private`; we reach in via `as unknown as { ... }`
+ * rather than changing visibility just for tests.
+ */
+import { describe, expect, it } from "vitest";
+
+import { RichMixScraper } from "./rich-mix";
+import { RichMixScraperV2 } from "./rich-mix-v2";
+import { BFIScraper } from "./bfi";
+
+type PrivDate = { parseDateTime: (s: string) => Date | null };
+type PrivBFI = { parseBFIDateTime: (s: string) => Date | null };
+
+describe("BST regression: Rich Mix parseDateTime", () => {
+  const scraper = new RichMixScraper() as unknown as PrivDate;
+
+  it("BST: 2026-05-26 18:10:00 UK local → 17:10 UTC", () => {
+    expect(scraper.parseDateTime("2026-05-26 18:10:00")?.toISOString())
+      .toBe("2026-05-26T17:10:00.000Z");
+  });
+
+  it("GMT: 2026-01-15 18:10:00 UK local → 18:10 UTC (no offset)", () => {
+    expect(scraper.parseDateTime("2026-01-15 18:10:00")?.toISOString())
+      .toBe("2026-01-15T18:10:00.000Z");
+  });
+});
+
+describe("BST regression: Rich Mix v2 parseDateTime", () => {
+  const scraper = new RichMixScraperV2() as unknown as PrivDate;
+
+  it("BST: 2026-05-26 18:10:00 UK local → 17:10 UTC", () => {
+    expect(scraper.parseDateTime("2026-05-26 18:10:00")?.toISOString())
+      .toBe("2026-05-26T17:10:00.000Z");
+  });
+
+  it("GMT: 2026-01-15 18:10:00 UK local → 18:10 UTC (no offset)", () => {
+    expect(scraper.parseDateTime("2026-01-15 18:10:00")?.toISOString())
+      .toBe("2026-01-15T18:10:00.000Z");
+  });
+});
+
+describe("BST regression: BFI parseBFIDateTime", () => {
+  const scraper = new BFIScraper() as unknown as PrivBFI;
+
+  it("BST: 'Tuesday 26 May 2026 18:10' → 17:10 UTC", () => {
+    expect(scraper.parseBFIDateTime("Tuesday 26 May 2026 18:10")?.toISOString())
+      .toBe("2026-05-26T17:10:00.000Z");
+  });
+
+  it("GMT: 'Thursday 15 January 2026 18:10' → 18:10 UTC (no offset)", () => {
+    expect(scraper.parseBFIDateTime("Thursday 15 January 2026 18:10")?.toISOString())
+      .toBe("2026-01-15T18:10:00.000Z");
+  });
+});

--- a/src/scrapers/cinemas/rich-mix-v2.ts
+++ b/src/scrapers/cinemas/rich-mix-v2.ts
@@ -12,6 +12,7 @@
 
 import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 // API response types
 interface SpektrixInstance {
@@ -113,8 +114,12 @@ export class RichMixScraperV2 extends BaseScraper {
   }
 
   /**
-   * Parse datetime string in format "2025-12-30 14:30:00"
-   * The API returns local London time
+   * Parse datetime string in format "2025-12-30 14:30:00" (UK local time).
+   *
+   * Goes through `ukLocalToUTC` so BST is applied explicitly — the previous
+   * `new Date(y,m,d,h,mi)` constructor depended on the runtime's local TZ,
+   * which silently stored BST clock-face times as UTC on the UTC server
+   * (rendering 1h ahead of reality to users).
    */
   private parseDateTime(dateStr: string): Date | null {
     if (!dateStr) return null;
@@ -124,13 +129,12 @@ export class RichMixScraperV2 extends BaseScraper {
 
     const [, year, month, day, hour, minute] = match;
 
-    return new Date(
+    return ukLocalToUTC(
       parseInt(year, 10),
       parseInt(month, 10) - 1,
       parseInt(day, 10),
       parseInt(hour, 10),
       parseInt(minute, 10),
-      0
     );
   }
 

--- a/src/scrapers/cinemas/rich-mix.ts
+++ b/src/scrapers/cinemas/rich-mix.ts
@@ -14,6 +14,7 @@ import { BOT_USER_AGENT } from "../constants";
 import type { RawScreening, ScraperConfig, CinemaScraper } from "../types";
 import { FestivalDetector } from "../festivals/festival-detector";
 import { checkHealth } from "../utils/health-check";
+import { ukLocalToUTC } from "../utils/date-parser";
 
 const RICHMIX_CONFIG: ScraperConfig & { apiUrl: string } = {
   cinemaId: "rich-mix",
@@ -128,28 +129,28 @@ export class RichMixScraper implements CinemaScraper {
   }
 
   /**
-   * Parse datetime string in format "2025-12-30 14:30:00"
-   * The API returns local London time
+   * Parse datetime string in format "2025-12-30 14:30:00" (UK local time).
+   *
+   * Goes through `ukLocalToUTC` so BST is applied explicitly — the previous
+   * `new Date(y,m,d,h,mi)` constructor depended on the runtime's local TZ,
+   * which silently stored BST clock-face times as UTC on the UTC server
+   * (rendering 1h ahead of reality to users).
    */
   private parseDateTime(dateStr: string): Date | null {
     if (!dateStr) return null;
 
-    // Format: "2025-12-30 14:30:00"
     const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/);
     if (!match) return null;
 
     const [, year, month, day, hour, minute] = match;
 
-    const date = new Date(
+    return ukLocalToUTC(
       parseInt(year, 10),
-      parseInt(month, 10) - 1, // 0-indexed month
+      parseInt(month, 10) - 1,
       parseInt(day, 10),
       parseInt(hour, 10),
       parseInt(minute, 10),
-      0
     );
-
-    return date;
   }
 
   async healthCheck(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Customer reported on 2026-05-26 (mid-BST) that pictures.london was showing showtimes 1 hour ahead of reality. Root cause: `bfi.ts`, `rich-mix.ts`, `rich-mix-v2.ts` used `new Date(y, m, d, h, mi)` (local-TZ constructor) which on the UTC server stored BST clock-face times as UTC.
- Routed all three through the project's existing `ukLocalToUTC()` helper (same fix Curzon/Picturehouse/Everyman got previously).
- Production data backfill already shipped on `main`'s schema (separate transaction): 5 BFI duplicates deleted, 210 BFI rows shifted -1h, 79 Rich Mix rows shifted -1h. Strictly scoped by `source_id`; `bfi-pdf` and `bfi-changes` data untouched. Details in `changelogs/2026-05-26-bst-scraper-timezone-fix.md`.

## Verification
- End-to-end against Rich Mix's Spektrix API (the original ground truth that surfaced the bug): pre-fix stored as `start` (UK local), post-fix matches `startUtc` exactly for next two showings of Devil Wears Prada 2.
- Algorithm verification: `TZ=UTC npx tsx scripts/verify-bst-fix.ts` → 7/7 pass.
- `npx tsc --noEmit | grep -E "rich-mix|bfi|bst-regression"` → no matches in changed files.
- `npx eslint <changed files>` → clean (exit 0, no output).

## Test plan
- [x] BST showing parses to `(clock-face - 1h) UTC`
- [x] GMT showing parses to `clock-face UTC` (no offset applied)
- [x] DST boundary cases honour project convention (`isUKSummerTime`)
- [x] Spot-check live DB vs richmix.org.uk Spektrix API
- [ ] After merge: monitor next nightly scrape — fresh rows for BFI/Rich Mix should arrive at the correct UTC and the next-day spot-check vs each cinema's site should match

## Known follow-ups
- Vitest workers hang in this checkout (pre-existing infra issue affecting other scraper tests too — `bfi.test.ts` also fails); the regression test file is correct and will run once that's resolved. Manual harness at `scripts/verify-bst-fix.ts` covers the algorithm in the meantime.
- Discussed adding an ESLint rule banning `new Date(\w+,\s*\w+,\s*\w+,\s*\w+,\s*\w+)` in `src/scrapers/**` to prevent this from recurring. Deferred — would land in a separate PR with the lint config change so reviewers can react to it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)