### PR TITLE
perf(fonts): repoint InterVariable preload to Cormorant-Italic + fix resource hints

### DIFF
--- a/changelogs/2026-05-29-repoint-inter-preload-to-cormorant.md
+++ b/changelogs/2026-05-29-repoint-inter-preload-to-cormorant.md
@@ -1,0 +1,21 @@
+# Repoint the misdirected InterVariable preload in app.html to Cormorant-Italic (+3 related fonts fixes)
+
+**PR**: perf campaign
+**Date**: 2026-05-29
+
+## Changes
+- **Repoint font preload** (`app.html` line 11): changed the high-priority `preload` from `/fonts/InterVariable.woff2` (352,240 B, never painted above the fold — only Chip.svelte after a filter and the FittedTitleCanvas fallback consume Inter) to `/fonts/Cormorant-Italic.woff2` (38,140 B, `--font-serif-italic`, painted on first load in the Header watchlist link and the homepage masthead/day headers). Inter still loads on demand via its retained `@font-face` (`font-display:swap`). Fraunces and IBMPlexMono preloads untouched.
+- **Drop `crossorigin` from the image.tmdb.org preconnect** (line 7): browsers key sockets by `(origin, CORS-mode)`. Every critical-path poster `<img>` (DesktopHybridCard, MobileFilmRow, FilmCard, the film-detail hero, the home LCP `preload as=image`) loads in NON-CORS mode, so the CORS-warmed socket could never be reused. The preconnect now matches the real non-CORS poster requests; the hover-only CORS canvas (FittedTitleCanvas) opens its own connection regardless. `dns-prefetch` left intact.
+- **Remove the dead `api.pictures.london` preconnect + dns-prefetch** (former lines 9-10): the browser never contacts that origin — the client API helper fetches relative `/api/*` paths that `vercel.json` rewrites server-side; the literal host only appears in SSR (`src/lib/server/api.ts`). The hint wasted a concurrent-connection slot and a DNS+TLS handshake every page load.
+- **Add `clerk.pictures.london` preconnect (crossorigin) + dns-prefetch** (in place of the removed api hints): in production the publishable key decodes to `clerk.pictures.london` and `ClerkProvider` renders unconditionally, so ClerkJS bootstraps its bundle + `/v1/client` on every production page. `crossorigin` is kept because ClerkJS fetches with CORS credentials, matching the warmed socket. In dev/non-clerk builds the hint is a harmless no-op.
+
+## Impact
+- **Who/what**: every visitor to pictures.london (all routes share `app.html`).
+- **Metrics moved**:
+  - LCP / critical-path font bytes: removes a 352 KB non-visible high-priority preload from the queue and promotes the 38 KB Cormorant-Italic face to kill above-the-fold FOUT on the masthead + Header watchlist link.
+  - LCP poster: removes one DNS+TLS round-trip (~100-300 ms on cold mobile) from the critical TMDB poster request by making the warmed socket reusable.
+  - TTFB/contention: frees a concurrent-connection slot by dropping the unused api.pictures.london handshake, letting tmdb/clerk connections open sooner.
+  - Hydration/auth-ready: saves one DNS+TLS round-trip (~100-300 ms cold) on the Clerk frontend-API connection bootstrapped on every production page.
+
+## Behavior preservation
+Rendered DOM, layout, and computed styles are byte-identical — only resource-hint `<link>` attributes/targets changed (no element produces visible output); acceptance: Playwright on `/` at 390×844 and 1280px confirms Cormorant-Italic is fetched early high-priority while InterVariable is NOT fetched on initial load (loads on demand when a Chip renders after a filter), exactly one non-CORS socket opens to image.tmdb.org and is reused by the LCP poster, no browser connection is ever opened to api.pictures.london, the Clerk socket warms during HTML parse, and pixel-diffs of the masthead + Header + film detail are identical after fonts settle.

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -4,11 +4,11 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#0a0a0a" />
-		<link rel="preconnect" href="https://image.tmdb.org" crossorigin />
+		<link rel="preconnect" href="https://image.tmdb.org" />
 		<link rel="dns-prefetch" href="https://image.tmdb.org" />
-		<link rel="preconnect" href="https://api.pictures.london" crossorigin />
-		<link rel="dns-prefetch" href="https://api.pictures.london" />
-		<link rel="preload" href="/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin />
+		<link rel="preconnect" href="https://clerk.pictures.london" crossorigin />
+		<link rel="dns-prefetch" href="https://clerk.pictures.london" />
+		<link rel="preload" href="/fonts/Cormorant-Italic.woff2" as="font" type="font/woff2" crossorigin />
 		<link rel="preload" href="/fonts/Fraunces.woff2" as="font" type="font/woff2" crossorigin />
 		<link rel="preload" href="/fonts/IBMPlexMono.woff2" as="font" type="font/woff2" crossorigin />
 		<script>


### PR DESCRIPTION
## What
Four behavior-preserving resource-hint changes in `frontend/src/app.html`:
1. **Repoint the font preload** from `/fonts/InterVariable.woff2` (352,240 B, never painted above the fold) to `/fonts/Cormorant-Italic.woff2` (38,140 B, `--font-serif-italic`, painted on first load in the Header watchlist link + homepage masthead/day headers). Inter still loads on demand via its retained `@font-face` (`font-display:swap`).
2. **Drop `crossorigin`** from the `image.tmdb.org` preconnect so the warmed socket matches the non-CORS critical-path poster requests (DesktopHybridCard, MobileFilmRow, FilmCard, film-detail hero, home LCP `preload as=image`).
3. **Remove the dead `api.pictures.london` preconnect + dns-prefetch** — the browser only fetches same-origin `/api/*` (rewritten server-side by `vercel.json`); the literal host is SSR-only (`src/lib/server/api.ts`).
4. **Add `clerk.pictures.london` preconnect (crossorigin) + dns-prefetch** — in production the publishable key decodes to that origin and `ClerkProvider` bootstraps ClerkJS + `/v1/client` on every page; `crossorigin` matches ClerkJS's CORS-credentialed fetches.

## Why
- LCP / critical-path font bytes: -352 KB off the high-priority preload queue; +38 KB Cormorant promoted to kill above-the-fold FOUT on masthead + header.
- LCP poster: removes one DNS+TLS round-trip (~100-300 ms cold mobile) by making the tmdb socket reusable for the non-CORS poster.
- TTFB/contention: frees a concurrent-connection slot by dropping the unused api.pictures.london handshake.
- Hydration / auth-ready: saves ~100-300 ms cold on the Clerk frontend-API connection bootstrapped on every production page.

## Behavior preservation
Rendered DOM, layout, and computed styles are byte-identical — only `<link>` resource-hint attributes/targets changed, none of which produce visible output. Local gate: `npx svelte-kit sync && npx svelte-check` → 0 errors, 2 (pre-existing) warnings.

**Acceptance**: Playwright on `/` at 390×844 and 1280px — Cormorant-Italic fetched early high-priority while InterVariable is NOT fetched on initial load (loads on demand when a Chip renders after a filter applies); exactly one non-CORS socket opens to image.tmdb.org and the LCP poster + home preload reuse it; no browser connection ever opens to api.pictures.london (SSR data still loads); the Clerk socket warms during HTML parse and sign-in/out still works; FittedTitleCanvas still reads the CORS canvas on hover; pixel-diff of masthead + Header + film detail identical after fonts settle; LCP neutral-or-better across 5 runs.

## Files
- `frontend/src/app.html`
- `changelogs/2026-05-29-repoint-inter-preload-to-cormorant.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)