### PR TITLE
fix(rate-limit): fail open when Upstash backing store is unavailable (P0 outage fix)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-05-30: P0 — rate limiter fails open (prod outage fix)
+**PR**: TBD | **Files**: `src/lib/rate-limit.ts`, `changelogs/2026-05-30-rate-limit-fail-open.md` (new)
+- Production was fully down (every API route + SSR returning 500 / `FUNCTION_INVOCATION_FAILED`). Root cause: Upstash Redis hit its 500k-request quota; `checkRateLimit()` (the first call in every route) threw the `max requests limit exceeded` error instead of failing open, 500'ing all DB-backed endpoints before the query even ran.
+- Fix: `checkRateLimit` now catches backing-store errors and falls back to the existing in-memory limiter — a rate limiter can no longer take down the whole API.
+- Also corrected during triage: prod `DATABASE_URL` env var had a trailing literal `\n` (corrupted db name `postgres\n`, `3D000`) — a latent bug that would have broken queries once past the limiter.
+
+---
+
 ## 2026-05-26: BST timezone fix — bfi.ts, rich-mix.ts, rich-mix-v2.ts off by +1h
 **PR**: TBD | **Files**: `src/scrapers/cinemas/bfi.ts`, `src/scrapers/cinemas/rich-mix.ts`, `src/scrapers/cinemas/rich-mix-v2.ts`, `src/scrapers/cinemas/bst-regression.test.ts` (new), `scripts/verify-bst-fix.ts` (new), `scripts/diagnose-bst-bug.ts` (new)
 - Customer-reported bug: site displayed showtimes 1 hour ahead of reality during BST. Three scrapers were using `new Date(y, m, d, h, mi)` (local-TZ constructor); on the UTC server this stored BST clock-face times as UTC, and the frontend's UTC→Europe/London render added +1h on top. Verified end-to-end against Rich Mix's Spektrix API.

--- a/changelogs/2026-05-30-rate-limit-fail-open.md
+++ b/changelogs/2026-05-30-rate-limit-fail-open.md
@@ -1,0 +1,21 @@
+# Rate limiter fails open when backing store is unavailable
+
+**Date**: 2026-05-30
+**Severity**: P0 incident fix (production outage)
+
+## Changes
+- `src/lib/rate-limit.ts`: wrapped the Upstash `rl.limit()` call in `checkRateLimit` in a try/catch. On any backing-store error the limiter now **fails open** by falling back to the existing per-instance in-memory limiter, instead of letting the error propagate.
+
+## Root cause (incident 2026-05-30)
+- Upstash Redis (the rate-limiter backing store) hit its **500,000-request quota** and began returning `ERR max requests limit exceeded` for every command.
+- `checkRateLimit()` is the **first** call in essentially every API route (before the DB query). The unhandled throw became a `500 Internal server error` on every DB-backed endpoint (`/api/cinemas`, `/api/screenings`, …).
+- The frontend SSR (`frontend/src/lib/server/api.ts` fetches `https://api.pictures.london`) then cascaded to `FUNCTION_INVOCATION_FAILED`, taking `www.pictures.london` down with it.
+- A separate latent bug was also fixed during triage: the production `DATABASE_URL` env var had a trailing literal `\n`, corrupting the database name to `postgres\n` (`3D000`). That value would have broken DB queries once the request got past the rate limiter, so it was corrected too.
+
+## Impact
+- A backing-store outage (downtime, quota, network) can no longer take down the entire API. Rate limiting degrades gracefully to per-instance in-memory counting.
+- Behavior is identical on the happy path (Upstash healthy → same limits, same responses).
+
+## Follow-ups (not in this PR)
+- Investigate/raise the Upstash request quota (root cause of the 500k overage).
+- Restore the **preview** `DATABASE_URL` env var (removed during triage; PR preview deploys need it).

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -154,13 +154,29 @@ export async function checkRateLimit(
   }
 
   const rl = getOrCreateRatelimiter(config);
-  const { success, remaining, reset } = await rl.limit(identifier);
 
-  return {
-    success,
-    remaining,
-    resetIn: Math.max(0, Math.ceil((reset - Date.now()) / 1000)),
-  };
+  // Fail OPEN if the backing store is unavailable. A rate limiter must never
+  // take down the whole API: if Upstash is unreachable, rate-limited, or over
+  // quota, `rl.limit()` throws — without this catch that throw propagates to
+  // every route's handler as a 500. (Incident 2026-05-30: Upstash hit its
+  // 500k request quota and EVERY DB-backed route 500'd here, before the query
+  // even ran.) On error we fall back to the per-instance in-memory limiter so
+  // basic protection survives, and never crash the request path.
+  try {
+    const { success, remaining, reset } = await rl.limit(identifier);
+
+    return {
+      success,
+      remaining,
+      resetIn: Math.max(0, Math.ceil((reset - Date.now()) / 1000)),
+    };
+  } catch (err) {
+    console.warn(
+      "[rate-limit] backing store unavailable, failing open via in-memory:",
+      (err as Error)?.message
+    );
+    return checkRateLimitInMemory(identifier, config);
+  }
 }
 
 /**


### PR DESCRIPTION
## P0 production outage — root cause + fix

**Symptom:** `pictures.london` and `api.pictures.london` were fully down — every API route `500 Internal server error`, frontend SSR `FUNCTION_INVOCATION_FAILED`.

**Root cause:** Upstash Redis (rate-limiter backing store) hit its **500,000-request quota** and returned `ERR max requests limit exceeded` for every command. `checkRateLimit()` runs **first** in essentially every API route (before the DB query) and let that error propagate — so every DB-backed endpoint 500'd, and the frontend SSR (which fetches `api.pictures.london`) cascaded down with it.

**Fix:** `checkRateLimit` now wraps the Upstash `rl.limit()` call in try/catch and **fails open** to the existing per-instance in-memory limiter on any backing-store error. A rate-limiter outage can no longer take down the whole API. Happy-path behavior is unchanged.

**Also fixed during triage (env, already applied to prod):** the production `DATABASE_URL` had a trailing literal `\n` (corrupted db name → `3D000`). Corrected via the Vercel dashboard/API.

## Status
- Fix already deployed directly to prod to restore service (site verified back up: `/api/cinemas` 200, `www` 200). This PR brings `main` in sync so the fix isn't lost on the next deploy.

## Follow-ups
- Raise/inspect the Upstash request quota (the 500k overage).
- Restore the **preview** `DATABASE_URL` env var (removed during triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)