### PR TITLE
perf(img): add srcset/sizes to command-palette FilmRow + UserStatusRow posters

### DIFF
--- a/changelogs/2026-05-30-cmdk-row-poster-srcset.md
+++ b/changelogs/2026-05-30-cmdk-row-poster-srcset.md
@@ -1,0 +1,16 @@
+# add srcset/sizes to command-palette FilmRow + UserStatusRow posters
+
+**PR**: perf campaign
+**Date**: 2026-05-30
+
+## Changes
+- `FilmRow.svelte`: poster `<img>` now derives responsive image attributes via the existing `getPosterImageAttributes` util (`baseSize: 'w92'`, `srcSetSizes: ['w92','w154']`, `sizes: '36px'`) and emits `srcset` + `sizes`. `src` falls back to the raw `film.posterUrl` for non-TMDB hosts.
+- `UserStatusRow.svelte`: same treatment, with `sizes: '32px'` to match its 32px poster box, falling back to the raw `status.filmPosterUrl`.
+- Existing `width`/`height`/`loading`/`decoding`/`alt`/`class` attributes left untouched on both rows.
+
+## Impact
+- Affects the cmd+k command palette result list (`FilmRow`, `UserStatusRow`).
+- Perf metric moved: poster payload on palette queries. Browsers now fetch the w92 (or w154 on hi-DPI) TMDB variant for a ~36px/32px box instead of the persisted w500 image. ~90% poster byte reduction (~300-450KB -> ~30-40KB for an 8-result query), improving open-to-image latency on mobile/3G.
+
+## Behavior preservation
+Rendered DOM box, layout, and computed styles are identical (same width/height, same CSS class, same fallback `src` for non-TMDB hosts); only the fetched image variant changes. Acceptance: Playwright opens cmd+k, types a query, asserts the row `<img>` carries `srcset` (w92 + w154) and `sizes`, renders at the identical CSS box with no layout shift, and non-TMDB posters still resolve to the raw `src`.

--- a/frontend/src/lib/components/search/rows/FilmRow.svelte
+++ b/frontend/src/lib/components/search/rows/FilmRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	/** A single film row in the palette result list. */
 	import type { FilmResult } from '$lib/search/result-types';
+	import { getPosterImageAttributes } from '$lib/utils';
 
 	interface Props {
 		film: FilmResult;
@@ -21,8 +22,15 @@
 	data-result-row
 >
 	{#if film.posterUrl}
+		{@const posterImage = getPosterImageAttributes(film.posterUrl, {
+			baseSize: 'w92',
+			srcSetSizes: ['w92', 'w154'],
+			sizes: '36px'
+		})}
 		<img
-			src={film.posterUrl}
+			src={posterImage?.src ?? film.posterUrl}
+			srcset={posterImage?.srcset}
+			sizes={posterImage?.sizes}
 			alt=""
 			class="poster"
 			width="36"

--- a/frontend/src/lib/components/search/rows/UserStatusRow.svelte
+++ b/frontend/src/lib/components/search/rows/UserStatusRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { UserStatusResult } from '$lib/search/result-types';
+	import { getPosterImageAttributes } from '$lib/utils';
 
 	interface Props {
 		status: UserStatusResult;
@@ -28,8 +29,15 @@
 	data-result-row
 >
 	{#if status.filmPosterUrl}
+		{@const posterImage = getPosterImageAttributes(status.filmPosterUrl, {
+			baseSize: 'w92',
+			srcSetSizes: ['w92', 'w154'],
+			sizes: '32px'
+		})}
 		<img
-			src={status.filmPosterUrl}
+			src={posterImage?.src ?? status.filmPosterUrl}
+			srcset={posterImage?.srcset}
+			sizes={posterImage?.sizes}
 			alt=""
 			class="poster"
 			width="32"


### PR DESCRIPTION
## What
Adds responsive `srcset` + `sizes` to the poster `<img>` in the cmd+k command-palette rows `FilmRow.svelte` and `UserStatusRow.svelte`, using the existing `getPosterImageAttributes` util (`baseSize: 'w92'`, `srcSetSizes: ['w92','w154']`, `sizes: '36px'` for FilmRow / `'32px'` for UserStatusRow). `src` falls back to the raw poster URL.

## Why
Both palette rows rendered the persisted **w500** TMDB image into a tiny ~36px/32px box with no `srcset`/`sizes`, over-fetching ~25-55KB per row. An 8-result palette query downloaded ~300-450KB of poster bytes for thumbnails. Round-1 added `width`/`height`/`loading`/`decoding` but not `srcset`/`sizes`.

Expected metric: ~90% poster payload reduction on palette queries (~300-450KB -> ~30-40KB for an 8-result query); faster open-to-image on mobile/3G. Browsers now fetch the w92 variant (w154 on hi-DPI) instead of w500.

## Behavior preservation
Identical rendered output: same `width`/`height` box, same CSS class, same `loading`/`decoding`/`alt`, and the util returns the raw URL for non-TMDB hosts so those posters render byte-identically. Only the fetched image variant changes — no layout shift.

Acceptance test: Playwright opens cmd+k, types a query, asserts each row `<img>` now carries `srcset` (w92 + w154) and `sizes`, the rendered poster is visually identical at the same CSS box, and non-TMDB posters still use the raw `src`; DevTools network shows the small (w92/w154) variant fetched, not w500.

## Files
- `frontend/src/lib/components/search/rows/FilmRow.svelte`
- `frontend/src/lib/components/search/rows/UserStatusRow.svelte`
- `changelogs/2026-05-30-cmdk-row-poster-srcset.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)