### PR TITLE
perf(hints): bounded Cache-Control for self-hosted /fonts/*.woff2

### DIFF
--- a/changelogs/2026-05-30-font-cache-control-header.md
+++ b/changelogs/2026-05-30-font-cache-control-header.md
@@ -1,0 +1,17 @@
+# add bounded Cache-Control header for self-hosted /fonts/*.woff2 (30-day, not immutable)
+
+**PR**: perf campaign
+**Date**: 2026-05-30
+
+## Changes
+- Added a top-level `headers` array to `frontend/vercel.json` (sibling to the existing `rewrites`).
+- Single entry matching `/fonts/(.*)` sets `Cache-Control: public, max-age=2592000, stale-while-revalidate=86400`.
+- 30-day TTL with 1-day stale-while-revalidate. Deliberately NOT `immutable` and NOT a year-long max-age, so a same-name font swap still propagates within 30 days.
+- Existing `/api/*` and `/ingest/*` rewrites left untouched (proxy intact).
+
+## Impact
+- Affects all returning visitors of pictures.london loading the self-hosted woff2 fonts in `frontend/static/fonts/` (Fraunces, IBMPlexMono, InterVariable, Cormorant-Italic — three of which are render-blocking preloaded per `app.html`).
+- Metric moved: eliminates the per-font conditional `304` revalidation round-trip on every repeat visit (fonts were previously served `cache-control: public, max-age=0, must-revalidate`). Removes a round-trip on the critical render path for returning visitors.
+
+## Behavior preservation
+- Caching-only header change; no rendered DOM, layout, computed style, or user-facing behavior changes. Acceptance: `curl -sD- -o/dev/null https://www.pictures.london/fonts/Fraunces.woff2` shows `cache-control: public, max-age=2592000, ...` (not `max-age=0`), and the `/api/*` + `/ingest/*` rewrites still proxy correctly.

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -12,5 +12,16 @@
 			"source": "/ingest/(.*)",
 			"destination": "https://eu.i.posthog.com/$1"
 		}
+	],
+	"headers": [
+		{
+			"source": "/fonts/(.*)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=2592000, stale-while-revalidate=86400"
+				}
+			]
+		}
 	]
 }


### PR DESCRIPTION
## What
Adds a top-level `headers` array to `frontend/vercel.json` (sibling to the existing `rewrites`) with a single entry matching `/fonts/(.*)`:

```
Cache-Control: public, max-age=2592000, stale-while-revalidate=86400
```

30-day TTL with 1-day stale-while-revalidate. Deliberately NOT `immutable` and NOT a year-long max-age, so a same-name font swap still propagates within 30 days. The existing `/api/*` and `/ingest/*` rewrites are untouched.

## Why
Live fonts are currently served `cache-control: public, max-age=0, must-revalidate` (verified on `https://www.pictures.london/fonts/Fraunces.woff2`). That forces a conditional `304` revalidation round-trip on **every repeat visit** for the three render-blocking PRELOADED fonts (Fraunces, IBMPlexMono, InterVariable per `app.html`), adding latency on the critical render path for returning visitors.

**Expected metric:** removes a per-font 304 revalidation round-trip on every repeat visit for the render-blocking preloaded fonts. Reversible 1-line revert.

## Behavior preservation
Caching-only header change — no rendered DOM, layout, computed style, or user-facing behavior changes anywhere.

**Acceptance test:** after merge + deploy, `curl -sD- -o/dev/null https://www.pictures.london/fonts/Fraunces.woff2` must show `cache-control: public, max-age=2592000, ...` (NOT `max-age=0`), and the `/api/*` + `/ingest/*` rewrites must still proxy correctly.

## Files
- `frontend/vercel.json` — add `headers` array for `/fonts/(.*)`
- `changelogs/2026-05-30-font-cache-control-header.md` — changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)