### PR TITLE
perf(home): hoist tomorrowIso + type cinema coordinates in day-header

### DIFF
--- a/changelogs/2026-05-30-home-dayheader-formatters-and-types.md
+++ b/changelogs/2026-05-30-home-dayheader-formatters-and-types.md
@@ -1,0 +1,35 @@
+# Homepage day-header: hoist tomorrowIso + type coordinates
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- `frontend/src/routes/+page.svelte`:
+  - Hoisted the per-render `tomorrowIso` IIFE out of the `{#snippet dayHeader}`
+    into a single component-scope `const tomorrowIso = $derived.by(...)` keyed
+    off `todayStore.value`. The IIFE previously re-ran for every visible day
+    header (up to `MAX_DAYS_VISIBLE = 7`) on every filter-change re-render,
+    even though its only input is the `today` store value. It now recomputes
+    once per `today` change.
+  - Added `coordinates: { lat: number; lng: number } | null` to the `cinemas`
+    `$derived` cast type. `DesktopFilterSidebar` and `MobileFilterSheet` read
+    `c.coordinates` / `c.coordinates!` for the haversine radius filter; the cast
+    previously omitted the field, so the prop contract was unchecked at the
+    boundary. The shape matches what `+layout.server.ts` already emits.
+  - (The two inline `Intl.DateTimeFormat` formatters were already hoisted to
+    module-scope consts in a prior change; no change needed there.)
+
+## Impact
+- Affects the homepage (`/`) render path only. Slightly less work per
+  filter-change re-render (one `tomorrowIso` computation instead of up to 7),
+  and a stronger compile-time type contract for the cinema list passed to the
+  filter sidebars.
+
+## Behavior preservation
+- Output is byte-identical. `tomorrowIso` uses the exact same UTC-noon anchor
+  (`todayStore.value + 'T12:00:00Z'`), `setUTCDate(+1)`, and
+  `toISOString().split('T')[0]` slice as the removed IIFE, so the `relative`
+  ('Today' / 'Tomorrow' / null) result is unchanged.
+- The `coordinates` type addition is a pure TypeScript cast (type-only, erased
+  at runtime). It introduces no runtime code and matches the actual data shape
+  already provided by the layout load, so runtime behavior is unaffected.

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -25,6 +25,16 @@
 	const dayHeaderWeekdayFmt = new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' });
 	const dayHeaderDayNumFmt = new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' });
 
+	// `tomorrowIso` depends only on `todayStore.value`, so compute it once per
+	// `today` change instead of inside the {#snippet dayHeader} IIFE that re-ran
+	// for every visible day header on every filter-change re-render. Output is
+	// byte-identical — same UTC-noon anchor + ISO-date slice as before.
+	const tomorrowIso = $derived.by(() => {
+		const t = new Date(todayStore.value + 'T12:00:00Z');
+		t.setUTCDate(t.getUTCDate() + 1);
+		return t.toISOString().split('T')[0];
+	});
+
 	// Sidebar collapsed state — persist across sessions.
 	const SIDEBAR_STORAGE_KEY = 'pictures-sidebar-collapsed';
 	function loadCollapsed(): boolean {
@@ -42,6 +52,7 @@
 		name: string;
 		shortName: string | null;
 		address: { area: string } | null;
+		coordinates: { lat: number; lng: number } | null;
 	}>);
 
 	let mobileFilterOpen = $state(false);
@@ -213,7 +224,6 @@
 	{@const weekday = dayHeaderWeekdayFmt.format(d)}
 	{@const dayNum = Number(dayHeaderDayNumFmt.format(d))}
 	{@const todayIso = todayStore.value}
-	{@const tomorrowIso = (() => { const t = new Date(todayIso + 'T12:00:00Z'); t.setUTCDate(t.getUTCDate() + 1); return t.toISOString().split('T')[0]; })()}
 	{@const relative = iso === todayIso ? 'Today' : iso === tomorrowIso ? 'Tomorrow' : null}
 	<h2 class="day-header">
 		{#if relative}<span class="day-header-relative">{relative}</span><span class="day-header-sep"> · </span>{/if}<span class="day-header-weekday">{weekday}</span><span class="italic-comma">,</span> <span class="day-header-ordinal">the {formatOrdinalDay(dayNum)}</span>


### PR DESCRIPTION
## What
Two scoped, behavior-preserving cleanups in `frontend/src/routes/+page.svelte`:

1. **Hoist `tomorrowIso`** out of the `{#snippet dayHeader}` IIFE into a single component-scope `const tomorrowIso = $derived.by(...)` keyed off `todayStore.value`.
2. **Type `coordinates`** on the `cinemas` `$derived` cast — add `coordinates: { lat: number; lng: number } | null`.

(The two inline `Intl.DateTimeFormat` formatters referenced in the original cluster were already hoisted to module-scope consts in a prior change, so no formatter change was needed.)

## Why
- The `tomorrowIso` IIFE re-ran for every visible day header (up to `MAX_DAYS_VISIBLE = 7`) on every filter-change re-render, despite depending only on the `today` store value. It now recomputes once per `today` change.
- `DesktopFilterSidebar` and `MobileFilterSheet` read `c.coordinates` / `c.coordinates!` for haversine radius filtering, but the cast omitted the field, so the prop contract went unchecked at the boundary. The added type matches the shape `+layout.server.ts` already emits.

## Behavior preservation (identical)
- `tomorrowIso` uses the same UTC-noon anchor (`todayStore.value + 'T12:00:00Z'`), `setUTCDate(+1)`, and `toISOString().split('T')[0]` slice as the removed IIFE — the `relative` ('Today' / 'Tomorrow' / null) result is unchanged.
- The `coordinates` addition is a type-only cast, erased at runtime — no runtime code introduced. Output is byte-identical.
- Gate: `svelte-check --threshold error` reports 0 errors (2 pre-existing warnings in unrelated files).

## Files
- `frontend/src/routes/+page.svelte`
- `changelogs/2026-05-30-home-dayheader-formatters-and-types.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)