### PR TITLE
perf(calendar): DayMasthead — reuse formatOrdinalDay + hoist three Intl formatters

### DIFF
--- a/changelogs/2026-05-30-daymasthead-ordinals-and-formatters.md
+++ b/changelogs/2026-05-30-daymasthead-ordinals-and-formatters.md
@@ -1,0 +1,22 @@
+# DayMasthead: reuse formatOrdinalDay helper + hoist three Intl formatters
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- Replaced the local 31-entry `ORDINALS` record (and the inline `ORDINALS[dayNum] ?? `${dayNum}th`` fallback) with the shared `formatOrdinalDay(dayNum)` helper exported from `$lib/utils` (backed by `ORDINAL_DAYS`, same `?? `${n}th`` fallback). The local record is deleted; the page now imports `formatOrdinalDay`.
+- Hoisted the three `Intl.DateTimeFormat` instances that were constructed on every recompute to module-scope consts, matching the cached-formatter pattern in `utils.ts`:
+  - `WEEKDAY_LONG` — `{ weekday: 'long', timeZone: 'Europe/London' }` (was inline in the `weekday` derived)
+  - `DAY_NUM` — `{ day: 'numeric', timeZone: 'Europe/London' }` (was inline in the `dayNum` derived)
+  - `WEEKDAY_SHORT` — `{ weekday: 'short', timeZone: 'Europe/London' }` (was constructed inside the `stripItems` `$derived.by` loop, allocating 4 per recompute)
+- The derived values now call `.format(...)` on the reused instances.
+
+## Impact
+- `frontend/src/lib/components/calendar/DayMasthead.svelte` only.
+- Removes per-recompute formatter allocations on the always-mounted homepage day masthead: 2 per recompute for the title plus 4 per recompute for the day strip, now amortized to one allocation each at module load.
+- De-duplicates the ordinal table against the canonical `ORDINAL_DAYS` in `utils.ts`, removing a drift hazard.
+
+## Behavior preservation
+- `formatOrdinalDay` uses the identical `ORDINAL_DAYS[dayNum] ?? `${dayNum}th`` mapping for the 1–31 day numbers a real calendar date produces, so the rendered ordinal is byte-identical.
+- The hoisted formatters use the same locale (`'en-GB'`) and the same options as the previous inline constructions; `Intl.DateTimeFormat` is stateless, so reusing one instance yields identical strings across all calls and DST.
+- No template markup, keys, or option values changed. `svelte-check --threshold error` reports 0 errors.

--- a/frontend/src/lib/components/calendar/DayMasthead.svelte
+++ b/frontend/src/lib/components/calendar/DayMasthead.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 	import { filters } from '$lib/stores/filters.svelte';
 	import { today as todayStore } from '$lib/stores/today.svelte';
+	import { formatOrdinalDay } from '$lib/utils';
 	import CalendarPopover from '$lib/components/filters/CalendarPopover.svelte';
+
+	// Cached Intl formatters — hoisted to module scope so they are allocated
+	// once rather than per recompute (and, for WEEKDAY_SHORT, per day-strip cell).
+	const WEEKDAY_LONG = new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' });
+	const DAY_NUM = new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' });
+	const WEEKDAY_SHORT = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' });
 
 	// Effective date — filter if set, else today (London). Reads from the
 	// shared today store so a midnight rollover advances every consumer
@@ -13,24 +20,10 @@
 	// civil date regardless of the user's local timezone.
 	const activeDateObj = $derived(new Date(activeDate + 'T12:00:00Z'));
 
-	// Ordinal e.g. "nineteenth". Cover 1..31.
-	const ORDINALS: Record<number, string> = {
-		1: 'first', 2: 'second', 3: 'third', 4: 'fourth', 5: 'fifth', 6: 'sixth', 7: 'seventh',
-		8: 'eighth', 9: 'ninth', 10: 'tenth', 11: 'eleventh', 12: 'twelfth', 13: 'thirteenth',
-		14: 'fourteenth', 15: 'fifteenth', 16: 'sixteenth', 17: 'seventeenth', 18: 'eighteenth',
-		19: 'nineteenth', 20: 'twentieth', 21: 'twenty-first', 22: 'twenty-second',
-		23: 'twenty-third', 24: 'twenty-fourth', 25: 'twenty-fifth', 26: 'twenty-sixth',
-		27: 'twenty-seventh', 28: 'twenty-eighth', 29: 'twenty-ninth', 30: 'thirtieth',
-		31: 'thirty-first'
-	};
-
-	const weekday = $derived(
-		new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' }).format(activeDateObj)
-	);
-	const dayNum = $derived(Number(
-		new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' }).format(activeDateObj)
-	));
-	const ordinal = $derived(ORDINALS[dayNum] ?? `${dayNum}th`);
+	const weekday = $derived(WEEKDAY_LONG.format(activeDateObj));
+	const dayNum = $derived(Number(DAY_NUM.format(activeDateObj)));
+	// Ordinal e.g. "nineteenth". Cover 1..31 via the shared utils helper.
+	const ordinal = $derived(formatOrdinalDay(dayNum));
 
 	// Compose the day strip: prev arrow, Today, and next 4 days of the week.
 	interface StripItem { key: string; label: string; date: string; isActive: boolean; }
@@ -48,7 +41,7 @@
 		for (let i = 1; i <= 4; i++) {
 			const iso = addDays(todayISO, i);
 			const d = new Date(iso + 'T12:00:00Z');
-			const label = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' }).format(d);
+			const label = WEEKDAY_SHORT.format(d);
 			items.push({ key: iso, label, date: iso, isActive: activeDate === iso });
 		}
 		return items;


### PR DESCRIPTION
## What
- Replace the local 31-entry `ORDINALS` record (and inline `ORDINALS[dayNum] ?? \`\${dayNum}th\`` fallback) with the shared `formatOrdinalDay(dayNum)` helper from `$lib/utils`, deleting the local record.
- Hoist the three `Intl.DateTimeFormat` instances to module-scope consts (`WEEKDAY_LONG`, `DAY_NUM`, `WEEKDAY_SHORT`), matching the cached-formatter pattern in `utils.ts`. The `weekday`/`dayNum` deriveds and the `stripItems` loop now call `.format(...)` on the reused instances.

## Why
- `formatOrdinalDay` is backed by `ORDINAL_DAYS` with the identical `?? \`\${n}th\`` fallback and is already used by the homepage day-header — the local table was a duplicate/drift hazard.
- The three formatters were constructed on every recompute of the always-mounted day masthead; the `weekday-short` one was allocated 4x per recompute inside the `stripItems` `$derived.by` loop. Hoisting amortizes these to a single allocation at module load.

## Behavior preservation (identical)
- `formatOrdinalDay` uses the same ordinal mapping for the 1–31 day numbers a real calendar date yields, so the rendered ordinal string is byte-identical.
- The hoisted formatters use the same locale (`'en-GB'`) and the same options as the previous inline constructions. `Intl.DateTimeFormat` is stateless, so reusing one instance produces identical strings across all calls and DST.
- No template markup, keys, or option values changed. `svelte-check --threshold error`: 0 errors.

## Files
- `frontend/src/lib/components/calendar/DayMasthead.svelte`
- `changelogs/2026-05-30-daymasthead-ordinals-and-formatters.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)