### PR TITLE
perf(search): hoist constant phrase tables off parse-query hot path

### DIFF
--- a/changelogs/2026-05-30-parse-query-hotpath-hoists.md
+++ b/changelogs/2026-05-30-parse-query-hotpath-hoists.md
@@ -1,0 +1,38 @@
+# parse-query: memoize phrase Sets/maxLen + hoist constant arrays off keystroke hot path
+
+**PR**: #101
+**Date**: 2026-05-30
+
+## Changes
+`frontend/src/lib/search/parse-query.ts` — `parseQuery` runs via a `$derived` on
+every cmd+k keystroke (`palette.svelte.ts`) and calls `scanPhrases` ~9x per
+keystroke over constant module-level phrase tables. Four allocations were moved
+off the per-keystroke hot path:
+
+- **Memoized `scanPhrases` per-table work** — added a module-level
+  `COMPILED_PHRASES` `WeakMap<Record<number, string[]>, CompiledPhrases>` and a
+  `compilePhrases()` helper. The per-length `new Set(phrases)` (previously rebuilt
+  inside the length loop on every call) and the `maxLen` derivation (previously
+  `Math.max(0, ...Object.keys(...).map(Number))` per call) are now computed once
+  per phrase-table object and cached. The inner scan reads from the cached `Set`.
+- **Hoisted `NEXT_DAY_PHRASES_BY_LENGTH`** — the `{ 2: Object.keys(DAY_NAMES).map((d) => `next ${d}`) }`
+  table (14-element array) was built inline on every `parseQuery` call; it is now a
+  module-level `const` computed once at load.
+- **Lifted `WEEKDAY_LABELS`** — `applyNextDay` and `applyDayThisWeek` each
+  allocated an identical `["SUN","MON","TUE","WED","THU","FRI","SAT"]` literal per
+  call. Both now index a single module-level `const WEEKDAY_LABELS`.
+
+## Impact
+- cmd+k command palette only. Fewer allocations per keystroke on the parse hot
+  path; no API, data, or output change.
+
+## Behavior preservation
+- Pure constant-data refactor — the phrase tables and weekday labels are fixed,
+  so memoizing/hoisting them yields byte-identical parse output.
+- `maxLen` semantics preserved: an empty table yields `maxLen = 0` (matching the
+  old `Math.max(0, ...)`), so the `len >= 2` loop is skipped exactly as before.
+  Missing or empty per-length entries are still skipped (`!phraseSet` /
+  `phraseSet.size === 0`, mirroring the old `!phrases || phrases.length === 0`).
+- The two remaining inline `{ 2: [...] }` literals are intentionally unchanged.
+- Verified: `svelte-check` 0 errors; existing `parse-query.test.ts` suite (49
+  tests) passes unchanged.

--- a/frontend/src/lib/search/parse-query.ts
+++ b/frontend/src/lib/search/parse-query.ts
@@ -183,16 +183,40 @@ function addDaysToDateString(yyyyMmDd: string, days: number): string {
 
 // ===== Phrase scanning =====
 
+// `scanPhrases` runs ~9x per keystroke over constant module-level tables.
+// Memoize the derived `maxLen` and per-length `Set` lookups per table so the
+// constant data is only processed once, not rebuilt on every call.
+interface CompiledPhrases {
+  maxLen: number;
+  sets: Map<number, Set<string>>;
+}
+const COMPILED_PHRASES = new WeakMap<Record<number, string[]>, CompiledPhrases>();
+
+function compilePhrases(phrasesByLength: Record<number, string[]>): CompiledPhrases {
+  let compiled = COMPILED_PHRASES.get(phrasesByLength);
+  if (!compiled) {
+    const sets = new Map<number, Set<string>>();
+    let maxLen = 0;
+    for (const key of Object.keys(phrasesByLength)) {
+      const len = Number(key);
+      if (len > maxLen) maxLen = len;
+      sets.set(len, new Set(phrasesByLength[len]));
+    }
+    compiled = { maxLen, sets };
+    COMPILED_PHRASES.set(phrasesByLength, compiled);
+  }
+  return compiled;
+}
+
 function scanPhrases(
   tokens: Token[],
   phrasesByLength: Record<number, string[]>,
   onMatch: (matchedPhrase: string, startIdx: number, endIdx: number) => boolean,
 ) {
-  const maxLen = Math.max(0, ...Object.keys(phrasesByLength).map(Number));
+  const { maxLen, sets } = compilePhrases(phrasesByLength);
   for (let len = maxLen; len >= 2; len--) {
-    const phrases = phrasesByLength[len];
-    if (!phrases || phrases.length === 0) continue;
-    const phraseSet = new Set(phrases);
+    const phraseSet = sets.get(len);
+    if (!phraseSet || phraseSet.size === 0) continue;
     for (let i = 0; i <= tokens.length - len; i++) {
       if (tokens.slice(i, i + len).some((t) => t.consumed)) continue;
       const joined = tokens.slice(i, i + len).map((t) => t.lower).join(" ");
@@ -216,6 +240,15 @@ const DAY_NAMES: Record<string, number> = {
   thursday: 4, thu: 4, thur: 4, thurs: 4,
   friday: 5, fri: 5,
   saturday: 6, sat: 6,
+};
+
+// Short weekday labels indexed by day-of-week (Sun=0). Shared by the date
+// scanners so the literal is allocated once, not per call.
+const WEEKDAY_LABELS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+// "next <day>" phrases, precomputed once off the keystroke hot path.
+const NEXT_DAY_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: Object.keys(DAY_NAMES).map((d) => `next ${d}`),
 };
 
 function applyTonight(intent: ParsedIntent, now: Date) {
@@ -273,7 +306,7 @@ function applyNextDay(intent: ParsedIntent, now: Date, dayIdx: number) {
   const target = addDaysToDateString(today, offset);
   intent.dateFrom = londonMidnight(target, 0);
   intent.dateTo = londonMidnight(addDaysToDateString(target, 1), 0);
-  const dayName = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"][dayIdx];
+  const dayName = WEEKDAY_LABELS[dayIdx];
   intent.chipDescriptors.push({
     id: `date:next-${dayIdx}`,
     kind: "date",
@@ -288,7 +321,7 @@ function applyDayThisWeek(intent: ParsedIntent, now: Date, dayIdx: number) {
   const target = addDaysToDateString(today, offset);
   intent.dateFrom = londonMidnight(target, 0);
   intent.dateTo = londonMidnight(addDaysToDateString(target, 1), 0);
-  const dayName = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"][dayIdx];
+  const dayName = WEEKDAY_LABELS[dayIdx];
   intent.chipDescriptors.push({ id: `date:${dayIdx}`, kind: "date", label: dayName });
 }
 
@@ -373,7 +406,7 @@ export function parseQuery(input: string, now: Date): ParsedIntent {
 
   scanPhrases(
     tokens,
-    { 2: Object.keys(DAY_NAMES).map((d) => `next ${d}`) },
+    NEXT_DAY_PHRASES_BY_LENGTH,
     (phrase) => {
       const dayPart = phrase.replace(/^next /, "");
       const idx = DAY_NAMES[dayPart];


### PR DESCRIPTION
## What
`parseQuery` runs via a `$derived` on every cmd+k keystroke (`palette.svelte.ts`) and calls `scanPhrases` ~9x per keystroke over constant module-level phrase tables. This clusters four allocations off that hot path:

- **Memoize `scanPhrases` per-table work** — a module-level `COMPILED_PHRASES` `WeakMap<Record<number, string[]>, CompiledPhrases>` (+ `compilePhrases()`) caches the derived `maxLen` and the per-length `Set`s, replacing the per-call `new Set(phrases)` inside the length loop and the `Math.max(0, ...Object.keys(...).map(Number))` recomputation.
- **Hoist `NEXT_DAY_PHRASES_BY_LENGTH`** — the `{ 2: Object.keys(DAY_NAMES).map((d) => \`next ${d}\`) }` table was built inline on every call; now a module-level `const`.
- **Lift `WEEKDAY_LABELS`** — `applyNextDay` and `applyDayThisWeek` each allocated an identical `["SUN".."SAT"]` literal per call; both now index one module-level `const`.

## Why
These are constant module-level data structures rebuilt on every keystroke. Computing them once removes redundant allocations from the command-palette parse hot path.

## Behavior preservation (identical)
- Pure constant-data refactor — phrase tables and weekday labels are fixed, so memoizing/hoisting yields byte-identical parse output.
- `maxLen` semantics preserved: empty table → `maxLen = 0` (matching old `Math.max(0, ...)`), loop skipped. Missing/empty per-length entries still skipped via `!phraseSet` / `phraseSet.size === 0` (mirroring old `!phrases || phrases.length === 0`).
- The two remaining inline `{ 2: [...] }` literals are intentionally unchanged.
- `svelte-check` 0 errors; existing `parse-query.test.ts` (49 tests) passes unchanged.

## Files
- `frontend/src/lib/search/parse-query.ts`
- `changelogs/2026-05-30-parse-query-hotpath-hoists.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)