### PR TITLE
perf(pretext): read getBoundingClientRect once per frame in BreathingGrid

### DIFF
--- a/changelogs/2026-05-30-breathinggrid-rect-per-frame.md
+++ b/changelogs/2026-05-30-breathinggrid-rect-per-frame.md
@@ -1,0 +1,19 @@
+# BreathingGrid: read getBoundingClientRect once per frame instead of per cell
+
+**PR**: #103
+**Date**: 2026-05-30
+
+## Changes
+- `getCharScale` no longer calls `containerEl.getBoundingClientRect()` internally. It now accepts a pre-computed `rect: DOMRect | null` parameter and uses it for the hover-proximity math.
+- Added a small `getFrameRect(mx)` helper that returns the container rect once (under the same `mx > -500 && containerEl` guard as before) or `null` when the pointer is not over the header.
+- The template computes `{@const frameRect = getFrameRect(mouseX)}` once per render (before the `{#each chars}` loop) and passes it into every `getCharScale` call.
+
+## Impact
+- Affects only the always-mounted header logo animation (`BreathingGrid.svelte`).
+- During pointer hover over the header, forced layout reads drop from O(cells) (~14 `getBoundingClientRect()` reflows per frame at 60fps) to O(1) per frame.
+- No visual or API change; no other files touched.
+
+## Behavior preservation
+- The rect is read under the exact same condition as before (`mx > -500 && containerEl`); when the guard is false `getFrameRect` returns `null` and `getCharScale`'s hover branch is skipped, identical to the prior `mx > -500 && containerEl` check.
+- All cells render in a single synchronous pass, so the layout cannot change between cells within one frame — every cell previously observed the identical rect anyway. Computed `scale` values are byte-identical.
+- `svelte-check --threshold error`: 0 errors; no new warnings introduced for this file.

--- a/frontend/src/lib/components/pretext/BreathingGrid.svelte
+++ b/frontend/src/lib/components/pretext/BreathingGrid.svelte
@@ -33,12 +33,17 @@
 	let animFrame: number;
 	let mounted = $state(false);
 
-	function getCharScale(cell: CharCell, time: number, mx: number, my: number): number {
+	function getCharScale(
+		cell: CharCell,
+		time: number,
+		mx: number,
+		my: number,
+		rect: DOMRect | null
+	): number {
 		const breathe = Math.sin((time / BREATHE_PERIOD) * Math.PI * 2 + cell.phase) * BREATHE_AMPLITUDE;
 		let scale = 1.0 + breathe;
 
-		if (mx > -500 && containerEl) {
-			const rect = containerEl.getBoundingClientRect();
+		if (mx > -500 && rect) {
 			const cx = rect.left + cell.col * CELL_SIZE + CELL_SIZE / 2;
 			const cy = rect.top + rect.height / 2;
 			const dist = Math.sqrt((mx - cx) ** 2 + (my - cy) ** 2);
@@ -51,6 +56,10 @@
 		}
 
 		return scale;
+	}
+
+	function getFrameRect(mx: number): DOMRect | null {
+		return mx > -500 && containerEl ? containerEl.getBoundingClientRect() : null;
 	}
 
 	function animate(timestamp: number) {
@@ -102,8 +111,9 @@
 	onmouseleave={handleMouseLeave}
 >
 	{#if mounted}
+		{@const frameRect = getFrameRect(mouseX)}
 		{#each chars as cell}
-			{@const scale = getCharScale(cell, animTime, mouseX, mouseY)}
+			{@const scale = getCharScale(cell, animTime, mouseX, mouseY, frameRect)}
 			<span class="grid-cell" class:separator={cell.isSeparator}>
 				<span class="grid-char font-display" style="transform: scale({scale});">
 					{cell.char}


### PR DESCRIPTION
## What
`getCharScale` no longer calls `containerEl.getBoundingClientRect()` once per character cell. A new `getFrameRect(mouseX)` helper reads the container rect a single time per render (under the same `mx > -500 && containerEl` guard), and the template passes that rect into every `getCharScale` call via `{@const frameRect = getFrameRect(mouseX)}` placed before the `{#each chars}` loop.

## Why
On the always-mounted header logo animation, hovering the header triggered `getCharScale` per cell (~14 cells). Each call performed a layout-forcing `getBoundingClientRect()` read — ~14 forced reflows per frame at 60fps, all returning the identical rect for that frame. This cuts forced-reflow reads from O(cells) to O(1) per frame.

## Behavior preservation (identical)
- The rect is read under the exact same condition as before (`mx > -500 && containerEl`); when false, `getFrameRect` returns `null` and `getCharScale`'s hover branch is skipped — identical to the prior in-function guard.
- All cells render in one synchronous pass, so layout cannot change between cells within a frame; every cell already observed the identical rect. Computed `scale` values are byte-identical.
- `svelte-check --threshold error`: 0 errors, no new warnings for this file.

## Files
- `frontend/src/lib/components/pretext/BreathingGrid.svelte`
- `changelogs/2026-05-30-breathinggrid-rect-per-frame.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)