### PR TITLE
perf(cinemas): drop dead groupBy import + hoist search.toLowerCase out of filter

### DIFF
--- a/changelogs/2026-05-30-cinemas-index-deadimport-and-search-hoist.md
+++ b/changelogs/2026-05-30-cinemas-index-deadimport-and-search-hoist.md
@@ -1,0 +1,18 @@
+# Cinemas index: drop dead groupBy import + hoist search.toLowerCase out of filter
+
+**PR**: #104
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `import { groupBy } from '$lib/utils'` in `frontend/src/routes/cinemas/+page.svelte`. The `grouped` `$derived` reimplements grouping inline and never calls `groupBy`; the symbol appeared only on the import line.
+- Hoisted `search.toLowerCase()` out of the `filtered` `.filter` callback. Previously it was recomputed twice per cinema on every keystroke (~118 redundant lowercasings across ~59 cinemas). Now `const q = search.toLowerCase()` is computed once before filtering and reused in both `c.name.toLowerCase().includes(q)` and `(c.address?.area.toLowerCase().includes(q) ?? false)`.
+- Converted the `filtered` `$derived` from a ternary expression to `$derived.by` to hold the hoisted local; the empty-search early return preserves the original else branch (`data.cinemas`).
+
+## Impact
+- Affects the Cinemas index page (`/cinemas`) only.
+- Pure performance/cleanup: fewer redundant string allocations per keystroke and one less dead import. No user-visible change.
+
+## Behavior preservation
+- Filtering results are byte-identical: same predicates, same operands, same falsy-search short-circuit returning `data.cinemas`.
+- `groupBy` was never referenced beyond the import, so removing it cannot alter runtime behavior.
+- `svelte-check --threshold error` passes with 0 errors for the modified file.

--- a/frontend/src/routes/cinemas/+page.svelte
+++ b/frontend/src/routes/cinemas/+page.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
 	import Badge from '$lib/components/ui/Badge.svelte';
-	import { groupBy } from '$lib/utils';
 
 	let { data } = $props();
 	let search = $state('');
 
-	const filtered = $derived(
-		search
-			? data.cinemas.filter((c) =>
-				c.name.toLowerCase().includes(search.toLowerCase()) ||
-				(c.address?.area.toLowerCase().includes(search.toLowerCase()) ?? false)
-			)
-			: data.cinemas
-	);
+	const filtered = $derived.by(() => {
+		if (!search) return data.cinemas;
+		const q = search.toLowerCase();
+		return data.cinemas.filter((c) =>
+			c.name.toLowerCase().includes(q) ||
+			(c.address?.area.toLowerCase().includes(q) ?? false)
+		);
+	});
 
 	const grouped = $derived.by(() => {
 		const groups: Record<string, typeof data.cinemas> = {};


### PR DESCRIPTION
## What
Two behavior-preserving cleanups in `frontend/src/routes/cinemas/+page.svelte`:
1. Removed the unused `import { groupBy } from '$lib/utils'`. The `grouped` `$derived` reimplements grouping inline and never referenced the symbol (it appeared only on the import line).
2. Hoisted `search.toLowerCase()` out of the `filtered` filter callback into a single `const q` computed once before filtering.

## Why
On every keystroke the old code recomputed `search.toLowerCase()` twice per cinema (~118 redundant lowercasings across ~59 cinemas). Computing it once removes that redundant work. The dead import is pure cruft.

## Behavior preservation (identical)
- Empty/falsy `search` returns `data.cinemas` exactly as the original ternary's else branch.
- Non-empty `search` filters with the same two predicates (`c.name` and `c.address?.area`), the same `??  false` guard, and the same lowercased query — just reused via `q`. Results are byte-identical.
- Removing `groupBy` has no runtime effect since it was never called.
- `npx svelte-check --threshold error` passes with 0 errors.

## Files
- `frontend/src/routes/cinemas/+page.svelte`
- `changelogs/2026-05-30-cinemas-index-deadimport-and-search-hoist.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)