### PR TITLE
perf(film-detail): drop dead formatScreeningDate import + remove redundant re-sort

### DIFF
--- a/changelogs/2026-05-30-film-detail-deadimport-and-sort.md
+++ b/changelogs/2026-05-30-film-detail-deadimport-and-sort.md
@@ -1,0 +1,16 @@
+# Film detail page: drop dead formatScreeningDate import + remove redundant re-sort
+
+**PR**: #105
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused named import `formatScreeningDate` from the `$lib/utils` import block in `frontend/src/routes/film/[id]/+page.svelte`. The token appeared only on the import line — the page builds its own day/relative-date labels (`nextScreeningLabel`, `formatScreeningDate` was never referenced). The other imports (`formatTime`, `toLondonDateStr`, `groupBy`, `getPosterImageAttributes`, `filmByline`, `formatScreeningFormat`) are kept.
+- Removed the redundant `.sort(([a], [b]) => a.localeCompare(b))` from the `groupedByDate` derived. Replaced `Object.entries(grouped).sort(...)` with `Object.entries(grouped)` plus an explanatory comment.
+
+## Impact
+- Affects the film detail page (`/film/[id]`) only.
+- Marginally smaller bundle (one fewer named binding pulled into the route) and skips a comparator-driven sort over the day-group keys on each recompute of `groupedByDate`.
+
+## Behavior preservation
+- `formatScreeningDate` was dead code — removing an unreferenced import cannot change runtime behavior.
+- `futureScreenings` is already sorted ascending by epoch-ms (decorate-sort-undecorate on `new Date(s.datetime).getTime()`), and invalid dates are excluded because `NaN > now` is `false`. `toLondonDateStr` returns a `YYYY-MM-DD` string that is monotonic in epoch-ms, so `groupBy` inserts day keys in chronological order. JavaScript preserves string-key insertion order, and `localeCompare` over `YYYY-MM-DD` keys produces the identical chronological ordering. The dropped `.sort()` was therefore a provable no-op — `Object.entries(grouped)` yields byte-identical output.

--- a/frontend/src/routes/film/[id]/+page.svelte
+++ b/frontend/src/routes/film/[id]/+page.svelte
@@ -8,7 +8,6 @@
 	import { today as todayStore } from '$lib/stores/today.svelte';
 	import {
 		formatTime,
-		formatScreeningDate,
 		toLondonDateStr,
 		groupBy,
 		getPosterImageAttributes,
@@ -102,7 +101,11 @@
 	// Day groups for the day strip
 	const groupedByDate = $derived.by(() => {
 		const grouped = groupBy(futureScreenings, (s) => toLondonDateStr(s.datetime));
-		return Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b));
+		// `futureScreenings` is already sorted ascending by epoch-ms and
+		// `toLondonDateStr` is monotonic in ms, so `groupBy` inserts day keys in
+		// chronological order — which JS preserves for string keys. The previous
+		// `.sort(localeCompare)` was therefore a no-op over YYYY-MM-DD keys.
+		return Object.entries(grouped);
 	});
 
 	let selectedDay = $state<string | null>(null);


### PR DESCRIPTION
## What
Two behavior-preserving cleanups in `frontend/src/routes/film/[id]/+page.svelte`:

1. **Remove the dead `formatScreeningDate` import** from the `$lib/utils` import block. The symbol was never referenced — the page builds its own day/relative-date labels (`dayLabel`, `nextScreeningLabel`). All other named imports are kept.
2. **Remove the redundant re-sort** in the `groupedByDate` derived. Replaced `Object.entries(grouped).sort(([a],[b]) => a.localeCompare(b))` with `Object.entries(grouped)`.

## Why
- The unused import adds a dead named binding to the route's module graph.
- `futureScreenings` is already sorted ascending by epoch-ms (decorate-sort-undecorate), so the day-group keys are already chronological. The `localeCompare` sort over those keys did no work on every recompute.

## Behavior preservation (identical)
- Removing an unreferenced import cannot change runtime behavior.
- `futureScreenings` is sorted ascending by epoch-ms and excludes invalid dates (`NaN > now` is `false`). `toLondonDateStr` returns `YYYY-MM-DD`, which is monotonic in epoch-ms, so `groupBy` inserts day keys in chronological order. JS preserves string-key insertion order, and `localeCompare` over `YYYY-MM-DD` keys yields the same chronological ordering. The dropped `.sort()` is a provable no-op — `Object.entries(grouped)` produces byte-identical output.
- Gate: `svelte-check --threshold error` → 0 errors (2 pre-existing warnings in unrelated files).

## Files
- `frontend/src/routes/film/[id]/+page.svelte`
- `changelogs/2026-05-30-film-detail-deadimport-and-sort.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)