### PR TITLE
perf(search): drop unused shortName from SSR cinema payload

### DIFF
--- a/changelogs/2026-05-30-search-server-trim-shortname.md
+++ b/changelogs/2026-05-30-search-server-trim-shortname.md
@@ -1,0 +1,16 @@
+# Search server load: drop unused shortName from cinema payload
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/search/+page.server.ts`, removed the `shortName: c.shortName` field from the cinema objects returned by the `load` function's `data.cinemas.map(...)`.
+- The `SearchResponse` interface still declares `shortName` because it describes the upstream `/api/films/search` response shape — only the field forwarded to the page was dropped.
+
+## Impact
+- Shrinks the SSR/serialized data payload for the `/search` route by one field per cinema.
+- No change to rendered output: `search/+page.svelte` renders only `cinema.name` and `cinema.area`; `shortName` was never consumed (grep confirms no usage outside the server load).
+
+## Behavior preservation
+- The search results page renders identically. `shortName` was dead data in the page payload.
+- `svelte-check --threshold error` reports 0 errors (2 pre-existing unrelated warnings in `FollowButton.svelte` and `LetterboxdRatingReveal.svelte`).

--- a/frontend/src/routes/search/+page.server.ts
+++ b/frontend/src/routes/search/+page.server.ts
@@ -40,7 +40,6 @@ export const load: PageServerLoad = async ({ url, fetch, setHeaders }) => {
 		cinemas: data.cinemas.map((c) => ({
 			id: c.id,
 			name: c.name,
-			shortName: c.shortName,
 			area: c.address
 		})),
 		query: q


### PR DESCRIPTION
## What
Remove the `shortName: c.shortName` field from the cinema objects returned by the `load` function in `frontend/src/routes/search/+page.server.ts`.

## Why
The `/search` server load forwarded `shortName` for every cinema, but `search/+page.svelte` renders only `cinema.name` and `cinema.area`. A grep confirms `shortName` is never consumed by the page. Dropping it shrinks the serialized SSR payload with no functional change. The `SearchResponse` interface keeps `shortName` because it describes the upstream `/api/films/search` response shape.

## Behavior preservation (identical)
- Rendered output of the `/search` page is byte-identical — `shortName` was dead data in the page payload.
- `npx svelte-check --threshold error` reports 0 errors (2 pre-existing, unrelated warnings in `FollowButton.svelte` and `LetterboxdRatingReveal.svelte`).

## Files
- `frontend/src/routes/search/+page.server.ts`
- `changelogs/2026-05-30-search-server-trim-shortname.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)