### PR TITLE
perf(reachable): drop unused director + isRepertory from screening payload

### DIFF
--- a/changelogs/2026-05-30-reachable-server-trim-payload.md
+++ b/changelogs/2026-05-30-reachable-server-trim-payload.md
@@ -1,0 +1,19 @@
+# Reachable server load: drop unused director + isRepertory from screening payload
+
+**PR**: #107
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/reachable/+page.server.ts`, removed two dead fields from the per-screening `film` object returned by the `load` function:
+  - `director: s.film.directors?.[0] ?? null`
+  - `isRepertory: s.film.isRepertory`
+- The returned `film` mapping now exposes only `{ id, title, year, runtime, posterUrl }`.
+
+## Impact
+- Affects the SSR/ISR payload serialized for the `/reachable` route. With `limit=200`, this trims two dead fields per screening (up to ~200 screenings) from the serialized page data, slightly reducing the SvelteKit data blob size.
+- No UI or user-facing change: `reachable/+page.svelte` re-maps `data.screenings` reading only `film.{id, title, year, runtime, posterUrl}`. A repo-wide grep confirms zero consumers of `director` or `isRepertory` for this route.
+
+## Behavior preservation
+- The two removed fields were never read by any consumer of the route's data, so the rendered output is byte-identical.
+- The incoming API response interface (`ScreeningsResponse`) is unchanged; only the projected payload drops fields that were already unused downstream.
+- `svelte-check --threshold error` passes with 0 errors (2 pre-existing warnings in unrelated files).

--- a/frontend/src/routes/reachable/+page.server.ts
+++ b/frontend/src/routes/reachable/+page.server.ts
@@ -59,10 +59,8 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 				id: s.film.id,
 				title: s.film.title,
 				year: s.film.year,
-				director: s.film.directors?.[0] ?? null,
 				runtime: s.film.runtime,
-				posterUrl: s.film.posterUrl,
-				isRepertory: s.film.isRepertory
+				posterUrl: s.film.posterUrl
 			},
 			cinema: {
 				id: s.cinema.id,


### PR DESCRIPTION
## What
Removes two dead fields (`director`, `isRepertory`) from the per-screening `film` object returned by the `/reachable` route's server `load` in `frontend/src/routes/reachable/+page.server.ts`. The returned `film` mapping now exposes only `{ id, title, year, runtime, posterUrl }`.

## Why
`reachable/+page.svelte` re-maps `data.screenings` into a `Screening[]`, reading only `film.{id, title, year, runtime, posterUrl}`. A repo-wide grep confirms zero consumers of `director` or `isRepertory` for this route. With `limit=200`, the two fields were serialized for up to ~200 screenings on every SSR/ISR render despite never being read.

## Behavior preservation (identical)
- The two removed fields were never read by any consumer, so rendered output is byte-identical.
- The incoming API response interface (`ScreeningsResponse`) is unchanged; only the projected payload drops already-unused fields.
- `svelte-check --threshold error` passes with 0 errors (2 pre-existing warnings in unrelated files: `FollowButton.svelte`, `LetterboxdRatingReveal.svelte`).

## Files
- `frontend/src/routes/reachable/+page.server.ts`
- `changelogs/2026-05-30-reachable-server-trim-payload.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)