### PR TITLE
perf(ssr): trim unused screening fields from cinema detail payload

### DIFF
--- a/changelogs/2026-05-30-cinema-slug-server-trim-payload.md
+++ b/changelogs/2026-05-30-cinema-slug-server-trim-payload.md
@@ -1,0 +1,21 @@
+# Cinema detail server load: trim unused screening fields from SSR payload
+
+**PR**: #106
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/cinemas/[slug]/+page.server.ts`, the `load` function's per-screening map no longer forwards fields the page never renders.
+- Dropped `screen` from each screening object.
+- Dropped `directors`, `runtime`, and `posterUrl` from each screening's nested `film` object.
+- The returned per-screening shape is now `{ id, datetime, format, bookingUrl, film: { id, title, year } }`.
+- The `CinemaResponse` interface is unchanged (it still describes the full upstream API response shape).
+
+## Impact
+- Cinema detail pages (`/cinemas/[slug]`) list dozens-to-hundreds of screenings. Each previously serialized a `directors` string array and a `posterUrl` string per screening into the SvelteKit `__data`/hydration payload, none of which the component reads.
+- Removing them shrinks the serialized SSR/hydration payload and ISR-cached output with zero change to rendered output.
+
+## Behavior preservation
+- The `[slug]/+page.svelte` component only reads `screening.datetime`, `screening.format`, `screening.bookingUrl`, `screening.film.id`, `screening.film.title`, and `screening.film.year`.
+- The `.screen-count` element in the component renders `cinema.screens` (cinema-level), not `screening.screen`. No reference to `screening.screen`, `film.directors`, `film.runtime`, or `film.posterUrl` exists in the component.
+- Therefore dropping these fields produces byte-identical rendered output; only the unused, serialized hydration data is removed.
+- Verified with `svelte-kit sync` + `svelte-check --threshold error`: 0 errors.

--- a/frontend/src/routes/cinemas/[slug]/+page.server.ts
+++ b/frontend/src/routes/cinemas/[slug]/+page.server.ts
@@ -62,14 +62,10 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
 			datetime: s.datetime,
 			format: s.format,
 			bookingUrl: s.bookingUrl,
-			screen: s.screen,
 			film: {
 				id: s.film.id,
 				title: s.film.title,
-				year: s.film.year,
-				directors: s.film.directors,
-				runtime: s.film.runtime,
-				posterUrl: s.film.posterUrl
+				year: s.film.year
 			}
 		}))
 	};


### PR DESCRIPTION
## What
Trim fields from the per-screening map in the cinema detail server load (`frontend/src/routes/cinemas/[slug]/+page.server.ts`):
- Drop `screen` from each screening object.
- Drop `directors`, `runtime`, and `posterUrl` from each screening's nested `film` object.

Returned per-screening shape becomes `{ id, datetime, format, bookingUrl, film: { id, title, year } }`.

## Why
`[slug]/+page.svelte` only reads `datetime`, `format`, `bookingUrl`, `film.id`, `film.title`, and `film.year`. The `.screen-count` element renders `cinema.screens` (cinema-level), not `screening.screen`. Cinema pages list dozens-to-hundreds of screenings, so each unused `directors` array and `posterUrl` string was real dead weight in the serialized `__data`/hydration payload and ISR-cached output.

## Behavior preservation (identical)
- No component reference exists to `screening.screen`, `film.directors`, `film.runtime`, or `film.posterUrl`.
- Rendered output is byte-identical; only unused serialized hydration data is removed.
- The `CinemaResponse` interface (upstream API shape) is unchanged.
- Verified: `svelte-kit sync` + `svelte-check --threshold error` -> 0 errors.

## Files
- `frontend/src/routes/cinemas/[slug]/+page.server.ts`
- `changelogs/2026-05-30-cinema-slug-server-trim-payload.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)