### PR TITLE
perf(festivals): drop dead type import + decorate-sort per-group screenings

### DIFF
--- a/changelogs/2026-05-30-festival-slug-deadimport-and-sort-hoist.md
+++ b/changelogs/2026-05-30-festival-slug-deadimport-and-sort-hoist.md
@@ -1,0 +1,17 @@
+# Festival detail: drop dead type import + decorate-sort the per-group screenings
+
+**PR**: #110
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `import type { ScreeningWithDetails } from '$lib/types'` from `frontend/src/routes/festivals/[slug]/+page.svelte` (single occurrence; type-only, erased at compile time).
+- Reworked the `filmGroups` `$derived.by` sort to decorate each screening once with `_ms = new Date(s.datetime).getTime()` and compare `a._ms - b._ms`, instead of allocating two `Date` objects per comparator call. Mirrors the established decorate-sort pattern in `this-weekend/+page.svelte`.
+
+## Impact
+- Festival detail page (`/festivals/[slug]`) only. Reduces `Date` allocations and `Date.parse` work during the per-film-group sort from O(n log n) parses to O(n) parses, where n is the screening count for the festival.
+- No user-visible change; identical sort order and rendered output.
+
+## Behavior preservation
+- The removed import was never referenced (grep-confirmed single occurrence) and is type-only — erased at compile time, so runtime output is byte-identical.
+- `new Date(x.datetime).getTime() - new Date(y.datetime).getTime()` and `x._ms - y._ms` produce identical comparator results because `_ms` is exactly `new Date(s.datetime).getTime()` computed once per screening. Sort stability and order are unchanged.
+- `svelte-check --threshold error` reports 0 errors; the only warnings are pre-existing and in unrelated files.

--- a/frontend/src/routes/festivals/[slug]/+page.svelte
+++ b/frontend/src/routes/festivals/[slug]/+page.svelte
@@ -2,7 +2,6 @@
 	import FilmCard from '$lib/components/calendar/FilmCard.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import FollowButton from '$lib/components/festivals/FollowButton.svelte';
-	import type { ScreeningWithDetails } from '$lib/types';
 	import { groupBy } from '$lib/utils';
 
 	let { data } = $props();
@@ -10,10 +9,15 @@
 	const screenings = $derived(data.screenings ?? []);
 
 	const filmGroups = $derived.by(() => {
-		const grouped = groupBy(screenings, (s) => s.film?.id ?? 'unknown');
+		type DecoratedScreening = (typeof screenings)[number] & { _ms: number };
+		const decorated = screenings.map((s) => {
+			(s as DecoratedScreening)._ms = new Date(s.datetime).getTime();
+			return s as DecoratedScreening;
+		});
+		const grouped = groupBy(decorated, (s) => s.film?.id ?? 'unknown');
 		return Object.values(grouped).map((ss) => ({
 			film: ss[0].film,
-			screenings: ss.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
+			screenings: ss.sort((a, b) => a._ms - b._ms)
 		}));
 	});
 </script>


### PR DESCRIPTION
## What
Two micro-optimizations on `frontend/src/routes/festivals/[slug]/+page.svelte`:
1. Delete the unused `import type { ScreeningWithDetails } from '$lib/types'` (line 5) — never referenced (single grep-confirmed occurrence).
2. In the `filmGroups` `$derived.by`, decorate each screening once with `_ms = new Date(s.datetime).getTime()` and compare `a._ms - b._ms` in the sort, instead of allocating two `Date` objects per comparator call.

## Why
The per-group sort previously parsed `datetime` and allocated two `Date` objects on every comparator invocation — O(n log n) parses. Decorating once is O(n) parses. The dead import added needless noise. This mirrors the established decorate-sort pattern in `this-weekend/+page.svelte`.

## Behavior preservation (identical)
- The removed import is type-only and erased at compile time, so runtime output is byte-identical.
- `_ms` is exactly `new Date(s.datetime).getTime()` computed once per screening, so `a._ms - b._ms` yields identical comparator results and the same sort order/stability.
- `svelte-check --threshold error` → 0 errors (the 2 warnings are pre-existing and in unrelated files).

## Files
- `frontend/src/routes/festivals/[slug]/+page.svelte`
- `changelogs/2026-05-30-festival-slug-deadimport-and-sort-hoist.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)