### PR TITLE
perf(watchlist): drop dead import, narrow sortBy union, hoist now out of filter

### DIFF
--- a/changelogs/2026-05-30-watchlist-deadimport-union-and-now-hoist.md
+++ b/changelogs/2026-05-30-watchlist-deadimport-union-and-now-hoist.md
@@ -1,0 +1,20 @@
+# Watchlist: drop dead Badge import, narrow sortBy union, hoist now out of filter
+
+**PR**: #111
+**Date**: 2026-05-30
+
+## Changes
+Three small, behavior-preserving cleanups in `frontend/src/routes/watchlist/+page.svelte`:
+
+- Removed the unused `import Badge from '$lib/components/ui/Badge.svelte'`. The symbol was only referenced on its own import line (grep-confirmed) and never used in the template or script.
+- Narrowed the `sortBy` state type from `'next' | 'added' | 'title'` to `'next' | 'title'`. The `'added'` member was never assigned (only the NEXT and A–Z buttons set `'next'`/`'title'`) and `sortedFilms` has no `'added'` branch, so the value was unreachable.
+- Hoisted the current-time read out of the future-screenings filter: compute `const now = Date.now()` once and compare `new Date(s.datetime).getTime() > now`, instead of allocating a fresh `new Date()` per screening inside the predicate.
+
+## Impact
+- Affects only the Watchlist page. No change to rendered output, sort behaviour, or filtering results.
+- Slightly fewer allocations when computing future screenings; one less unused module import in the bundle.
+
+## Behavior preservation
+- Identical runtime behavior. Sorting still supports exactly the two values the UI can produce (`'next'`, `'title'`).
+- The filter still keeps screenings strictly after the current instant; `Date.now()` captured once at the start of `loadFilms` matches the practically-equal `new Date()` reads that previously ran microseconds apart within the same synchronous filter pass.
+- Removing the dead import has no effect on behavior or output.

--- a/frontend/src/routes/watchlist/+page.svelte
+++ b/frontend/src/routes/watchlist/+page.svelte
@@ -2,7 +2,6 @@
 	import { filmStatuses } from '$lib/stores/film-status.svelte';
 	import { apiGet } from '$lib/api/client';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
-	import Badge from '$lib/components/ui/Badge.svelte';
 	import { formatTime, getPosterImageAttributes } from '$lib/utils';
 	import { onMount } from 'svelte';
 
@@ -19,7 +18,7 @@
 
 	let films = $state<WatchlistFilm[]>([]);
 	let loading = $state(true);
-	let sortBy = $state<'next' | 'added' | 'title'>('next');
+	let sortBy = $state<'next' | 'title'>('next');
 
 	const wantToSeeIds = $derived(filmStatuses.getFilmIdsByStatus('want_to_see'));
 
@@ -39,8 +38,9 @@
 						film: { id: string; title: string; year: number | null; directors: string[]; runtime: number | null; posterUrl: string | null };
 						screenings: Array<{ id: string; datetime: string; bookingUrl: string }>;
 					}>(`/api/films/${id}`);
+					const now = Date.now();
 					const futureScreenings = res.screenings
-						.filter((s) => new Date(s.datetime) > new Date())
+						.filter((s) => new Date(s.datetime).getTime() > now)
 						.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime());
 
 					return {


### PR DESCRIPTION
## What
Three small, behavior-preserving cleanups in `frontend/src/routes/watchlist/+page.svelte`:

- Remove the unused `import Badge from '$lib/components/ui/Badge.svelte'` (referenced only on its own import line — grep-confirmed).
- Narrow the `sortBy` state type from `'next' | 'added' | 'title'` to `'next' | 'title'`. `'added'` is never assigned (only the NEXT and A–Z buttons set `'next'`/`'title'`) and `sortedFilms` has no `'added'` branch.
- Hoist the current-time read out of the future-screenings filter: compute `const now = Date.now()` once and compare `new Date(s.datetime).getTime() > now` instead of allocating a fresh `new Date()` per screening.

## Why
Removes dead code from the bundle, tightens a type to the values the UI can actually produce, and avoids per-element `Date` allocation when computing future screenings.

## Behavior preservation (identical)
- Rendered output, sort behaviour, and filtering results are unchanged.
- Sorting still handles exactly the two reachable values (`'next'`, `'title'`).
- The filter still keeps screenings strictly after the current instant; capturing `Date.now()` once at the start of `loadFilms` matches the practically-equal `new Date()` reads that previously ran microseconds apart within the same synchronous filter pass.
- `svelte-check --threshold error` passes with 0 errors.

## Files
- `frontend/src/routes/watchlist/+page.svelte`
- `changelogs/2026-05-30-watchlist-deadimport-union-and-now-hoist.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)