### PR TITLE
perf(cinema): drop redundant re-sort of already-ascending date groups

### DIFF
--- a/changelogs/2026-05-30-cinema-slug-drop-redundant-sort.md
+++ b/changelogs/2026-05-30-cinema-slug-drop-redundant-sort.md
@@ -1,0 +1,15 @@
+# Cinema detail page: remove redundant re-sort of already-ascending date groups
+
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/cinemas/[slug]/+page.svelte`, the `groupedByDate` derived value previously did `Object.entries(groupBy(...)).sort(([a], [b]) => a.localeCompare(b))`.
+- `futureScreenings` is already sorted strictly ascending by epoch-ms (in the `futureScreenings` derivation just above). `toLondonDateStr` produces `YYYY-MM-DD` keys via a fixed-locale `Intl.DateTimeFormat` and is monotonic non-decreasing in ms. `groupBy` inserts keys in first-seen order, and JS preserves string-key insertion order for non-integer-like keys.
+- Therefore the date-string keys are already emitted in chronological order, and the `localeCompare` sort was a guaranteed no-op. Replaced with `return Object.entries(grouped);` and added an explanatory comment.
+
+## Impact
+- Cinema detail page (`/cinemas/[slug]`). Removes an O(k log k) comparator plus closure allocation per re-derivation of the grouped-by-date list (k = number of distinct future dates).
+
+## Behavior preservation
+- Output order is byte-identical: the keys were already in ascending chronological order before the removed sort ran, so the sort never reordered anything.
+- No change to grouping, filtering, or rendered markup. `svelte-check --threshold error` reports 0 errors.

--- a/frontend/src/routes/cinemas/[slug]/+page.svelte
+++ b/frontend/src/routes/cinemas/[slug]/+page.svelte
@@ -29,8 +29,13 @@
 	});
 
 	const groupedByDate = $derived.by(() => {
+		// `futureScreenings` is sorted strictly ascending by epoch-ms above and
+		// `toLondonDateStr` is monotonic non-decreasing in ms, so `groupBy`'s
+		// first-seen string-key insertion order (preserved by JS for these keys)
+		// is already chronological — the previous `.sort(localeCompare)` was a
+		// guaranteed no-op.
 		const grouped = groupBy(futureScreenings, (s) => toLondonDateStr(s.datetime));
-		return Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b));
+		return Object.entries(grouped);
 	});
 </script>
 


### PR DESCRIPTION
## What
Removes the redundant `.sort(([a], [b]) => a.localeCompare(b))` on `groupedByDate` in the cinema detail page, returning `Object.entries(grouped)` directly.

## Why
`futureScreenings` is already sorted strictly ascending by epoch-ms (in the derivation just above). `toLondonDateStr` produces `YYYY-MM-DD` keys via a fixed-locale `Intl.DateTimeFormat` and is monotonic non-decreasing in ms. `groupBy` inserts keys in first-seen order, and JS preserves string-key insertion order for non-integer-like keys. So the `YYYY-MM-DD` keys are already emitted in ascending chronological order and the `localeCompare` sort never reordered anything — it was a guaranteed no-op. Dropping it removes an O(k log k) comparator plus closure allocation per re-derivation (k = distinct future dates).

## Behavior preservation (identical)
- Output order is byte-identical: the keys were already ascending before the removed sort ran.
- No change to grouping, filtering, or rendered markup.
- `svelte-check --threshold error` reports 0 errors.

## Files
- `frontend/src/routes/cinemas/[slug]/+page.svelte`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
