### PR TITLE
perf(map): CinemaMap drop dead validCinemas + hoist marker/popup literal constants

### DIFF
--- a/changelogs/2026-05-30-cinemamap-deadcode-and-loop-constants.md
+++ b/changelogs/2026-05-30-cinemamap-deadcode-and-loop-constants.md
@@ -1,0 +1,21 @@
+# CinemaMap: remove dead validCinemas + hoist marker/popup literal constants
+
+**PR**: #114
+**Date**: 2026-05-30
+
+## Changes
+- `frontend/src/lib/components/map/CinemaMap.svelte`:
+  - Removed the dead `const validCinemas = $derived(...)` block. It was never read — `onMount` recomputes the identical `coordinates` filter inline as `cinemasWithCoords`, and grep confirmed `validCinemas` has no other reference in the component.
+  - Added a `<script module lang="ts">` block (matching the established `ScreeningRow.svelte` pattern) hoisting the constant literal strings that `createMarkerElement` and `createPopupContent` previously rebuilt on every call:
+    - Marker SVG: `MARKER_WIDTH` (`'20'`), `MARKER_HEIGHT` (`'26'`), `MARKER_VIEWBOX` (`'0 0 20 26'`), `MARKER_PATH_D` (the pin path `d`), `MARKER_PIN_FILL` (`'#1a1a1a'`), `MARKER_CIRCLE_CX`/`CY` (`'10'`), `MARKER_CIRCLE_R` (`'4'`), `MARKER_CIRCLE_FILL` (`'#fff'`).
+    - Popup: `POPUP_DIV_PADDING` (`'4px'`), `POPUP_LINK_CSS`, `POPUP_AREA_CSS`.
+  - `createMarkerElement`/`createPopupContent` now reference the module-scope consts instead of inline literals.
+
+## Impact
+- Map page (`/map`) marker and popup rendering. These builders run once per cinema (dozens of venues), so the literal strings are now allocated once per module load instead of per call.
+- Removes a dead `$derived` that re-filtered the full cinema list on every `cinemas` prop change.
+
+## Behavior preservation
+- Identical DOM output. The hoisted constants are byte-for-byte the same strings/values that were previously inlined; SVG attributes, path `d`, fills, and popup cssText are unchanged.
+- The deleted `validCinemas` had zero readers; the in-`onMount` `cinemasWithCoords` filter (used to place markers) is untouched.
+- svelte-check: 0 errors (the 2 pre-existing warnings are in unrelated files).

--- a/frontend/src/lib/components/map/CinemaMap.svelte
+++ b/frontend/src/lib/components/map/CinemaMap.svelte
@@ -1,3 +1,22 @@
+<script module lang="ts">
+	// Hoisted to module scope: createMarkerElement / createPopupContent run
+	// once per cinema, so these constant literal strings were rebuilt on every
+	// call. Shared here so the produced DOM is byte-identical to the inline form.
+	const MARKER_WIDTH = '20';
+	const MARKER_HEIGHT = '26';
+	const MARKER_VIEWBOX = '0 0 20 26';
+	const MARKER_PATH_D = 'M10 0C4.5 0 0 4.5 0 10C0 17.5 10 26 10 26S20 17.5 20 10C20 4.5 15.5 0 10 0Z';
+	const MARKER_PIN_FILL = '#1a1a1a';
+	const MARKER_CIRCLE_CX = '10';
+	const MARKER_CIRCLE_CY = '10';
+	const MARKER_CIRCLE_R = '4';
+	const MARKER_CIRCLE_FILL = '#fff';
+
+	const POPUP_DIV_PADDING = '4px';
+	const POPUP_LINK_CSS = 'font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:#1a1a1a;text-decoration:none';
+	const POPUP_AREA_CSS = 'font-size:11px;color:#666;margin-top:2px';
+</script>
+
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
@@ -7,20 +26,14 @@
 
 	let mapContainer = $state<HTMLDivElement>();
 
-	const validCinemas = $derived(
-		cinemas.filter((c): c is Cinema & { coordinates: { lat: number; lng: number } } =>
-			!!c.coordinates?.lat && !!c.coordinates?.lng
-		)
-	);
-
 	function createPopupContent(cinema: Cinema & { coordinates: { lat: number; lng: number } }): HTMLDivElement {
 		const div = document.createElement('div');
-		div.style.padding = '4px';
+		div.style.padding = POPUP_DIV_PADDING;
 
 		const link = document.createElement('a');
 		link.href = `/cinemas/${cinema.id}`;
 		link.textContent = cinema.name;
-		link.style.cssText = 'font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:#1a1a1a;text-decoration:none';
+		link.style.cssText = POPUP_LINK_CSS;
 		link.addEventListener('mouseenter', () => { link.style.textDecoration = 'underline'; });
 		link.addEventListener('mouseleave', () => { link.style.textDecoration = 'none'; });
 		div.appendChild(link);
@@ -28,7 +41,7 @@
 		if (cinema.address?.area) {
 			const area = document.createElement('p');
 			area.textContent = cinema.address.area;
-			area.style.cssText = 'font-size:11px;color:#666;margin-top:2px';
+			area.style.cssText = POPUP_AREA_CSS;
 			div.appendChild(area);
 		}
 
@@ -50,20 +63,20 @@
 		});
 
 		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-		svg.setAttribute('width', '20');
-		svg.setAttribute('height', '26');
-		svg.setAttribute('viewBox', '0 0 20 26');
+		svg.setAttribute('width', MARKER_WIDTH);
+		svg.setAttribute('height', MARKER_HEIGHT);
+		svg.setAttribute('viewBox', MARKER_VIEWBOX);
 
 		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-		path.setAttribute('d', 'M10 0C4.5 0 0 4.5 0 10C0 17.5 10 26 10 26S20 17.5 20 10C20 4.5 15.5 0 10 0Z');
-		path.setAttribute('fill', '#1a1a1a');
+		path.setAttribute('d', MARKER_PATH_D);
+		path.setAttribute('fill', MARKER_PIN_FILL);
 		svg.appendChild(path);
 
 		const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-		circle.setAttribute('cx', '10');
-		circle.setAttribute('cy', '10');
-		circle.setAttribute('r', '4');
-		circle.setAttribute('fill', '#fff');
+		circle.setAttribute('cx', MARKER_CIRCLE_CX);
+		circle.setAttribute('cy', MARKER_CIRCLE_CY);
+		circle.setAttribute('r', MARKER_CIRCLE_R);
+		circle.setAttribute('fill', MARKER_CIRCLE_FILL);
 		svg.appendChild(circle);
 
 		el.appendChild(svg);


### PR DESCRIPTION
## What
- Delete the dead `validCinemas` `$derived` in `CinemaMap.svelte`. It was never read — `onMount` already recomputes the identical `coordinates` filter inline as `cinemasWithCoords`.
- Add a `<script module lang="ts">` block (matching the established `ScreeningRow.svelte` pattern) hoisting the constant literal strings that `createMarkerElement` / `createPopupContent` previously rebuilt on every call: marker SVG `width`/`height`/`viewBox`/path `d`/fills/circle `cx`/`cy`/`r`, and popup `div` padding + link/area `cssText`.

## Why
- `createMarkerElement` and `createPopupContent` run once per cinema (dozens of venues on `/map`), each reconstructing the same literal strings. Hoisting builds them once per module load.
- The dead `$derived` re-ran a full-list filter on every `cinemas` prop change for no consumer.

## Behavior preservation (identical)
- DOM output is byte-identical: the hoisted constants are the exact strings/values previously inlined (SVG attributes, path `d`, fills, popup `cssText`).
- The removed `validCinemas` had zero readers; the marker-placement `cinemasWithCoords` filter is untouched.
- `svelte-check --threshold error`: 0 errors (2 pre-existing warnings are in unrelated files).

## Files
- `frontend/src/lib/components/map/CinemaMap.svelte`
- `changelogs/2026-05-30-cinemamap-deadcode-and-loop-constants.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)