### PR TITLE
refactor(map): drop dead page import + remove any cast on venue filter

### DIFF
--- a/changelogs/2026-05-30-map-deadimport-and-any-cast.md
+++ b/changelogs/2026-05-30-map-deadimport-and-any-cast.md
@@ -1,0 +1,15 @@
+# Map page: drop dead page import + remove any cast on venue-count filter
+
+**PR**: #113
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `import { page } from '$app/state'` from `frontend/src/routes/map/+page.svelte`. The only "page" matches in the file are the `.map-page` CSS class and the `aria-labelledby="map-heading"` attribute — neither uses the imported `page` store. Dropping it removes `$app/state` from this page's module graph.
+- Removed the `: any` cast on the venue-count filter callback: `cinemas.filter((c: any) => c.coordinates)` → `cinemas.filter((c) => c.coordinates)`. `cinemas` is `$derived(data?.cinemas ?? [])`, whose elements carry a `coordinates: { lat; lng } | null` field (from the root layout load), so `c` now infers correctly and the `c.coordinates` access stays type-checked.
+
+## Impact
+- Frontend `/map` route only. No user-facing or runtime behaviour change.
+- Slightly leaner module graph (no `$app/state` pulled in) and stronger type checking on the venue count.
+
+## Behavior preservation
+- Identical runtime output. The removed import was never referenced, so eliminating it changes no executed code. Removing the `any` cast is a compile-time-only change — the emitted JavaScript for the filter is byte-identical (TypeScript/Svelte type annotations are erased at build). `npx svelte-check --threshold error` reports 0 errors.

--- a/frontend/src/routes/map/+page.svelte
+++ b/frontend/src/routes/map/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import CinemaMap from '$lib/components/map/CinemaMap.svelte';
-	import { page } from '$app/state';
 
 	// Cinemas are loaded in the root layout and available via parent data
 	let { data } = $props();
@@ -17,7 +16,7 @@
 		<h1 id="map-heading" class="font-display text-sm font-bold tracking-wide-swiss uppercase">
 			CINEMA MAP
 		</h1>
-		<span class="text-xs text-[var(--color-muted)] font-mono">{cinemas.filter((c: any) => c.coordinates).length} VENUES</span>
+		<span class="text-xs text-[var(--color-muted)] font-mono">{cinemas.filter((c) => c.coordinates).length} VENUES</span>
 	</div>
 	<div class="map-body">
 		<CinemaMap {cinemas} />


### PR DESCRIPTION
## What
Two type-only cleanups in `frontend/src/routes/map/+page.svelte`, clustered into one PR:

1. Remove the unused `import { page } from '$app/state'`. The only "page" matches in the file are the `.map-page` CSS class and the `aria-labelledby="map-heading"` attribute — neither uses the imported store. Dropping it removes `$app/state` from this page's module graph.
2. Remove the `: any` cast on the venue-count filter callback: `cinemas.filter((c: any) => c.coordinates)` → `cinemas.filter((c) => c.coordinates)`.

## Why
- The dead import needlessly pulls `$app/state` into the page bundle.
- The `any` cast disabled type checking on `c`. `cinemas` is `$derived(data?.cinemas ?? [])`, whose elements carry `coordinates: { lat; lng } | null` (from the root layout's `+layout.server.ts` load), so `c` now infers correctly and the `c.coordinates` access stays type-checked.

## Behavior preservation (identical)
- The removed import was never referenced, so eliminating it changes no executed code.
- Removing the `any` cast is compile-time-only — TypeScript/Svelte type annotations are erased at build, so the emitted JavaScript for the filter is byte-identical.
- `npx svelte-check --tsconfig ./tsconfig.json --threshold error` → 0 errors (2 pre-existing warnings in unrelated files, unchanged).

## Files
- `frontend/src/routes/map/+page.svelte`
- `changelogs/2026-05-30-map-deadimport-and-any-cast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)