### PR TITLE
perf(reachable): cache Intl.DateTimeFormat instances in DeadlinePicker

### DIFF
--- a/changelogs/2026-05-30-deadlinepicker-cached-formatters.md
+++ b/changelogs/2026-05-30-deadlinepicker-cached-formatters.md
@@ -1,0 +1,22 @@
+# DeadlinePicker: reuse cached Intl.DateTimeFormat instances in formatSelectedTime
+
+**PR**: #116
+**Date**: 2026-05-30
+
+## Changes
+- Added a `<script module lang="ts">` block to `frontend/src/lib/components/reachable/DeadlinePicker.svelte` that hoists three module-scope `Intl.DateTimeFormat` constants:
+  - `LONDON_DATE_FORMATTER` — `en-CA`, `timeZone: 'Europe/London'` (YYYY-MM-DD)
+  - `TIME_FORMATTER` — `en-GB`, `hour: '2-digit'`, `minute: '2-digit'`, `hour12: false` (HH:mm)
+  - `DAY_MONTH_FORMATTER` — `en-GB`, `weekday: 'short'`, `day: 'numeric'`, `month: 'short'` ('Mon, 1 Jan')
+- Rewrote `formatSelectedTime` to call `.format(d)` on the reused instances instead of constructing a fresh formatter from inline options on every `toLocaleDateString`/`toLocaleTimeString` call.
+- Previously the function made up to five formatter constructions per invocation (three `en-CA` London-tz dates, one `en-GB` time, one `en-GB` weekday/day/month).
+
+## Impact
+- Frontend only (`reachable/DeadlinePicker.svelte`). The "FINISHED BY" deadline selector renders its selected-time label without rebuilding formatters each call.
+- Matches the established hoist pattern already used in `frontend/src/lib/components/search/rows/ScreeningRow.svelte`.
+
+## Behavior preservation
+- The hoisted formatter options are identical to the inline options they replace, so the produced strings (`YYYY-MM-DD` comparison keys, `HH:mm` time, `'Mon, 1 Jan'` long form) are byte-identical.
+- The time and weekday/day/month formatters intentionally omit `timeZone`, exactly as the original `toLocaleTimeString`/`toLocaleDateString` calls did (runtime-local). Only the `en-CA` date-comparison formatter uses `Europe/London`, again matching the original.
+- Verified equivalence with a Node script comparing inline vs hoisted output across multiple dates including the BST transition day — all match.
+- `svelte-check --threshold error` passes with 0 errors.

--- a/frontend/src/lib/components/reachable/DeadlinePicker.svelte
+++ b/frontend/src/lib/components/reachable/DeadlinePicker.svelte
@@ -1,3 +1,23 @@
+<script module lang="ts">
+	// Hoisted to module scope: built once per module load and shared across
+	// every DeadlinePicker instead of reconstructed on each formatSelectedTime
+	// call. The configs are constant so the formatted output is byte-identical
+	// to the per-call builders they replace.
+	const LONDON_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+		timeZone: 'Europe/London'
+	});
+	const TIME_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false
+	});
+	const DAY_MONTH_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+		weekday: 'short',
+		day: 'numeric',
+		month: 'short'
+	});
+</script>
+
 <script lang="ts">
 	let {
 		value = null,
@@ -63,17 +83,17 @@
 
 	function formatSelectedTime(date: Date): string {
 		const now = new Date();
-		const todayStr = now.toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+		const todayStr = LONDON_DATE_FORMATTER.format(now);
 		const tomorrowDate = new Date(now);
 		tomorrowDate.setDate(tomorrowDate.getDate() + 1);
-		const tomorrowStr = tomorrowDate.toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
-		const targetStr = date.toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+		const tomorrowStr = LONDON_DATE_FORMATTER.format(tomorrowDate);
+		const targetStr = LONDON_DATE_FORMATTER.format(date);
 
-		const timeStr = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
+		const timeStr = TIME_FORMATTER.format(date);
 
 		if (targetStr === todayStr) return `Today at ${timeStr}`;
 		if (targetStr === tomorrowStr) return `Tomorrow at ${timeStr}`;
-		return date.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' }) + ` at ${timeStr}`;
+		return DAY_MONTH_FORMATTER.format(date) + ` at ${timeStr}`;
 	}
 </script>
 


### PR DESCRIPTION
## What
Hoist three module-scope `Intl.DateTimeFormat` instances in `DeadlinePicker.svelte` and reuse them in `formatSelectedTime`, instead of constructing fresh formatters from inline options on every call.

- `LONDON_DATE_FORMATTER` — `en-CA`, `timeZone: 'Europe/London'` (YYYY-MM-DD comparison keys)
- `TIME_FORMATTER` — `en-GB`, `hour: '2-digit'`, `minute: '2-digit'`, `hour12: false` (HH:mm)
- `DAY_MONTH_FORMATTER` — `en-GB`, `weekday: 'short'`, `day: 'numeric'`, `month: 'short'` ('Mon, 1 Jan')

## Why
`formatSelectedTime` previously built up to five formatters per invocation (three `en-CA` London-tz dates, one `en-GB` time, one `en-GB` weekday/day/month). Constructing an `Intl.DateTimeFormat` is comparatively expensive; reusing cached instances follows the established hoist pattern already in `search/rows/ScreeningRow.svelte`.

## Behavior preservation (identical)
- The hoisted options mirror the inline options exactly. The time and weekday/day/month formatters intentionally omit `timeZone` (runtime-local), just as the original `toLocaleTimeString`/`toLocaleDateString` calls did; only the `en-CA` date-comparison formatter uses `Europe/London`, matching the original.
- Output strings (date comparison keys, HH:mm time, 'Mon, 1 Jan' long form) are byte-identical. Verified with a Node equivalence script comparing inline vs hoisted output across multiple dates including the BST transition day — all match.
- `svelte-check --threshold error` passes with 0 errors (the only 2 warnings are pre-existing in unrelated files).

## Files
- `frontend/src/lib/components/reachable/DeadlinePicker.svelte`
- `changelogs/2026-05-30-deadlinepicker-cached-formatters.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)