### PR TITLE
perf(reachable): compute urgencyClass once per group via {@const}

### DIFF
--- a/changelogs/2026-05-30-reachable-results-group-urgency-const.md
+++ b/changelogs/2026-05-30-reachable-results-group-urgency-const.md
@@ -1,0 +1,17 @@
+# ReachableResults: compute urgencyClass once per group via {@const}
+
+**PR**: #115
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/reachable/ReachableResults.svelte`, added a group-scoped `{@const urgencyCss = urgencyClass(urgency)}` immediately after the existing `{@const groupScreenings = groups[urgency]}` inside the `{#each urgencyOrder}` block.
+- Replaced the two call sites that previously invoked `urgencyClass(urgency)` directly — the group header `<h2 class="group-label ...">` and the per-card `<div class="leave-badge ...">` — with references to `urgencyCss`.
+
+## Impact
+- Affects only the Reachable results view (`ReachableResults.svelte`).
+- `urgencyClass` is a pure switch over the group's `urgency`, which is constant for the whole group. Previously it was re-evaluated once per screening card inside the `{#each groupScreenings}` loop. Now it is computed once per urgency group and reused, eliminating redundant switch evaluations on large result sets.
+
+## Behavior preservation
+- `urgencyClass(urgency)` is a pure function with no side effects, returning a fixed string per `urgency` value.
+- `urgency` does not change within a group, so the single group-scoped computation yields the exact same string the per-card calls would have produced.
+- The emitted `class` attribute strings on both the group header and each leave badge are byte-identical to before. No runtime behavior or output changes.

--- a/frontend/src/lib/components/reachable/ReachableResults.svelte
+++ b/frontend/src/lib/components/reachable/ReachableResults.svelte
@@ -71,11 +71,12 @@
 
 		{#each urgencyOrder as urgency (urgency)}
 			{@const groupScreenings = groups[urgency]}
+			{@const urgencyCss = urgencyClass(urgency)}
 			{#if groupScreenings.length > 0}
 				<div class="urgency-group">
 					<!-- Group header -->
 					<div class="group-header">
-						<h2 class="group-label {urgencyClass(urgency)}">
+						<h2 class="group-label {urgencyCss}">
 							{getUrgencyLabel(urgency)}
 						</h2>
 						<span class="group-count">({groupScreenings.length})</span>
@@ -113,7 +114,7 @@
 								<!-- Content -->
 								<div class="card-content">
 									<!-- Leave-by badge -->
-									<div class="leave-badge {urgencyClass(urgency)}">
+									<div class="leave-badge {urgencyCss}">
 										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 											<circle cx="12" cy="12" r="10" />
 											<polyline points="12 6 12 12 16 14" />


### PR DESCRIPTION
## What
In `ReachableResults.svelte`, hoist the per-group urgency CSS class into a single `{@const urgencyCss = urgencyClass(urgency)}` declared right after the existing `{@const groupScreenings = groups[urgency]}`, and reference `urgencyCss` at both the group header (`<h2 class="group-label ...">`) and the per-card leave badge (`<div class="leave-badge ...">`).

## Why
`urgencyClass(urgency)` was invoked at the group header and again inside the `{#each groupScreenings}` loop — once per screening card. Since `urgency` is constant for the whole group, the `switch` ran redundantly on every card. Computing it once per group eliminates that repeated work on large result sets.

## Behavior preservation (identical)
- `urgencyClass` is a pure switch returning a fixed string per `urgency`, with no side effects.
- `urgency` does not change within a group, so the single group-scoped value equals what each per-card call produced.
- The emitted `class` attribute strings on both elements are byte-identical. No runtime behavior or output changes. `svelte-check` passes with 0 errors.

## Files
- `frontend/src/lib/components/reachable/ReachableResults.svelte`
- `changelogs/2026-05-30-reachable-results-group-urgency-const.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)