### PR TITLE
perf(search): hoist FestivalRow date-range Intl.DateTimeFormat to module scope

### DIFF
--- a/changelogs/2026-05-30-festivalrow-hoist-formatter.md
+++ b/changelogs/2026-05-30-festivalrow-hoist-formatter.md
@@ -1,0 +1,17 @@
+# FestivalRow: hoist date-range Intl.DateTimeFormat to script module scope
+
+**PR**: #117
+**Date**: 2026-05-30
+
+## Changes
+- Moved the constant `Intl.DateTimeFormat('en-GB', { month: 'short', day: 'numeric', timeZone: 'Europe/London' })` out of the `dateRange` `$derived.by` body and into a new `<script module>` block as a shared `const RANGE_FORMATTER`.
+- `dateRange` now references the hoisted `RANGE_FORMATTER` instead of constructing a new formatter on every recompute.
+- Mirrors the existing pattern in the sibling `ScreeningRow.svelte` (`<script module>` with `TIME_FORMATTER`/`WEEKDAY_FORMATTER`/`LONDON_DATE_FORMATTER`).
+
+## Impact
+- Affects the search results UI (`frontend/src/lib/components/search/rows/FestivalRow.svelte`).
+- The formatter is now built once per module load and shared across all `FestivalRow` instances, rather than reconstructed per derived recompute per row.
+
+## Behavior preservation
+- The formatter arguments are fully constant, so the formatted date-range output is byte-identical to the per-call builder.
+- No change to component props, markup, styles, or rendered text. Purely a hoist of a constant object construction to module scope.

--- a/frontend/src/lib/components/search/rows/FestivalRow.svelte
+++ b/frontend/src/lib/components/search/rows/FestivalRow.svelte
@@ -1,3 +1,14 @@
+<script module lang="ts">
+	// Hoisted to module scope: built once per module load and shared across
+	// every FestivalRow instead of reconstructed per recompute. The config is
+	// constant so the formatted output is byte-identical to the per-call builder.
+	const RANGE_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+		month: 'short',
+		day: 'numeric',
+		timeZone: 'Europe/London'
+	});
+</script>
+
 <script lang="ts">
 	import type { FestivalResult } from '$lib/search/result-types';
 
@@ -19,12 +30,7 @@
 	);
 
 	const dateRange = $derived.by(() => {
-		const fmt = new Intl.DateTimeFormat('en-GB', {
-			month: 'short',
-			day: 'numeric',
-			timeZone: 'Europe/London'
-		});
-		return `${fmt.format(new Date(festival.startDate))} – ${fmt.format(new Date(festival.endDate))}`;
+		return `${RANGE_FORMATTER.format(new Date(festival.startDate))} – ${RANGE_FORMATTER.format(new Date(festival.endDate))}`;
 	});
 </script>
 


### PR DESCRIPTION
## What
Hoist the constant `Intl.DateTimeFormat('en-GB', { month: 'short', day: 'numeric', timeZone: 'Europe/London' })` out of the `dateRange` `$derived.by` body in `FestivalRow.svelte` and into a new `<script module>` block as a shared `const RANGE_FORMATTER`. `dateRange` now references the hoisted formatter.

## Why
The formatter was reconstructed on every `dateRange` recompute, once per festival row, even though its arguments are fully constant. Building it once per module load and sharing it across all `FestivalRow` instances removes that redundant allocation. This mirrors the existing pattern already used in the sibling `ScreeningRow.svelte` (`<script module>` with `TIME_FORMATTER`/`WEEKDAY_FORMATTER`/`LONDON_DATE_FORMATTER`).

## Behavior preservation (identical)
The formatter config is constant, so the formatted date-range string is byte-identical to the previous per-call builder. No change to props, markup, styles, or rendered text — purely a hoist of a constant object construction to module scope. `svelte-check --threshold error` reports 0 errors.

## Files
- `frontend/src/lib/components/search/rows/FestivalRow.svelte`
- `changelogs/2026-05-30-festivalrow-hoist-formatter.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)