### PR TITLE
perf(header): precompute NAV_ITEMS desktop/mobile filters once

### DIFF
--- a/changelogs/2026-05-30-header-hoist-nav-filters.md
+++ b/changelogs/2026-05-30-header-hoist-nav-filters.md
@@ -1,0 +1,28 @@
+# Header: precompute NAV_ITEMS desktop/mobile filters once
+
+**PR**: #118
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/layout/Header.svelte`, hoisted the two inline
+  `NAV_ITEMS.filter(...)` passes out of the markup into script-scope constants
+  computed once: `const DESKTOP_NAV = NAV_ITEMS.filter((n) => n.desktop);` and
+  `const MOBILE_NAV = NAV_ITEMS.filter((n) => n.mobile);`.
+- Updated the desktop `{#each ...}` (was `NAV_ITEMS.filter((n) => n.desktop)`)
+  to iterate `DESKTOP_NAV`, and the mobile `{#each ...}` (was
+  `NAV_ITEMS.filter((n) => n.mobile)`) to iterate `MOBILE_NAV`. Each keys
+  (`(item.href)`) are unchanged.
+
+## Impact
+- The sticky header re-renders on every `page.url.pathname` change and every
+  `mobileMenuOpen` toggle. Previously both `.filter()` passes re-ran on each of
+  those renders even though `NAV_ITEMS` is a static const that is never mutated.
+  Now the two filtered arrays are computed once at module/component init.
+
+## Behavior preservation
+- `NAV_ITEMS` is a static, never-mutated const, so the filtered results are
+  invariant across renders — moving the filter to init-time produces the exact
+  same arrays in the same order.
+- The `{#each}` blocks render identical items with identical `(item.href)` keys,
+  classes, attributes, and text. Output is byte-identical.
+- `svelte-kit sync` + `svelte-check --threshold error` pass with 0 errors.

--- a/frontend/src/lib/components/layout/Header.svelte
+++ b/frontend/src/lib/components/layout/Header.svelte
@@ -40,6 +40,11 @@
 		{ href: '/directors', label: 'Directors', desktop: false, mobile: true }
 	];
 
+	// NAV_ITEMS is static and never mutated, so the per-surface filters are
+	// computed once here rather than re-run inline on every header re-render.
+	const DESKTOP_NAV = NAV_ITEMS.filter((n) => n.desktop);
+	const MOBILE_NAV = NAV_ITEMS.filter((n) => n.mobile);
+
 	function isActive(href: string, matchPrefix?: boolean): boolean {
 		return matchPrefix ? page.url.pathname.startsWith(href) : page.url.pathname === href;
 	}
@@ -82,7 +87,7 @@
 
 			<div class="brand-right">
 				<nav class="nav-links" aria-label="Main">
-					{#each NAV_ITEMS.filter((n) => n.desktop) as item (item.href)}
+					{#each DESKTOP_NAV as item (item.href)}
 						<a
 							href={item.href}
 							class="nav-link"
@@ -125,7 +130,7 @@
 		<!-- Mobile nav menu -->
 		{#if mobileMenuOpen}
 			<nav class="mobile-nav" aria-label="Mobile navigation">
-				{#each NAV_ITEMS.filter((n) => n.mobile) as item (item.href)}
+				{#each MOBILE_NAV as item (item.href)}
 					<a
 						href={item.href}
 						class="mobile-nav-link"


### PR DESCRIPTION
## What
Hoist the two inline `NAV_ITEMS.filter(...)` passes in `Header.svelte` out of the markup into script-scope constants computed once:

```ts
const DESKTOP_NAV = NAV_ITEMS.filter((n) => n.desktop);
const MOBILE_NAV = NAV_ITEMS.filter((n) => n.mobile);
```

The desktop `{#each}` now iterates `DESKTOP_NAV` and the mobile `{#each}` iterates `MOBILE_NAV`. Keys (`(item.href)`) are unchanged.

## Why
The sticky header re-renders on every `page.url.pathname` change and every `mobileMenuOpen` toggle. `NAV_ITEMS` is a static const that is never mutated, yet both `.filter()` passes re-ran on each of those renders. Computing the two filtered arrays once at component init avoids the redundant work.

## Behavior preservation (identical)
- `NAV_ITEMS` is static and never mutated, so the filtered arrays are invariant across renders — moving the filter to init-time yields the exact same arrays in the same order.
- Both `{#each}` blocks render identical items with identical `(item.href)` keys, classes, attributes, and text. Output is byte-identical.
- `svelte-kit sync` + `svelte-check --threshold error` pass with 0 errors (the only 2 warnings are pre-existing, in unrelated files).

## Files
- `frontend/src/lib/components/layout/Header.svelte`

🤖 Generated with [Claude Code](https://claude.com/claude-code)