### PR TITLE
perf(filters): hoist inline Date getUTCDate() for Today/Tomorrow chips

### DIFF
--- a/changelogs/2026-05-30-mobilefiltersheet-hoist-day-numbers.md
+++ b/changelogs/2026-05-30-mobilefiltersheet-hoist-day-numbers.md
@@ -1,0 +1,17 @@
+# MobileFilterSheet: hoist inline Date getUTCDate() for Today/Tomorrow chips
+
+**PR**: #119
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/filters/MobileFilterSheet.svelte`, the Today/Tomorrow chips previously rendered `{new Date(today + 'T12:00:00Z').getUTCDate()}` and `{new Date(tomorrow + 'T12:00:00Z').getUTCDate()}` inline in the template, allocating two `Date` objects on every re-render of the open sheet.
+- Hoisted these into two instance consts next to the existing precomputed labels:
+  - `const todayDay = new Date(today + 'T12:00:00Z').getUTCDate();`
+  - `const tomorrowDay = new Date(tomorrow + 'T12:00:00Z').getUTCDate();`
+- Template now references `{todayDay}` / `{tomorrowDay}`.
+
+## Impact
+- Micro-optimisation for the mobile filter sheet: the two day-number values are computed once per component instance instead of on every render, matching how `today`/`tomorrow`/`todayLabel`/`tomorrowLabel` are already handled in the same `<script>` block.
+
+## Behavior preservation
+- Byte-identical output. `today` and `tomorrow` are fixed instance consts for the component lifetime, so `getUTCDate()` always returns the same numbers. The displayed day numbers in the Today/Tomorrow chips are unchanged; only the computation is moved out of the render path.

--- a/frontend/src/lib/components/filters/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/filters/MobileFilterSheet.svelte
@@ -105,6 +105,8 @@
 	const dayFmt = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' });
 	const todayLabel = dayFmt.format(new Date(today + 'T12:00:00Z'));
 	const tomorrowLabel = dayFmt.format(new Date(tomorrow + 'T12:00:00Z'));
+	const todayDay = new Date(today + 'T12:00:00Z').getUTCDate();
+	const tomorrowDay = new Date(tomorrow + 'T12:00:00Z').getUTCDate();
 
 	function pick(preset: 'today' | 'tomorrow' | 'weekend' | null) {
 		if (preset === 'today') {
@@ -214,8 +216,8 @@
 					<span class="hint">today</span>
 				</div>
 				<div class="chips">
-					<button type="button" class="chip" class:active={whenState === 'today'} onclick={() => pick(whenState === 'today' ? null : 'today')}>Today<span class="sub">{todayLabel} {new Date(today + 'T12:00:00Z').getUTCDate()}</span></button>
-					<button type="button" class="chip" class:active={whenState === 'tomorrow'} onclick={() => pick(whenState === 'tomorrow' ? null : 'tomorrow')}>Tomorrow<span class="sub">{tomorrowLabel} {new Date(tomorrow + 'T12:00:00Z').getUTCDate()}</span></button>
+					<button type="button" class="chip" class:active={whenState === 'today'} onclick={() => pick(whenState === 'today' ? null : 'today')}>Today<span class="sub">{todayLabel} {todayDay}</span></button>
+					<button type="button" class="chip" class:active={whenState === 'tomorrow'} onclick={() => pick(whenState === 'tomorrow' ? null : 'tomorrow')}>Tomorrow<span class="sub">{tomorrowLabel} {tomorrowDay}</span></button>
 					<button type="button" class="chip" class:active={whenState === 'weekend'} onclick={() => pick(whenState === 'weekend' ? null : 'weekend')}>This weekend</button>
 					<button type="button" class="chip" onclick={() => (datePickerOpen = true)}>Pick a date</button>
 				</div>


### PR DESCRIPTION
## What
Hoist the two inline `new Date(...).getUTCDate()` expressions in `MobileFilterSheet.svelte`'s Today/Tomorrow chips into `todayDay` / `tomorrowDay` instance consts, placed next to the existing precomputed `todayLabel` / `tomorrowLabel`. The template now references `{todayDay}` / `{tomorrowDay}`.

## Why
The chips previously allocated two `Date` objects on every re-render of the open sheet. `today` and `tomorrow` are already fixed instance consts (computed once), and the labels derived from them are precomputed the same way — the day numbers should be too. This keeps the work out of the render path.

## Behavior preservation (identical)
`today` and `tomorrow` are immutable for the component lifetime, so `getUTCDate()` always returns the same numbers. The displayed day numbers are unchanged — output is byte-identical; only the computation moves from per-render to per-instance.

## Files
- `frontend/src/lib/components/filters/MobileFilterSheet.svelte`
- `changelogs/2026-05-30-mobilefiltersheet-hoist-day-numbers.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)