### PR TITLE
perf(filters): hoist duplicated en-CA London Intl formatter out of applyIntent

### DIFF
--- a/changelogs/2026-05-30-filters-store-hoist-london-ymd.md
+++ b/changelogs/2026-05-30-filters-store-hoist-london-ymd.md
@@ -1,0 +1,17 @@
+# filters store: hoist duplicated en-CA London Intl formatter out of applyIntent
+
+**PR**: #120
+**Date**: 2026-05-30
+
+## Changes
+- Hoisted a single module-level `const LONDON_YMD = new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/London', year: 'numeric', month: '2-digit', day: '2-digit' })` near the top of `frontend/src/lib/stores/filters.svelte.ts`.
+- Replaced the two byte-identical inline `new Intl.DateTimeFormat(...)` instances inside `applyIntent` (one for `dateFrom`, one for `dateTo`) with calls to the shared `LONDON_YMD.format(...)`.
+
+## Impact
+- `applyIntent` runs on the cmd+k palette intent-apply path. The previous code allocated two fresh `Intl.DateTimeFormat` instances per call; this removes both allocations by reusing one stateless module-scope formatter.
+- Mirrors the established hoist pattern (`DATE_LONDON_ISO` in `utils.ts`).
+
+## Behavior preservation
+- The hoisted formatter uses the exact same locale (`en-CA`) and options (`timeZone: 'Europe/London'`, `year: 'numeric'`, `month: '2-digit'`, `day: '2-digit'`) as the two original inline formatters.
+- `Intl.DateTimeFormat` is stateless, so reusing one instance yields identical `YYYY-MM-DD` strings, including across DST boundaries.
+- Output is byte-identical; no rendered or stored value changes.

--- a/frontend/src/lib/stores/filters.svelte.ts
+++ b/frontend/src/lib/stores/filters.svelte.ts
@@ -4,6 +4,17 @@ import type { ParsedIntent } from '$lib/search/parse-query';
 
 const STORAGE_KEY = 'pictures-filters';
 
+// Cached London-tz YYYY-MM-DD formatter reused across applyIntent calls.
+// Instantiating a fresh Intl.DateTimeFormat per call dominates the cost on
+// the cmd+k keystroke path; allocate once at module scope (mirrors the
+// DATE_LONDON_ISO hoist in utils.ts). Stateless — identical output across DST.
+const LONDON_YMD = new Intl.DateTimeFormat('en-CA', {
+	timeZone: 'Europe/London',
+	year: 'numeric',
+	month: '2-digit',
+	day: '2-digit'
+});
+
 interface PersistedFilters {
 	cinemaIds: string[];
 	formats: string[];
@@ -268,22 +279,8 @@ export const filters = {
 			// ParsedIntent.dateFrom/dateTo are JS Dates representing the
 			// London-midnight instant; the filters store uses YYYY-MM-DD
 			// strings in London tz. Round-trip via Intl so DST stays sane.
-			dateFrom = parsed.dateFrom
-				? new Intl.DateTimeFormat('en-CA', {
-						timeZone: 'Europe/London',
-						year: 'numeric',
-						month: '2-digit',
-						day: '2-digit'
-					}).format(parsed.dateFrom)
-				: null;
-			dateTo = parsed.dateTo
-				? new Intl.DateTimeFormat('en-CA', {
-						timeZone: 'Europe/London',
-						year: 'numeric',
-						month: '2-digit',
-						day: '2-digit'
-					}).format(parsed.dateTo)
-				: null;
+			dateFrom = parsed.dateFrom ? LONDON_YMD.format(parsed.dateFrom) : null;
+			dateTo = parsed.dateTo ? LONDON_YMD.format(parsed.dateTo) : null;
 		}
 		if (parsed.timeFrom !== undefined) timeFrom = parsed.timeFrom;
 		if (parsed.timeTo !== undefined) timeTo = parsed.timeTo;


### PR DESCRIPTION
## What
Hoist the duplicated `Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/London', year, month, day })` out of `applyIntent` in `frontend/src/lib/stores/filters.svelte.ts` into a single module-level `const LONDON_YMD`, and reuse it for both the `dateFrom` and `dateTo` formatting.

## Why
`applyIntent` previously constructed two byte-identical `Intl.DateTimeFormat` instances inline on every call (one per date field). `applyIntent` runs on the cmd+k intent-apply path. Allocating a fresh formatter per call is pure overhead; a single stateless module-scope instance removes 2 allocations per call. Mirrors the established `DATE_LONDON_ISO` hoist pattern in `utils.ts`.

## Behavior preservation (identical)
- The hoisted formatter uses the exact same locale (`en-CA`) and options (`timeZone: 'Europe/London'`, `year: 'numeric'`, `month: '2-digit'`, `day: '2-digit'`) as both original inline formatters.
- `Intl.DateTimeFormat` is stateless, so reusing one instance produces identical `YYYY-MM-DD` strings, including across DST boundaries.
- Output is byte-identical; no rendered or stored value changes.
- Gate: `svelte-kit sync` + `svelte-check --threshold error` → 0 errors (the only 2 warnings are pre-existing in unrelated files).

## Files
- `frontend/src/lib/stores/filters.svelte.ts`
- `changelogs/2026-05-30-filters-store-hoist-london-ymd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)