### PR TITLE
perf(directors): hoist query lowercasing out of the filter loop

### DIFF
--- a/changelogs/2026-05-30-directors-hoist-search-lowercase.md
+++ b/changelogs/2026-05-30-directors-hoist-search-lowercase.md
@@ -1,0 +1,15 @@
+# Directors page: hoist query lowercasing out of the filter loop
+
+**PR**: #123
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/directors/+page.svelte`, the `filtered` derived value previously called `search.toLowerCase()` once per director on every keystroke inside the `.filter()` predicate.
+- Switched the derived to the `$derived.by(() => {...})` form so the lowercased query can be computed once (`const q = search.toLowerCase();`) and reused across all directors in the filter.
+- The empty-search short-circuit (returning `data.directors` unfiltered) is preserved.
+
+## Impact
+- Frontend only. The directors API returns every director across the next 14 days with no LIMIT (realistically several hundred entries), so this removes hundreds of redundant `toLowerCase()` calls per keystroke during search.
+
+## Behavior preservation
+- Identical output. The filter predicate, the case-insensitive matching, and the empty-search branch are unchanged. `q` is exactly `search.toLowerCase()`, the same value previously recomputed inline per director. No change to rendering, ordering, or filtering results.

--- a/frontend/src/routes/directors/+page.svelte
+++ b/frontend/src/routes/directors/+page.svelte
@@ -10,11 +10,11 @@
 	let { data }: { data: { directors: DirectorEntry[] } } = $props();
 	let search = $state('');
 
-	const filtered = $derived(
-		search
-			? data.directors.filter((d) => d.name.toLowerCase().includes(search.toLowerCase()))
-			: data.directors
-	);
+	const filtered = $derived.by(() => {
+		if (!search) return data.directors;
+		const q = search.toLowerCase();
+		return data.directors.filter((d) => d.name.toLowerCase().includes(q));
+	});
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## What
Hoist `search.toLowerCase()` out of the per-director `.filter()` predicate on the directors page. The `filtered` derived now computes the lowercased query once and reuses it across all entries.

## Why
The directors API has no LIMIT — it returns every director across the next 14 days (realistically several hundred entries). The old code recomputed `search.toLowerCase()` once per director on every keystroke, i.e. hundreds of redundant string allocations per keypress during search.

## Behavior preservation (identical)
- Same empty-search short-circuit: returns `data.directors` unfiltered when `search` is falsy.
- Same case-insensitive substring match. `q` is exactly `search.toLowerCase()` — the identical value previously recomputed inline per director.
- No change to rendering, ordering, or filtered results. Uses the idiomatic Svelte 5 `$derived.by` form (already established in the project frontend rules) to host the intermediate `const`.
- Gate: `svelte-check --threshold error` → 0 errors.

## Files
- `frontend/src/routes/directors/+page.svelte`
- `changelogs/2026-05-30-directors-hoist-search-lowercase.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)