### PR TITLE
perf(filters): hoist MobileDatePicker weekday-header array to module const

### DIFF
--- a/changelogs/2026-05-30-mobiledatepicker-hoist-weekdays.md
+++ b/changelogs/2026-05-30-mobiledatepicker-hoist-weekdays.md
@@ -1,0 +1,17 @@
+# MobileDatePicker: hoist inline weekday-header array to a module const
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- Added a top-level `const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su']` next to the existing `MONTH_NAMES` const in `frontend/src/lib/components/filters/MobileDatePicker.svelte`.
+- Changed the weekday-header `{#each}` block to iterate `WEEKDAYS` instead of an inline array literal.
+
+## Impact
+- Avoids re-allocating a 7-element array literal on every render (e.g. month navigation) in the mobile date picker.
+- Purely internal; affects only the mobile filter date-picker component.
+
+## Behavior preservation
+- Identical rendered output: same seven labels, same order, same `(d + i)` keys, same `class:weekend={i >= 5}` indices.
+- Constant data hoisted out of the render path; no logic, markup, or styling changed.
+- Consistent with the file's existing `MONTH_NAMES` module const pattern.

--- a/frontend/src/lib/components/filters/MobileDatePicker.svelte
+++ b/frontend/src/lib/components/filters/MobileDatePicker.svelte
@@ -16,6 +16,7 @@
 	let viewYear = $state(initial.getUTCFullYear());
 
 	const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+	const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su'];
 
 	function prev() { if (viewMonth === 0) { viewMonth = 11; viewYear--; } else viewMonth--; }
 	function next() { if (viewMonth === 11) { viewMonth = 0; viewYear++; } else viewMonth++; }
@@ -85,7 +86,7 @@
 		</div>
 
 		<div class="weekdays">
-			{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}
+			{#each WEEKDAYS as d, i (d + i)}
 				<div class="wk" class:weekend={i >= 5}>{d}</div>
 			{/each}
 		</div>


### PR DESCRIPTION
## What
Hoist the inline weekday-header array literal in `MobileDatePicker.svelte` to a top-level `const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su']` (placed next to the existing `MONTH_NAMES` const) and iterate that in the `{#each}` block instead of the literal.

## Why
The weekday-header `{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}` re-allocated a fresh 7-element array on every render — e.g. each month navigation. Hoisting to a module-level const allocates it once.

## Behavior preservation (identical)
- Same seven labels in the same order, same `(d + i)` keys, same `class:weekend={i >= 5}` indices.
- Constant data moved out of the render path; no logic, markup, or styling changed.
- Mirrors the file's existing `MONTH_NAMES` module-const pattern.
- `svelte-check --threshold error`: 0 errors.

## Files
- `frontend/src/lib/components/filters/MobileDatePicker.svelte`
- `changelogs/2026-05-30-mobiledatepicker-hoist-weekdays.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)