### PR TITLE
perf(CalendarPopover): hoist weekday-header array to module const

### DIFF
--- a/changelogs/2026-05-30-calendarpopover-hoist-weekdays.md
+++ b/changelogs/2026-05-30-calendarpopover-hoist-weekdays.md
@@ -1,0 +1,16 @@
+# CalendarPopover: hoist inline weekday-header array to a module const
+
+**PR**: #121
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/filters/CalendarPopover.svelte`, added a top-level `const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su'];` alongside the existing `MONTH_NAMES` const.
+- Updated the weekday-header loop from `{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}` to `{#each WEEKDAYS as d, i (d + i)}`.
+
+## Impact
+- The 7-element weekday array is now allocated once at module scope instead of on every render (e.g. each month-navigation click). Tiny allocation/GC reduction in a frequently-re-rendered popover.
+- Matches the file's own `MONTH_NAMES` convention for static label arrays.
+
+## Behavior preservation
+- Identical data, identical keys (`d + i`), identical iteration order and rendered output. The `class:is-weekend={i >= 5}` logic is unchanged because the array contents and order are byte-identical.
+- Verified with `svelte-kit sync` + `svelte-check --threshold error`: 0 errors, no new warnings in this file.

--- a/frontend/src/lib/components/filters/CalendarPopover.svelte
+++ b/frontend/src/lib/components/filters/CalendarPopover.svelte
@@ -25,6 +25,7 @@
 	});
 
 	const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+	const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su'];
 
 	// `$effect` re-syncs `viewMonth`/`viewYear` from `selected` whenever the
 	// parent prop changes — intentional: if the parent jumps the selected
@@ -93,7 +94,7 @@
 	</div>
 
 	<div class="cal-weekdays">
-		{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}
+		{#each WEEKDAYS as d, i (d + i)}
 			<div class="cal-weekday" class:is-weekend={i >= 5}>{d}</div>
 		{/each}
 	</div>


### PR DESCRIPTION
## What
Hoists the inline weekday-header array out of the `{#each}` loop in `CalendarPopover.svelte` into a top-level `const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su'];` declared alongside the existing `MONTH_NAMES` const, and iterates `{#each WEEKDAYS as d, i (d + i)}`.

## Why
The array literal was inlined directly in the template, so a fresh 7-element array was allocated on every render of the popover (e.g. each month-navigation click). Hoisting to a module-scope const allocates it once and matches the file's own `MONTH_NAMES` convention for static label arrays.

## Behavior preservation (identical)
- Same array contents, same order, same keys (`d + i`).
- `class:is-weekend={i >= 5}` logic is unaffected because the index mapping is byte-identical.
- Rendered output is identical. `svelte-check --threshold error` reports 0 errors and no new warnings in this file.

## Files
- `frontend/src/lib/components/filters/CalendarPopover.svelte`
- `changelogs/2026-05-30-calendarpopover-hoist-weekdays.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)