### PR TITLE
refactor(layout): extract duplicated app-shell into a {#snippet}

### DIFF
--- a/changelogs/2026-05-30-layout-extract-shell-snippet.md
+++ b/changelogs/2026-05-30-layout-extract-shell-snippet.md
@@ -1,0 +1,20 @@
+# Root layout: extract duplicated app-shell into a {#snippet}
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/+layout.svelte`, the `{#if clerkEnabled}` and `{:else}` branches duplicated the app-shell markup verbatim: the `<a class="skip-link">` and the `<div class="min-h-dvh flex flex-col">` containing `<Header cinemas={data?.cinemas ?? []} />`, `<main id="main-content">{@render children()}</main>` and `<Footer />`.
+- Defined a `{#snippet shell()}...{/snippet}` covering exactly that shared skip-link + shell `<div>` block, and replaced both inline copies with `{@render shell()}`.
+- Left the per-branch provider logic untouched: the Clerk branch still renders `ClerkProvider` wrapping `PostHogProvider`, `SyncProvider`, `GlobalCmdkBinding`, and the conditional lazy `{#if CommandPalette}<CommandPalette />{/if}`; the else branch still renders `PostHogProvider` and `GlobalCmdkBinding` only.
+
+## Impact
+- Removes a real drift hazard: the two copies of the shell can no longer diverge.
+- No new imports, no dependency changes, no logic changes.
+
+## Behavior preservation
+- The snippet captures byte-identical markup to the two previous inline copies; render order within each branch is preserved (providers first, then skip-link + shell).
+- `data`, `children`, and `Header`/`main`/`Footer` references inside the snippet resolve to the same component-scope bindings.
+- Clerk-only `SyncProvider` and the lazy/conditional `CommandPalette` placement are unchanged.
+- Rendered DOM is identical in both the Clerk-enabled and Clerk-disabled paths.
+- Verified with `svelte-kit sync` + `svelte-check --threshold error`: 0 errors (the only 2 warnings are pre-existing and in unrelated files).

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -51,27 +51,7 @@
 
 <JsonLd data={organizationSchema()} />
 
-{#if clerkEnabled}
-	<ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
-		<PostHogProvider />
-		<SyncProvider />
-		<GlobalCmdkBinding />
-		{#if CommandPalette}
-			<CommandPalette />
-		{/if}
-		<a href="#main-content" class="skip-link">Skip to content</a>
-
-		<div class="min-h-dvh flex flex-col">
-			<Header cinemas={data?.cinemas ?? []} />
-			<main id="main-content" class="flex-1" tabindex="-1">
-				{@render children()}
-			</main>
-			<Footer />
-		</div>
-	</ClerkProvider>
-{:else}
-	<PostHogProvider />
-	<GlobalCmdkBinding />
+{#snippet shell()}
 	<a href="#main-content" class="skip-link">Skip to content</a>
 
 	<div class="min-h-dvh flex flex-col">
@@ -81,6 +61,22 @@
 		</main>
 		<Footer />
 	</div>
+{/snippet}
+
+{#if clerkEnabled}
+	<ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
+		<PostHogProvider />
+		<SyncProvider />
+		<GlobalCmdkBinding />
+		{#if CommandPalette}
+			<CommandPalette />
+		{/if}
+		{@render shell()}
+	</ClerkProvider>
+{:else}
+	<PostHogProvider />
+	<GlobalCmdkBinding />
+	{@render shell()}
 {/if}
 
 <style>


### PR DESCRIPTION
## What
Extracts the duplicated app-shell markup in `frontend/src/routes/+layout.svelte` into a single `{#snippet shell()}`. The `{#if clerkEnabled}` and `{:else}` branches both repeated the `<a class="skip-link">` plus the `<div class="min-h-dvh flex flex-col">` block (`Header` / `main` with `{@render children()}` / `Footer`) verbatim. Both branches now call `{@render shell()}`.

## Why
The two copies of the shell were a drift hazard — a change to one branch (e.g. a new `Header` prop or `main` attribute) could silently diverge from the other. A single snippet makes the shared shell a single source of truth.

## Behavior preservation (identical)
- The snippet covers exactly the byte-identical skip-link + shell `<div>` that both branches previously inlined.
- Per-branch provider logic is untouched: the Clerk branch still renders `ClerkProvider` wrapping `PostHogProvider`, `SyncProvider`, `GlobalCmdkBinding`, and the conditional lazy `{#if CommandPalette}<CommandPalette />{/if}`; the else branch still renders `PostHogProvider` and `GlobalCmdkBinding` only.
- Render order within each branch is preserved (providers first, then skip-link + shell).
- No new imports, no dependency changes, no logic changes. Rendered DOM is identical in both auth paths.
- `svelte-kit sync` + `svelte-check --threshold error`: 0 errors (the 2 warnings are pre-existing, in unrelated files).

## Files
- `frontend/src/routes/+layout.svelte`
- `changelogs/2026-05-30-layout-extract-shell-snippet.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)