### PR TITLE
refactor(search): compute FilmRow tmdbRating.toFixed(1) once

### DIFF
--- a/changelogs/2026-05-30-filmrow-dedupe-rating-format.md
+++ b/changelogs/2026-05-30-filmrow-dedupe-rating-format.md
@@ -1,0 +1,17 @@
+# FilmRow: compute tmdbRating.toFixed(1) once
+
+**PR**: #124
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/search/rows/FilmRow.svelte`, `film.tmdbRating.toFixed(1)` was computed twice: once in the `aria-label="TMDB rating {...}"` and once in the visible `★ {...}` text.
+- Introduced `const rating = $derived(film.tmdbRating != null ? film.tmdbRating.toFixed(1) : null)` and reused `rating` in both the `aria-label` and the visible label.
+- The render gate is now `rating != null && film.tmdbRating != null && film.tmdbRating >= 7` (the `film.tmdbRating != null` clause is retained so TypeScript narrows `film.tmdbRating` to a non-null number for the `>= 7` comparison; it is logically equivalent to `rating != null`).
+
+## Impact
+- Affects the search/command palette film result rows only. No visual, textual, or accessibility-string change.
+
+## Behavior preservation
+- `rating != null` is exactly equivalent to `film.tmdbRating != null`, so the combined render condition is logically identical to the original `film.tmdbRating != null && film.tmdbRating >= 7`.
+- When rendered, `rating` holds the same string as `film.tmdbRating.toFixed(1)`, so both the `aria-label` and visible `★ ...` text are byte-for-byte identical to before. The label and value now share a single source and can never drift.
+- Verified with `svelte-check --threshold error`: 0 errors.

--- a/frontend/src/lib/components/search/rows/FilmRow.svelte
+++ b/frontend/src/lib/components/search/rows/FilmRow.svelte
@@ -10,6 +10,8 @@
 	}
 
 	let { film, selected, id }: Props = $props();
+
+	const rating = $derived(film.tmdbRating != null ? film.tmdbRating.toFixed(1) : null);
 </script>
 
 <button
@@ -49,9 +51,9 @@
 			{#if film.directors.length}{film.directors[0]}{/if}
 		</span>
 	</div>
-	{#if film.tmdbRating != null && film.tmdbRating >= 7}
-		<span class="rating" aria-label="TMDB rating {film.tmdbRating.toFixed(1)}">
-			★ {film.tmdbRating.toFixed(1)}
+	{#if rating != null && film.tmdbRating != null && film.tmdbRating >= 7}
+		<span class="rating" aria-label="TMDB rating {rating}">
+			★ {rating}
 		</span>
 	{/if}
 </button>


### PR DESCRIPTION
## What
In `frontend/src/lib/components/search/rows/FilmRow.svelte`, `film.tmdbRating.toFixed(1)` was computed twice — once in the `aria-label="TMDB rating {...}"` and once in the visible `★ {...}` text. This change computes it once via `const rating = $derived(film.tmdbRating != null ? film.tmdbRating.toFixed(1) : null)` and reuses `rating` in both places.

## Why
The accessibility label and the visible value were derived from two independent `.toFixed(1)` calls, so they could in principle drift and were redundantly recomputed. Sharing a single derived source makes the two strings guaranteed identical and removes the duplicate format call.

## Behavior preservation (identical)
- `rating != null` is exactly equivalent to `film.tmdbRating != null`, so the render gate `rating != null && film.tmdbRating != null && film.tmdbRating >= 7` is logically identical to the original `film.tmdbRating != null && film.tmdbRating >= 7`. (The `film.tmdbRating != null` clause is retained so TypeScript narrows `film.tmdbRating` to a non-null number for the `>= 7` comparison.)
- When rendered, `rating` holds the same string `film.tmdbRating.toFixed(1)` produced before, so the `aria-label` and the visible `★ ...` text are byte-for-byte unchanged.
- `svelte-check --threshold error`: 0 errors.

## Files
- `frontend/src/lib/components/search/rows/FilmRow.svelte`
- `changelogs/2026-05-30-filmrow-dedupe-rating-format.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)