### PR TITLE
refactor(film): drop unused #each index in LetterboxdRatingReveal stars

### DIFF
--- a/changelogs/2026-05-30-letterboxd-drop-unused-each-index.md
+++ b/changelogs/2026-05-30-letterboxd-drop-unused-each-index.md
@@ -1,0 +1,19 @@
+# LetterboxdRatingReveal: drop unused loop index in star #each blocks
+
+**PR**: #125
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `, i` loop-index binding from both star `{#each}` blocks in `frontend/src/lib/components/film/LetterboxdRatingReveal.svelte`:
+  - `{#each Array(displayStars) as _, i}` → `{#each Array(displayStars) as _}`
+  - `{#each Array(Math.max(0, emptyStars)) as _, i}` → `{#each Array(Math.max(0, emptyStars)) as _}`
+- The index `i` was never referenced inside either block body (the SVG star markup uses neither the item `_` nor the index).
+
+## Impact
+- Affects the rendered Letterboxd rating reveal component only.
+- Stops the Svelte compiler from tracking a dead per-iteration index binding for the filled and empty star loops.
+
+## Behavior preservation
+- Byte-identical rendered output: both loops still render the same number of `<svg>` stars driven by `displayStars` and `Math.max(0, emptyStars)`.
+- No item or index value was ever consumed, so removing the index changes nothing observable at runtime.
+- `svelte-check --threshold error` passes with 0 errors.

--- a/frontend/src/lib/components/film/LetterboxdRatingReveal.svelte
+++ b/frontend/src/lib/components/film/LetterboxdRatingReveal.svelte
@@ -31,7 +31,7 @@
 {#if isRevealed}
 	<div class="rating-revealed">
 		<div class="stars">
-			{#each Array(displayStars) as _, i}
+			{#each Array(displayStars) as _}
 				<svg viewBox="0 0 24 24" class="star" fill={LETTERBOXD_ORANGE} stroke={LETTERBOXD_ORANGE} stroke-width="1.5">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/>
 				</svg>
@@ -47,7 +47,7 @@
 					<path fill="url(#half-{filmId})" stroke={LETTERBOXD_ORANGE} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/>
 				</svg>
 			{/if}
-			{#each Array(Math.max(0, emptyStars)) as _, i}
+			{#each Array(Math.max(0, emptyStars)) as _}
 				<svg viewBox="0 0 24 24" class="star" fill="transparent" stroke="#666" stroke-width="1.5">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/>
 				</svg>


### PR DESCRIPTION
## What
Remove the unused `, i` loop-index binding from both star `{#each}` blocks in `frontend/src/lib/components/film/LetterboxdRatingReveal.svelte`:

- `{#each Array(displayStars) as _, i}` → `{#each Array(displayStars) as _}`
- `{#each Array(Math.max(0, emptyStars)) as _, i}` → `{#each Array(Math.max(0, emptyStars)) as _}`

## Why
The index `i` is never referenced inside either block body — the SVG star markup uses neither the item `_` nor the index. Dropping it stops the Svelte compiler from tracking a dead per-iteration binding.

## Behavior preservation (identical)
Byte-identical rendered output: both loops still render the same count of `<svg>` stars driven by `displayStars` and `Math.max(0, emptyStars)`. No item or index value was ever consumed, so nothing observable changes at runtime. `svelte-check --threshold error` passes with 0 errors.

## Files
- `frontend/src/lib/components/film/LetterboxdRatingReveal.svelte`
- `changelogs/2026-05-30-letterboxd-drop-unused-each-index.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)