### PR TITLE
refactor(utils): drop redundant nested typeof guard in formatScreeningDate

### DIFF
--- a/changelogs/2026-05-30-utils-simplify-typeof-guard.md
+++ b/changelogs/2026-05-30-utils-simplify-typeof-guard.md
@@ -1,0 +1,17 @@
+# utils: drop redundant nested typeof guard in formatScreeningDate
+
+**PR**: #127
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/utils.ts`, simplified line 52 of `formatScreeningDate`.
+- The expression `new Date(date + (typeof date === 'string' && !date.includes('T') ? 'T00:00:00' : ''))` sits inside the `typeof date === 'string' ? ... : date` branch, where TypeScript has already narrowed `date` to `string`. The inner `typeof date === 'string' &&` is therefore provably always `true`.
+- Reduced to `new Date(date + (!date.includes('T') ? 'T00:00:00' : ''))`.
+
+## Impact
+- Affects only the internal control flow of `formatScreeningDate`, a widely-imported date formatting helper used in the SvelteKit frontend.
+- No runtime behavior change for any caller.
+
+## Behavior preservation
+- The removed `typeof date === 'string' &&` term always evaluated to `true` at this point because the surrounding ternary branch guarantees `date` is a string. Removing an always-true `&&` operand leaves the conditional's result unchanged, so the concatenation argument passed to `new Date(...)` is byte-identical for every input.
+- Verified with `svelte-check --threshold error`: 0 errors.

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -49,7 +49,7 @@ export function toLondonDateStr(date: Date | string): string {
 }
 
 export function formatScreeningDate(date: Date | string): string {
-	const d = typeof date === 'string' ? new Date(date + (typeof date === 'string' && !date.includes('T') ? 'T00:00:00' : '')) : date;
+	const d = typeof date === 'string' ? new Date(date + (!date.includes('T') ? 'T00:00:00' : '')) : date;
 	const todayStr = toLondonDateStr(new Date());
 	const targetStr = typeof date === 'string' && !date.includes('T') ? date : toLondonDateStr(d);
 


### PR DESCRIPTION
## What
Simplifies line 52 of `formatScreeningDate` in `frontend/src/lib/utils.ts` by removing a redundant nested `typeof date === 'string' &&` guard.

Before:
```ts
const d = typeof date === 'string' ? new Date(date + (typeof date === 'string' && !date.includes('T') ? 'T00:00:00' : '')) : date;
```
After:
```ts
const d = typeof date === 'string' ? new Date(date + (!date.includes('T') ? 'T00:00:00' : '')) : date;
```

## Why
The inner `typeof date === 'string' &&` term lives inside the `typeof date === 'string' ? ... : date` branch, where TypeScript has already narrowed `date` to `string`. That makes the inner check provably always `true` — it never affects evaluation. Dropping it clarifies control flow on this widely-imported helper.

## Behavior preservation (identical)
Removing an always-true operand from an `&&` expression cannot change the conditional's result, so the string passed to `new Date(...)` is byte-identical for every input. No caller behavior changes. Verified with `svelte-check --threshold error`: 0 errors.

## Files
- `frontend/src/lib/utils.ts`
- `changelogs/2026-05-30-utils-simplify-typeof-guard.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)