### PR TITLE
refactor(search): remove unused empty CHAIN_PHRASES_BY_LENGTH placeholder

### DIFF
--- a/changelogs/2026-05-30-chains-vocab-delete-empty-placeholder.md
+++ b/changelogs/2026-05-30-chains-vocab-delete-empty-placeholder.md
@@ -1,0 +1,15 @@
+# chains vocab: remove unused empty CHAIN_PHRASES_BY_LENGTH placeholder
+
+**PR**: #129
+**Date**: 2026-05-30
+
+## Changes
+- Deleted the `CHAIN_PHRASES_BY_LENGTH: Record<number, string[]> = { 2: [] }` export (and its `// Multi-word phrases for chains.` comment) from `frontend/src/lib/search/vocab/chains.ts`.
+
+## Impact
+- Affects the search vocabulary module only. The export was an always-empty placeholder, never imported anywhere in the codebase — a repo-wide grep matched only its own definition.
+- `parse-query.ts` imports `CHAIN_TOKENS`, `CINEMA_ALIAS_TOKENS`, and `CINEMA_ALIAS_PHRASES_BY_LENGTH` from this file but never `CHAIN_PHRASES_BY_LENGTH`, and runs no chain-phrase scan. Removing it eliminates dead code that implied a non-existent multi-word-chain feature.
+
+## Behavior preservation
+- Byte-identical runtime behavior. The deleted constant was never read by any module, so no code path changes.
+- `svelte-kit sync` + `svelte-check --tsconfig ./tsconfig.json --threshold error` reports 0 errors after the change (2 pre-existing warnings in unrelated components remain unchanged).

--- a/frontend/src/lib/search/vocab/chains.ts
+++ b/frontend/src/lib/search/vocab/chains.ts
@@ -20,11 +20,6 @@ export const CHAIN_TOKENS: Record<string, string> = {
   odeon: "Odeon",
 };
 
-// Multi-word phrases for chains.
-export const CHAIN_PHRASES_BY_LENGTH: Record<number, string[]> = {
-  2: [],
-};
-
 // Specific cinema aliases → slug (cinemas.id).
 // IMPORTANT: these slugs must match real cinemas.id values in the
 // database. Verify with `SELECT id FROM cinemas` after any change.


### PR DESCRIPTION
## What
Delete the `CHAIN_PHRASES_BY_LENGTH: Record<number, string[]> = { 2: [] }` export (and its leading `// Multi-word phrases for chains.` comment) from `frontend/src/lib/search/vocab/chains.ts`.

## Why
The export was an always-empty placeholder that was never imported anywhere. A repo-wide grep for `CHAIN_PHRASES_BY_LENGTH` matched only its own definition. `parse-query.ts` imports `CHAIN_TOKENS`, `CINEMA_ALIAS_TOKENS`, and `CINEMA_ALIAS_PHRASES_BY_LENGTH` from this file but never `CHAIN_PHRASES_BY_LENGTH`, and runs no chain-phrase scan. The dead export implied a multi-word-chain matching feature that does not exist.

## Behavior preservation (identical)
The constant was never read by any module, so no runtime code path is affected — byte-identical behavior. `npx svelte-kit sync && npx svelte-check --tsconfig ./tsconfig.json --threshold error` reports 0 errors after the change (the 2 pre-existing warnings in unrelated components remain unchanged).

## Files
- `frontend/src/lib/search/vocab/chains.ts`
- `changelogs/2026-05-30-chains-vocab-delete-empty-placeholder.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)