### PR TITLE
chore(frontend): consolidate 30 CI-green refactor/perf PRs (#606-#636)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-05-31: Consolidate 30 CI-green refactor/perf PRs (#606–#636) into one batch
+**PR**: TBD | **Files**: 60 files across `frontend/src/{routes,lib}/…` (per-PR detail in #606–#636)
+- Merged all **30** file-disjoint refactor/perf branches (`rf/*`, created 2026-05-30) into a single integration branch so they ship in one CI cycle instead of 30 sequential "branch up-to-date" rebases (O(n²) → O(n)).
+- All 30 merged cleanly against current `origin/main` — **zero conflicts, zero skips, zero reverts**. None of the refactors' intents were obsoleted by newer main.
+- Content: delete unused exports/imports + dead code, hoist `Intl` formatters / constants / weekday arrays out of hot paths, dedupe rating formatting, simplify a `typeof` guard, trim SSR payload fields (cinema-slug / reachable / search / home / festival-slug), and per-frame `getBoundingClientRect` fix in BreathingGrid.
+- Behavior-preserving. Verified: `npm run check` → 0 errors (2 pre-existing unrelated warnings), `npm run build` → success. Supersedes individual PRs #606–#636 (excl. already-merged #619).
+
+---
+
 ## 2026-05-30: Scraper coverage + freshness pass — end of June 2026
 **PR**: TBD | **Files**: `src/scrapers/pipeline.ts`, `src/scrapers/chains/everyman.ts`, `src/scrapers/cinemas/bfi.ts`, `src/scrapers/cinemas/olympic.ts`, `src/scrapers/cinemas/david-lean.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
 - **42P10 upsert keystone**: `(cinema_id, source_id)` upsert lacked `targetWhere source_id IS NOT NULL` for its partial index → Postgres silently dropped every fresh INSERT across all source_id scrapers (Everyman/Curzon/Picturehouse), freezing forward coverage. Re-applied the lost 2026-05-27 fix.

--- a/changelogs/2026-05-30-breathinggrid-rect-per-frame.md
+++ b/changelogs/2026-05-30-breathinggrid-rect-per-frame.md
@@ -1,0 +1,19 @@
+# BreathingGrid: read getBoundingClientRect once per frame instead of per cell
+
+**PR**: #103
+**Date**: 2026-05-30
+
+## Changes
+- `getCharScale` no longer calls `containerEl.getBoundingClientRect()` internally. It now accepts a pre-computed `rect: DOMRect | null` parameter and uses it for the hover-proximity math.
+- Added a small `getFrameRect(mx)` helper that returns the container rect once (under the same `mx > -500 && containerEl` guard as before) or `null` when the pointer is not over the header.
+- The template computes `{@const frameRect = getFrameRect(mouseX)}` once per render (before the `{#each chars}` loop) and passes it into every `getCharScale` call.
+
+## Impact
+- Affects only the always-mounted header logo animation (`BreathingGrid.svelte`).
+- During pointer hover over the header, forced layout reads drop from O(cells) (~14 `getBoundingClientRect()` reflows per frame at 60fps) to O(1) per frame.
+- No visual or API change; no other files touched.
+
+## Behavior preservation
+- The rect is read under the exact same condition as before (`mx > -500 && containerEl`); when the guard is false `getFrameRect` returns `null` and `getCharScale`'s hover branch is skipped, identical to the prior `mx > -500 && containerEl` check.
+- All cells render in a single synchronous pass, so the layout cannot change between cells within one frame — every cell previously observed the identical rect anyway. Computed `scale` values are byte-identical.
+- `svelte-check --threshold error`: 0 errors; no new warnings introduced for this file.

--- a/changelogs/2026-05-30-calendarpopover-hoist-weekdays.md
+++ b/changelogs/2026-05-30-calendarpopover-hoist-weekdays.md
@@ -1,0 +1,16 @@
+# CalendarPopover: hoist inline weekday-header array to a module const
+
+**PR**: #121
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/filters/CalendarPopover.svelte`, added a top-level `const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su'];` alongside the existing `MONTH_NAMES` const.
+- Updated the weekday-header loop from `{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}` to `{#each WEEKDAYS as d, i (d + i)}`.
+
+## Impact
+- The 7-element weekday array is now allocated once at module scope instead of on every render (e.g. each month-navigation click). Tiny allocation/GC reduction in a frequently-re-rendered popover.
+- Matches the file's own `MONTH_NAMES` convention for static label arrays.
+
+## Behavior preservation
+- Identical data, identical keys (`d + i`), identical iteration order and rendered output. The `class:is-weekend={i >= 5}` logic is unchanged because the array contents and order are byte-identical.
+- Verified with `svelte-kit sync` + `svelte-check --threshold error`: 0 errors, no new warnings in this file.

--- a/changelogs/2026-05-30-chains-vocab-delete-empty-placeholder.md
+++ b/changelogs/2026-05-30-chains-vocab-delete-empty-placeholder.md
@@ -1,0 +1,15 @@
+# chains vocab: remove unused empty CHAIN_PHRASES_BY_LENGTH placeholder
+
+**PR**: #129
+**Date**: 2026-05-30
+
+## Changes
+- Deleted the `CHAIN_PHRASES_BY_LENGTH: Record<number, string[]> = { 2: [] }` export (and its `// Multi-word phrases for chains.` comment) from `frontend/src/lib/search/vocab/chains.ts`.
+
+## Impact
+- Affects the search vocabulary module only. The export was an always-empty placeholder, never imported anywhere in the codebase — a repo-wide grep matched only its own definition.
+- `parse-query.ts` imports `CHAIN_TOKENS`, `CINEMA_ALIAS_TOKENS`, and `CINEMA_ALIAS_PHRASES_BY_LENGTH` from this file but never `CHAIN_PHRASES_BY_LENGTH`, and runs no chain-phrase scan. Removing it eliminates dead code that implied a non-existent multi-word-chain feature.
+
+## Behavior preservation
+- Byte-identical runtime behavior. The deleted constant was never read by any module, so no code path changes.
+- `svelte-kit sync` + `svelte-check --tsconfig ./tsconfig.json --threshold error` reports 0 errors after the change (2 pre-existing warnings in unrelated components remain unchanged).

--- a/changelogs/2026-05-30-cinema-slug-drop-redundant-sort.md
+++ b/changelogs/2026-05-30-cinema-slug-drop-redundant-sort.md
@@ -1,0 +1,15 @@
+# Cinema detail page: remove redundant re-sort of already-ascending date groups
+
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/cinemas/[slug]/+page.svelte`, the `groupedByDate` derived value previously did `Object.entries(groupBy(...)).sort(([a], [b]) => a.localeCompare(b))`.
+- `futureScreenings` is already sorted strictly ascending by epoch-ms (in the `futureScreenings` derivation just above). `toLondonDateStr` produces `YYYY-MM-DD` keys via a fixed-locale `Intl.DateTimeFormat` and is monotonic non-decreasing in ms. `groupBy` inserts keys in first-seen order, and JS preserves string-key insertion order for non-integer-like keys.
+- Therefore the date-string keys are already emitted in chronological order, and the `localeCompare` sort was a guaranteed no-op. Replaced with `return Object.entries(grouped);` and added an explanatory comment.
+
+## Impact
+- Cinema detail page (`/cinemas/[slug]`). Removes an O(k log k) comparator plus closure allocation per re-derivation of the grouped-by-date list (k = number of distinct future dates).
+
+## Behavior preservation
+- Output order is byte-identical: the keys were already in ascending chronological order before the removed sort ran, so the sort never reordered anything.
+- No change to grouping, filtering, or rendered markup. `svelte-check --threshold error` reports 0 errors.

--- a/changelogs/2026-05-30-cinema-slug-server-trim-payload.md
+++ b/changelogs/2026-05-30-cinema-slug-server-trim-payload.md
@@ -1,0 +1,21 @@
+# Cinema detail server load: trim unused screening fields from SSR payload
+
+**PR**: #106
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/cinemas/[slug]/+page.server.ts`, the `load` function's per-screening map no longer forwards fields the page never renders.
+- Dropped `screen` from each screening object.
+- Dropped `directors`, `runtime`, and `posterUrl` from each screening's nested `film` object.
+- The returned per-screening shape is now `{ id, datetime, format, bookingUrl, film: { id, title, year } }`.
+- The `CinemaResponse` interface is unchanged (it still describes the full upstream API response shape).
+
+## Impact
+- Cinema detail pages (`/cinemas/[slug]`) list dozens-to-hundreds of screenings. Each previously serialized a `directors` string array and a `posterUrl` string per screening into the SvelteKit `__data`/hydration payload, none of which the component reads.
+- Removing them shrinks the serialized SSR/hydration payload and ISR-cached output with zero change to rendered output.
+
+## Behavior preservation
+- The `[slug]/+page.svelte` component only reads `screening.datetime`, `screening.format`, `screening.bookingUrl`, `screening.film.id`, `screening.film.title`, and `screening.film.year`.
+- The `.screen-count` element in the component renders `cinema.screens` (cinema-level), not `screening.screen`. No reference to `screening.screen`, `film.directors`, `film.runtime`, or `film.posterUrl` exists in the component.
+- Therefore dropping these fields produces byte-identical rendered output; only the unused, serialized hydration data is removed.
+- Verified with `svelte-kit sync` + `svelte-check --threshold error`: 0 errors.

--- a/changelogs/2026-05-30-cinemamap-deadcode-and-loop-constants.md
+++ b/changelogs/2026-05-30-cinemamap-deadcode-and-loop-constants.md
@@ -1,0 +1,21 @@
+# CinemaMap: remove dead validCinemas + hoist marker/popup literal constants
+
+**PR**: #114
+**Date**: 2026-05-30
+
+## Changes
+- `frontend/src/lib/components/map/CinemaMap.svelte`:
+  - Removed the dead `const validCinemas = $derived(...)` block. It was never read — `onMount` recomputes the identical `coordinates` filter inline as `cinemasWithCoords`, and grep confirmed `validCinemas` has no other reference in the component.
+  - Added a `<script module lang="ts">` block (matching the established `ScreeningRow.svelte` pattern) hoisting the constant literal strings that `createMarkerElement` and `createPopupContent` previously rebuilt on every call:
+    - Marker SVG: `MARKER_WIDTH` (`'20'`), `MARKER_HEIGHT` (`'26'`), `MARKER_VIEWBOX` (`'0 0 20 26'`), `MARKER_PATH_D` (the pin path `d`), `MARKER_PIN_FILL` (`'#1a1a1a'`), `MARKER_CIRCLE_CX`/`CY` (`'10'`), `MARKER_CIRCLE_R` (`'4'`), `MARKER_CIRCLE_FILL` (`'#fff'`).
+    - Popup: `POPUP_DIV_PADDING` (`'4px'`), `POPUP_LINK_CSS`, `POPUP_AREA_CSS`.
+  - `createMarkerElement`/`createPopupContent` now reference the module-scope consts instead of inline literals.
+
+## Impact
+- Map page (`/map`) marker and popup rendering. These builders run once per cinema (dozens of venues), so the literal strings are now allocated once per module load instead of per call.
+- Removes a dead `$derived` that re-filtered the full cinema list on every `cinemas` prop change.
+
+## Behavior preservation
+- Identical DOM output. The hoisted constants are byte-for-byte the same strings/values that were previously inlined; SVG attributes, path `d`, fills, and popup cssText are unchanged.
+- The deleted `validCinemas` had zero readers; the in-`onMount` `cinemasWithCoords` filter (used to place markers) is untouched.
+- svelte-check: 0 errors (the 2 pre-existing warnings are in unrelated files).

--- a/changelogs/2026-05-30-cinemas-index-deadimport-and-search-hoist.md
+++ b/changelogs/2026-05-30-cinemas-index-deadimport-and-search-hoist.md
@@ -1,0 +1,18 @@
+# Cinemas index: drop dead groupBy import + hoist search.toLowerCase out of filter
+
+**PR**: #104
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `import { groupBy } from '$lib/utils'` in `frontend/src/routes/cinemas/+page.svelte`. The `grouped` `$derived` reimplements grouping inline and never calls `groupBy`; the symbol appeared only on the import line.
+- Hoisted `search.toLowerCase()` out of the `filtered` `.filter` callback. Previously it was recomputed twice per cinema on every keystroke (~118 redundant lowercasings across ~59 cinemas). Now `const q = search.toLowerCase()` is computed once before filtering and reused in both `c.name.toLowerCase().includes(q)` and `(c.address?.area.toLowerCase().includes(q) ?? false)`.
+- Converted the `filtered` `$derived` from a ternary expression to `$derived.by` to hold the hoisted local; the empty-search early return preserves the original else branch (`data.cinemas`).
+
+## Impact
+- Affects the Cinemas index page (`/cinemas`) only.
+- Pure performance/cleanup: fewer redundant string allocations per keystroke and one less dead import. No user-visible change.
+
+## Behavior preservation
+- Filtering results are byte-identical: same predicates, same operands, same falsy-search short-circuit returning `data.cinemas`.
+- `groupBy` was never referenced beyond the import, so removing it cannot alter runtime behavior.
+- `svelte-check --threshold error` passes with 0 errors for the modified file.

--- a/changelogs/2026-05-30-daymasthead-ordinals-and-formatters.md
+++ b/changelogs/2026-05-30-daymasthead-ordinals-and-formatters.md
@@ -1,0 +1,22 @@
+# DayMasthead: reuse formatOrdinalDay helper + hoist three Intl formatters
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- Replaced the local 31-entry `ORDINALS` record (and the inline `ORDINALS[dayNum] ?? `${dayNum}th`` fallback) with the shared `formatOrdinalDay(dayNum)` helper exported from `$lib/utils` (backed by `ORDINAL_DAYS`, same `?? `${n}th`` fallback). The local record is deleted; the page now imports `formatOrdinalDay`.
+- Hoisted the three `Intl.DateTimeFormat` instances that were constructed on every recompute to module-scope consts, matching the cached-formatter pattern in `utils.ts`:
+  - `WEEKDAY_LONG` — `{ weekday: 'long', timeZone: 'Europe/London' }` (was inline in the `weekday` derived)
+  - `DAY_NUM` — `{ day: 'numeric', timeZone: 'Europe/London' }` (was inline in the `dayNum` derived)
+  - `WEEKDAY_SHORT` — `{ weekday: 'short', timeZone: 'Europe/London' }` (was constructed inside the `stripItems` `$derived.by` loop, allocating 4 per recompute)
+- The derived values now call `.format(...)` on the reused instances.
+
+## Impact
+- `frontend/src/lib/components/calendar/DayMasthead.svelte` only.
+- Removes per-recompute formatter allocations on the always-mounted homepage day masthead: 2 per recompute for the title plus 4 per recompute for the day strip, now amortized to one allocation each at module load.
+- De-duplicates the ordinal table against the canonical `ORDINAL_DAYS` in `utils.ts`, removing a drift hazard.
+
+## Behavior preservation
+- `formatOrdinalDay` uses the identical `ORDINAL_DAYS[dayNum] ?? `${dayNum}th`` mapping for the 1–31 day numbers a real calendar date produces, so the rendered ordinal is byte-identical.
+- The hoisted formatters use the same locale (`'en-GB'`) and the same options as the previous inline constructions; `Intl.DateTimeFormat` is stateless, so reusing one instance yields identical strings across all calls and DST.
+- No template markup, keys, or option values changed. `svelte-check --threshold error` reports 0 errors.

--- a/changelogs/2026-05-30-deadlinepicker-cached-formatters.md
+++ b/changelogs/2026-05-30-deadlinepicker-cached-formatters.md
@@ -1,0 +1,22 @@
+# DeadlinePicker: reuse cached Intl.DateTimeFormat instances in formatSelectedTime
+
+**PR**: #116
+**Date**: 2026-05-30
+
+## Changes
+- Added a `<script module lang="ts">` block to `frontend/src/lib/components/reachable/DeadlinePicker.svelte` that hoists three module-scope `Intl.DateTimeFormat` constants:
+  - `LONDON_DATE_FORMATTER` — `en-CA`, `timeZone: 'Europe/London'` (YYYY-MM-DD)
+  - `TIME_FORMATTER` — `en-GB`, `hour: '2-digit'`, `minute: '2-digit'`, `hour12: false` (HH:mm)
+  - `DAY_MONTH_FORMATTER` — `en-GB`, `weekday: 'short'`, `day: 'numeric'`, `month: 'short'` ('Mon, 1 Jan')
+- Rewrote `formatSelectedTime` to call `.format(d)` on the reused instances instead of constructing a fresh formatter from inline options on every `toLocaleDateString`/`toLocaleTimeString` call.
+- Previously the function made up to five formatter constructions per invocation (three `en-CA` London-tz dates, one `en-GB` time, one `en-GB` weekday/day/month).
+
+## Impact
+- Frontend only (`reachable/DeadlinePicker.svelte`). The "FINISHED BY" deadline selector renders its selected-time label without rebuilding formatters each call.
+- Matches the established hoist pattern already used in `frontend/src/lib/components/search/rows/ScreeningRow.svelte`.
+
+## Behavior preservation
+- The hoisted formatter options are identical to the inline options they replace, so the produced strings (`YYYY-MM-DD` comparison keys, `HH:mm` time, `'Mon, 1 Jan'` long form) are byte-identical.
+- The time and weekday/day/month formatters intentionally omit `timeZone`, exactly as the original `toLocaleTimeString`/`toLocaleDateString` calls did (runtime-local). Only the `en-CA` date-comparison formatter uses `Europe/London`, again matching the original.
+- Verified equivalence with a Node script comparing inline vs hoisted output across multiple dates including the BST transition day — all match.
+- `svelte-check --threshold error` passes with 0 errors.

--- a/changelogs/2026-05-30-directors-hoist-search-lowercase.md
+++ b/changelogs/2026-05-30-directors-hoist-search-lowercase.md
@@ -1,0 +1,15 @@
+# Directors page: hoist query lowercasing out of the filter loop
+
+**PR**: #123
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/directors/+page.svelte`, the `filtered` derived value previously called `search.toLowerCase()` once per director on every keystroke inside the `.filter()` predicate.
+- Switched the derived to the `$derived.by(() => {...})` form so the lowercased query can be computed once (`const q = search.toLowerCase();`) and reused across all directors in the filter.
+- The empty-search short-circuit (returning `data.directors` unfiltered) is preserved.
+
+## Impact
+- Frontend only. The directors API returns every director across the next 14 days with no LIMIT (realistically several hundred entries), so this removes hundreds of redundant `toLowerCase()` calls per keystroke during search.
+
+## Behavior preservation
+- Identical output. The filter predicate, the case-insensitive matching, and the empty-search branch are unchanged. `q` is exactly `search.toLowerCase()`, the same value previously recomputed inline per director. No change to rendering, ordering, or filtering results.

--- a/changelogs/2026-05-30-festival-slug-deadimport-and-sort-hoist.md
+++ b/changelogs/2026-05-30-festival-slug-deadimport-and-sort-hoist.md
@@ -1,0 +1,17 @@
+# Festival detail: drop dead type import + decorate-sort the per-group screenings
+
+**PR**: #110
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `import type { ScreeningWithDetails } from '$lib/types'` from `frontend/src/routes/festivals/[slug]/+page.svelte` (single occurrence; type-only, erased at compile time).
+- Reworked the `filmGroups` `$derived.by` sort to decorate each screening once with `_ms = new Date(s.datetime).getTime()` and compare `a._ms - b._ms`, instead of allocating two `Date` objects per comparator call. Mirrors the established decorate-sort pattern in `this-weekend/+page.svelte`.
+
+## Impact
+- Festival detail page (`/festivals/[slug]`) only. Reduces `Date` allocations and `Date.parse` work during the per-film-group sort from O(n log n) parses to O(n) parses, where n is the screening count for the festival.
+- No user-visible change; identical sort order and rendered output.
+
+## Behavior preservation
+- The removed import was never referenced (grep-confirmed single occurrence) and is type-only — erased at compile time, so runtime output is byte-identical.
+- `new Date(x.datetime).getTime() - new Date(y.datetime).getTime()` and `x._ms - y._ms` produce identical comparator results because `_ms` is exactly `new Date(s.datetime).getTime()` computed once per screening. Sort stability and order are unchanged.
+- `svelte-check --threshold error` reports 0 errors; the only warnings are pre-existing and in unrelated files.

--- a/changelogs/2026-05-30-festivalrow-hoist-formatter.md
+++ b/changelogs/2026-05-30-festivalrow-hoist-formatter.md
@@ -1,0 +1,17 @@
+# FestivalRow: hoist date-range Intl.DateTimeFormat to script module scope
+
+**PR**: #117
+**Date**: 2026-05-30
+
+## Changes
+- Moved the constant `Intl.DateTimeFormat('en-GB', { month: 'short', day: 'numeric', timeZone: 'Europe/London' })` out of the `dateRange` `$derived.by` body and into a new `<script module>` block as a shared `const RANGE_FORMATTER`.
+- `dateRange` now references the hoisted `RANGE_FORMATTER` instead of constructing a new formatter on every recompute.
+- Mirrors the existing pattern in the sibling `ScreeningRow.svelte` (`<script module>` with `TIME_FORMATTER`/`WEEKDAY_FORMATTER`/`LONDON_DATE_FORMATTER`).
+
+## Impact
+- Affects the search results UI (`frontend/src/lib/components/search/rows/FestivalRow.svelte`).
+- The formatter is now built once per module load and shared across all `FestivalRow` instances, rather than reconstructed per derived recompute per row.
+
+## Behavior preservation
+- The formatter arguments are fully constant, so the formatted date-range output is byte-identical to the per-call builder.
+- No change to component props, markup, styles, or rendered text. Purely a hoist of a constant object construction to module scope.

--- a/changelogs/2026-05-30-film-detail-deadimport-and-sort.md
+++ b/changelogs/2026-05-30-film-detail-deadimport-and-sort.md
@@ -1,0 +1,16 @@
+# Film detail page: drop dead formatScreeningDate import + remove redundant re-sort
+
+**PR**: #105
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused named import `formatScreeningDate` from the `$lib/utils` import block in `frontend/src/routes/film/[id]/+page.svelte`. The token appeared only on the import line — the page builds its own day/relative-date labels (`nextScreeningLabel`, `formatScreeningDate` was never referenced). The other imports (`formatTime`, `toLondonDateStr`, `groupBy`, `getPosterImageAttributes`, `filmByline`, `formatScreeningFormat`) are kept.
+- Removed the redundant `.sort(([a], [b]) => a.localeCompare(b))` from the `groupedByDate` derived. Replaced `Object.entries(grouped).sort(...)` with `Object.entries(grouped)` plus an explanatory comment.
+
+## Impact
+- Affects the film detail page (`/film/[id]`) only.
+- Marginally smaller bundle (one fewer named binding pulled into the route) and skips a comparator-driven sort over the day-group keys on each recompute of `groupedByDate`.
+
+## Behavior preservation
+- `formatScreeningDate` was dead code — removing an unreferenced import cannot change runtime behavior.
+- `futureScreenings` is already sorted ascending by epoch-ms (decorate-sort-undecorate on `new Date(s.datetime).getTime()`), and invalid dates are excluded because `NaN > now` is `false`. `toLondonDateStr` returns a `YYYY-MM-DD` string that is monotonic in epoch-ms, so `groupBy` inserts day keys in chronological order. JavaScript preserves string-key insertion order, and `localeCompare` over `YYYY-MM-DD` keys produces the identical chronological ordering. The dropped `.sort()` was therefore a provable no-op — `Object.entries(grouped)` yields byte-identical output.

--- a/changelogs/2026-05-30-filmrow-dedupe-rating-format.md
+++ b/changelogs/2026-05-30-filmrow-dedupe-rating-format.md
@@ -1,0 +1,17 @@
+# FilmRow: compute tmdbRating.toFixed(1) once
+
+**PR**: #124
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/search/rows/FilmRow.svelte`, `film.tmdbRating.toFixed(1)` was computed twice: once in the `aria-label="TMDB rating {...}"` and once in the visible `★ {...}` text.
+- Introduced `const rating = $derived(film.tmdbRating != null ? film.tmdbRating.toFixed(1) : null)` and reused `rating` in both the `aria-label` and the visible label.
+- The render gate is now `rating != null && film.tmdbRating != null && film.tmdbRating >= 7` (the `film.tmdbRating != null` clause is retained so TypeScript narrows `film.tmdbRating` to a non-null number for the `>= 7` comparison; it is logically equivalent to `rating != null`).
+
+## Impact
+- Affects the search/command palette film result rows only. No visual, textual, or accessibility-string change.
+
+## Behavior preservation
+- `rating != null` is exactly equivalent to `film.tmdbRating != null`, so the combined render condition is logically identical to the original `film.tmdbRating != null && film.tmdbRating >= 7`.
+- When rendered, `rating` holds the same string as `film.tmdbRating.toFixed(1)`, so both the `aria-label` and visible `★ ...` text are byte-for-byte identical to before. The label and value now share a single source and can never drift.
+- Verified with `svelte-check --threshold error`: 0 errors.

--- a/changelogs/2026-05-30-filters-store-hoist-london-ymd.md
+++ b/changelogs/2026-05-30-filters-store-hoist-london-ymd.md
@@ -1,0 +1,17 @@
+# filters store: hoist duplicated en-CA London Intl formatter out of applyIntent
+
+**PR**: #120
+**Date**: 2026-05-30
+
+## Changes
+- Hoisted a single module-level `const LONDON_YMD = new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/London', year: 'numeric', month: '2-digit', day: '2-digit' })` near the top of `frontend/src/lib/stores/filters.svelte.ts`.
+- Replaced the two byte-identical inline `new Intl.DateTimeFormat(...)` instances inside `applyIntent` (one for `dateFrom`, one for `dateTo`) with calls to the shared `LONDON_YMD.format(...)`.
+
+## Impact
+- `applyIntent` runs on the cmd+k palette intent-apply path. The previous code allocated two fresh `Intl.DateTimeFormat` instances per call; this removes both allocations by reusing one stateless module-scope formatter.
+- Mirrors the established hoist pattern (`DATE_LONDON_ISO` in `utils.ts`).
+
+## Behavior preservation
+- The hoisted formatter uses the exact same locale (`en-CA`) and options (`timeZone: 'Europe/London'`, `year: 'numeric'`, `month: '2-digit'`, `day: '2-digit'`) as the two original inline formatters.
+- `Intl.DateTimeFormat` is stateless, so reusing one instance yields identical `YYYY-MM-DD` strings, including across DST boundaries.
+- Output is byte-identical; no rendered or stored value changes.

--- a/changelogs/2026-05-30-header-hoist-nav-filters.md
+++ b/changelogs/2026-05-30-header-hoist-nav-filters.md
@@ -1,0 +1,28 @@
+# Header: precompute NAV_ITEMS desktop/mobile filters once
+
+**PR**: #118
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/layout/Header.svelte`, hoisted the two inline
+  `NAV_ITEMS.filter(...)` passes out of the markup into script-scope constants
+  computed once: `const DESKTOP_NAV = NAV_ITEMS.filter((n) => n.desktop);` and
+  `const MOBILE_NAV = NAV_ITEMS.filter((n) => n.mobile);`.
+- Updated the desktop `{#each ...}` (was `NAV_ITEMS.filter((n) => n.desktop)`)
+  to iterate `DESKTOP_NAV`, and the mobile `{#each ...}` (was
+  `NAV_ITEMS.filter((n) => n.mobile)`) to iterate `MOBILE_NAV`. Each keys
+  (`(item.href)`) are unchanged.
+
+## Impact
+- The sticky header re-renders on every `page.url.pathname` change and every
+  `mobileMenuOpen` toggle. Previously both `.filter()` passes re-ran on each of
+  those renders even though `NAV_ITEMS` is a static const that is never mutated.
+  Now the two filtered arrays are computed once at module/component init.
+
+## Behavior preservation
+- `NAV_ITEMS` is a static, never-mutated const, so the filtered results are
+  invariant across renders — moving the filter to init-time produces the exact
+  same arrays in the same order.
+- The `{#each}` blocks render identical items with identical `(item.href)` keys,
+  classes, attributes, and text. Output is byte-identical.
+- `svelte-kit sync` + `svelte-check --threshold error` pass with 0 errors.

--- a/changelogs/2026-05-30-home-dayheader-formatters-and-types.md
+++ b/changelogs/2026-05-30-home-dayheader-formatters-and-types.md
@@ -1,0 +1,35 @@
+# Homepage day-header: hoist tomorrowIso + type coordinates
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- `frontend/src/routes/+page.svelte`:
+  - Hoisted the per-render `tomorrowIso` IIFE out of the `{#snippet dayHeader}`
+    into a single component-scope `const tomorrowIso = $derived.by(...)` keyed
+    off `todayStore.value`. The IIFE previously re-ran for every visible day
+    header (up to `MAX_DAYS_VISIBLE = 7`) on every filter-change re-render,
+    even though its only input is the `today` store value. It now recomputes
+    once per `today` change.
+  - Added `coordinates: { lat: number; lng: number } | null` to the `cinemas`
+    `$derived` cast type. `DesktopFilterSidebar` and `MobileFilterSheet` read
+    `c.coordinates` / `c.coordinates!` for the haversine radius filter; the cast
+    previously omitted the field, so the prop contract was unchecked at the
+    boundary. The shape matches what `+layout.server.ts` already emits.
+  - (The two inline `Intl.DateTimeFormat` formatters were already hoisted to
+    module-scope consts in a prior change; no change needed there.)
+
+## Impact
+- Affects the homepage (`/`) render path only. Slightly less work per
+  filter-change re-render (one `tomorrowIso` computation instead of up to 7),
+  and a stronger compile-time type contract for the cinema list passed to the
+  filter sidebars.
+
+## Behavior preservation
+- Output is byte-identical. `tomorrowIso` uses the exact same UTC-noon anchor
+  (`todayStore.value + 'T12:00:00Z'`), `setUTCDate(+1)`, and
+  `toISOString().split('T')[0]` slice as the removed IIFE, so the `relative`
+  ('Today' / 'Tomorrow' / null) result is unchanged.
+- The `coordinates` type addition is a pure TypeScript cast (type-only, erased
+  at runtime). It introduces no runtime code and matches the actual data shape
+  already provided by the layout load, so runtime behavior is unaffected.

--- a/changelogs/2026-05-30-home-server-drop-meta.md
+++ b/changelogs/2026-05-30-home-server-drop-meta.md
@@ -1,0 +1,18 @@
+# Homepage server load: drop unused meta payload
+
+**PR**: #109
+**Date**: 2026-05-30
+
+## Changes
+- Removed the `meta: { total, startDate, endDate }` key from the object returned by the homepage `load` in `frontend/src/routes/+page.server.ts`.
+- A repo-wide grep confirmed the only references to `.meta.total/startDate/endDate` were the lines building this object; the homepage `+page.svelte` and client components never read `data.meta`.
+- Left the `meta` field on the local `ScreeningsResponse` interface intact, since the upstream `/api/screenings` response genuinely returns it and the interface documents the real fetch shape (it is simply no longer forwarded to the page).
+
+## Impact
+- Trims dead data from the SSR/ISR payload on the homepage LCP path, with zero consumers affected.
+- The separate `meta: data.meta` return in `frontend/src/routes/film/[id]/+page.server.ts` is a different file and out of scope; it is unchanged.
+
+## Behavior preservation
+- No consumer read `data.meta` on the homepage, so removing it cannot change any rendered output or runtime behavior.
+- The shape passed to the page is otherwise byte-identical (same `screenings` array, same mapping).
+- `svelte-check --threshold error` reports 0 errors; the two remaining warnings are pre-existing and in unrelated files.

--- a/changelogs/2026-05-30-layout-extract-shell-snippet.md
+++ b/changelogs/2026-05-30-layout-extract-shell-snippet.md
@@ -1,0 +1,20 @@
+# Root layout: extract duplicated app-shell into a {#snippet}
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/+layout.svelte`, the `{#if clerkEnabled}` and `{:else}` branches duplicated the app-shell markup verbatim: the `<a class="skip-link">` and the `<div class="min-h-dvh flex flex-col">` containing `<Header cinemas={data?.cinemas ?? []} />`, `<main id="main-content">{@render children()}</main>` and `<Footer />`.
+- Defined a `{#snippet shell()}...{/snippet}` covering exactly that shared skip-link + shell `<div>` block, and replaced both inline copies with `{@render shell()}`.
+- Left the per-branch provider logic untouched: the Clerk branch still renders `ClerkProvider` wrapping `PostHogProvider`, `SyncProvider`, `GlobalCmdkBinding`, and the conditional lazy `{#if CommandPalette}<CommandPalette />{/if}`; the else branch still renders `PostHogProvider` and `GlobalCmdkBinding` only.
+
+## Impact
+- Removes a real drift hazard: the two copies of the shell can no longer diverge.
+- No new imports, no dependency changes, no logic changes.
+
+## Behavior preservation
+- The snippet captures byte-identical markup to the two previous inline copies; render order within each branch is preserved (providers first, then skip-link + shell).
+- `data`, `children`, and `Header`/`main`/`Footer` references inside the snippet resolve to the same component-scope bindings.
+- Clerk-only `SyncProvider` and the lazy/conditional `CommandPalette` placement are unchanged.
+- Rendered DOM is identical in both the Clerk-enabled and Clerk-disabled paths.
+- Verified with `svelte-kit sync` + `svelte-check --threshold error`: 0 errors (the only 2 warnings are pre-existing and in unrelated files).

--- a/changelogs/2026-05-30-letterboxd-drop-unused-each-index.md
+++ b/changelogs/2026-05-30-letterboxd-drop-unused-each-index.md
@@ -1,0 +1,19 @@
+# LetterboxdRatingReveal: drop unused loop index in star #each blocks
+
+**PR**: #125
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `, i` loop-index binding from both star `{#each}` blocks in `frontend/src/lib/components/film/LetterboxdRatingReveal.svelte`:
+  - `{#each Array(displayStars) as _, i}` → `{#each Array(displayStars) as _}`
+  - `{#each Array(Math.max(0, emptyStars)) as _, i}` → `{#each Array(Math.max(0, emptyStars)) as _}`
+- The index `i` was never referenced inside either block body (the SVG star markup uses neither the item `_` nor the index).
+
+## Impact
+- Affects the rendered Letterboxd rating reveal component only.
+- Stops the Svelte compiler from tracking a dead per-iteration index binding for the filled and empty star loops.
+
+## Behavior preservation
+- Byte-identical rendered output: both loops still render the same number of `<svg>` stars driven by `displayStars` and `Math.max(0, emptyStars)`.
+- No item or index value was ever consumed, so removing the index changes nothing observable at runtime.
+- `svelte-check --threshold error` passes with 0 errors.

--- a/changelogs/2026-05-30-map-deadimport-and-any-cast.md
+++ b/changelogs/2026-05-30-map-deadimport-and-any-cast.md
@@ -1,0 +1,15 @@
+# Map page: drop dead page import + remove any cast on venue-count filter
+
+**PR**: #113
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `import { page } from '$app/state'` from `frontend/src/routes/map/+page.svelte`. The only "page" matches in the file are the `.map-page` CSS class and the `aria-labelledby="map-heading"` attribute — neither uses the imported `page` store. Dropping it removes `$app/state` from this page's module graph.
+- Removed the `: any` cast on the venue-count filter callback: `cinemas.filter((c: any) => c.coordinates)` → `cinemas.filter((c) => c.coordinates)`. `cinemas` is `$derived(data?.cinemas ?? [])`, whose elements carry a `coordinates: { lat; lng } | null` field (from the root layout load), so `c` now infers correctly and the `c.coordinates` access stays type-checked.
+
+## Impact
+- Frontend `/map` route only. No user-facing or runtime behaviour change.
+- Slightly leaner module graph (no `$app/state` pulled in) and stronger type checking on the venue count.
+
+## Behavior preservation
+- Identical runtime output. The removed import was never referenced, so eliminating it changes no executed code. Removing the `any` cast is a compile-time-only change — the emitted JavaScript for the filter is byte-identical (TypeScript/Svelte type annotations are erased at build). `npx svelte-check --threshold error` reports 0 errors.

--- a/changelogs/2026-05-30-mobiledatepicker-hoist-weekdays.md
+++ b/changelogs/2026-05-30-mobiledatepicker-hoist-weekdays.md
@@ -1,0 +1,17 @@
+# MobileDatePicker: hoist inline weekday-header array to a module const
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- Added a top-level `const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su']` next to the existing `MONTH_NAMES` const in `frontend/src/lib/components/filters/MobileDatePicker.svelte`.
+- Changed the weekday-header `{#each}` block to iterate `WEEKDAYS` instead of an inline array literal.
+
+## Impact
+- Avoids re-allocating a 7-element array literal on every render (e.g. month navigation) in the mobile date picker.
+- Purely internal; affects only the mobile filter date-picker component.
+
+## Behavior preservation
+- Identical rendered output: same seven labels, same order, same `(d + i)` keys, same `class:weekend={i >= 5}` indices.
+- Constant data hoisted out of the render path; no logic, markup, or styling changed.
+- Consistent with the file's existing `MONTH_NAMES` module const pattern.

--- a/changelogs/2026-05-30-mobilefiltersheet-hoist-day-numbers.md
+++ b/changelogs/2026-05-30-mobilefiltersheet-hoist-day-numbers.md
@@ -1,0 +1,17 @@
+# MobileFilterSheet: hoist inline Date getUTCDate() for Today/Tomorrow chips
+
+**PR**: #119
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/filters/MobileFilterSheet.svelte`, the Today/Tomorrow chips previously rendered `{new Date(today + 'T12:00:00Z').getUTCDate()}` and `{new Date(tomorrow + 'T12:00:00Z').getUTCDate()}` inline in the template, allocating two `Date` objects on every re-render of the open sheet.
+- Hoisted these into two instance consts next to the existing precomputed labels:
+  - `const todayDay = new Date(today + 'T12:00:00Z').getUTCDate();`
+  - `const tomorrowDay = new Date(tomorrow + 'T12:00:00Z').getUTCDate();`
+- Template now references `{todayDay}` / `{tomorrowDay}`.
+
+## Impact
+- Micro-optimisation for the mobile filter sheet: the two day-number values are computed once per component instance instead of on every render, matching how `today`/`tomorrow`/`todayLabel`/`tomorrowLabel` are already handled in the same `<script>` block.
+
+## Behavior preservation
+- Byte-identical output. `today` and `tomorrow` are fixed instance consts for the component lifetime, so `getUTCDate()` always returns the same numbers. The displayed day numbers in the Today/Tomorrow chips are unchanged; only the computation is moved out of the render path.

--- a/changelogs/2026-05-30-parse-query-hotpath-hoists.md
+++ b/changelogs/2026-05-30-parse-query-hotpath-hoists.md
@@ -1,0 +1,38 @@
+# parse-query: memoize phrase Sets/maxLen + hoist constant arrays off keystroke hot path
+
+**PR**: #101
+**Date**: 2026-05-30
+
+## Changes
+`frontend/src/lib/search/parse-query.ts` — `parseQuery` runs via a `$derived` on
+every cmd+k keystroke (`palette.svelte.ts`) and calls `scanPhrases` ~9x per
+keystroke over constant module-level phrase tables. Four allocations were moved
+off the per-keystroke hot path:
+
+- **Memoized `scanPhrases` per-table work** — added a module-level
+  `COMPILED_PHRASES` `WeakMap<Record<number, string[]>, CompiledPhrases>` and a
+  `compilePhrases()` helper. The per-length `new Set(phrases)` (previously rebuilt
+  inside the length loop on every call) and the `maxLen` derivation (previously
+  `Math.max(0, ...Object.keys(...).map(Number))` per call) are now computed once
+  per phrase-table object and cached. The inner scan reads from the cached `Set`.
+- **Hoisted `NEXT_DAY_PHRASES_BY_LENGTH`** — the `{ 2: Object.keys(DAY_NAMES).map((d) => `next ${d}`) }`
+  table (14-element array) was built inline on every `parseQuery` call; it is now a
+  module-level `const` computed once at load.
+- **Lifted `WEEKDAY_LABELS`** — `applyNextDay` and `applyDayThisWeek` each
+  allocated an identical `["SUN","MON","TUE","WED","THU","FRI","SAT"]` literal per
+  call. Both now index a single module-level `const WEEKDAY_LABELS`.
+
+## Impact
+- cmd+k command palette only. Fewer allocations per keystroke on the parse hot
+  path; no API, data, or output change.
+
+## Behavior preservation
+- Pure constant-data refactor — the phrase tables and weekday labels are fixed,
+  so memoizing/hoisting them yields byte-identical parse output.
+- `maxLen` semantics preserved: an empty table yields `maxLen = 0` (matching the
+  old `Math.max(0, ...)`), so the `len >= 2` loop is skipped exactly as before.
+  Missing or empty per-length entries are still skipped (`!phraseSet` /
+  `phraseSet.size === 0`, mirroring the old `!phrases || phrases.length === 0`).
+- The two remaining inline `{ 2: [...] }` literals are intentionally unchanged.
+- Verified: `svelte-check` 0 errors; existing `parse-query.test.ts` suite (49
+  tests) passes unchanged.

--- a/changelogs/2026-05-30-reachable-results-group-urgency-const.md
+++ b/changelogs/2026-05-30-reachable-results-group-urgency-const.md
@@ -1,0 +1,17 @@
+# ReachableResults: compute urgencyClass once per group via {@const}
+
+**PR**: #115
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/components/reachable/ReachableResults.svelte`, added a group-scoped `{@const urgencyCss = urgencyClass(urgency)}` immediately after the existing `{@const groupScreenings = groups[urgency]}` inside the `{#each urgencyOrder}` block.
+- Replaced the two call sites that previously invoked `urgencyClass(urgency)` directly — the group header `<h2 class="group-label ...">` and the per-card `<div class="leave-badge ...">` — with references to `urgencyCss`.
+
+## Impact
+- Affects only the Reachable results view (`ReachableResults.svelte`).
+- `urgencyClass` is a pure switch over the group's `urgency`, which is constant for the whole group. Previously it was re-evaluated once per screening card inside the `{#each groupScreenings}` loop. Now it is computed once per urgency group and reused, eliminating redundant switch evaluations on large result sets.
+
+## Behavior preservation
+- `urgencyClass(urgency)` is a pure function with no side effects, returning a fixed string per `urgency` value.
+- `urgency` does not change within a group, so the single group-scoped computation yields the exact same string the per-card calls would have produced.
+- The emitted `class` attribute strings on both the group header and each leave badge are byte-identical to before. No runtime behavior or output changes.

--- a/changelogs/2026-05-30-reachable-server-trim-payload.md
+++ b/changelogs/2026-05-30-reachable-server-trim-payload.md
@@ -1,0 +1,19 @@
+# Reachable server load: drop unused director + isRepertory from screening payload
+
+**PR**: #107
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/reachable/+page.server.ts`, removed two dead fields from the per-screening `film` object returned by the `load` function:
+  - `director: s.film.directors?.[0] ?? null`
+  - `isRepertory: s.film.isRepertory`
+- The returned `film` mapping now exposes only `{ id, title, year, runtime, posterUrl }`.
+
+## Impact
+- Affects the SSR/ISR payload serialized for the `/reachable` route. With `limit=200`, this trims two dead fields per screening (up to ~200 screenings) from the serialized page data, slightly reducing the SvelteKit data blob size.
+- No UI or user-facing change: `reachable/+page.svelte` re-maps `data.screenings` reading only `film.{id, title, year, runtime, posterUrl}`. A repo-wide grep confirms zero consumers of `director` or `isRepertory` for this route.
+
+## Behavior preservation
+- The two removed fields were never read by any consumer of the route's data, so the rendered output is byte-identical.
+- The incoming API response interface (`ScreeningsResponse`) is unchanged; only the projected payload drops fields that were already unused downstream.
+- `svelte-check --threshold error` passes with 0 errors (2 pre-existing warnings in unrelated files).

--- a/changelogs/2026-05-30-result-types-delete-totalresults.md
+++ b/changelogs/2026-05-30-result-types-delete-totalresults.md
@@ -1,0 +1,13 @@
+# result-types: delete unused totalResults export
+
+**PR**: #128
+**Date**: 2026-05-30
+
+## Changes
+- Removed the unused `totalResults(results: PaletteResults): number` export from `frontend/src/lib/search/result-types.ts` (previously lines 172-174).
+
+## Impact
+- Dead-code cleanup only. The function had zero importers across `frontend/src` and `src`. The only other `totalResults` occurrences are an unrelated local `const totalResults` inside `SearchInput.svelte` (derived from `films.length + cinemas.length` — a different symbol). The palette store computes counts via `flattenResults(...).length` / `flatRows.length` directly, so nothing depended on this helper.
+
+## Behavior preservation
+- No runtime behavior changes. The deleted symbol was never imported or invoked anywhere, so removing it cannot alter any code path or output. `svelte-check --threshold error` passes with 0 errors (2 pre-existing warnings in unrelated files remain unchanged).

--- a/changelogs/2026-05-30-search-server-trim-shortname.md
+++ b/changelogs/2026-05-30-search-server-trim-shortname.md
@@ -1,0 +1,16 @@
+# Search server load: drop unused shortName from cinema payload
+
+**PR**: TBD
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/routes/search/+page.server.ts`, removed the `shortName: c.shortName` field from the cinema objects returned by the `load` function's `data.cinemas.map(...)`.
+- The `SearchResponse` interface still declares `shortName` because it describes the upstream `/api/films/search` response shape — only the field forwarded to the page was dropped.
+
+## Impact
+- Shrinks the SSR/serialized data payload for the `/search` route by one field per cinema.
+- No change to rendered output: `search/+page.svelte` renders only `cinema.name` and `cinema.area`; `shortName` was never consumed (grep confirms no usage outside the server load).
+
+## Behavior preservation
+- The search results page renders identically. `shortName` was dead data in the page payload.
+- `svelte-check --threshold error` reports 0 errors (2 pre-existing unrelated warnings in `FollowButton.svelte` and `LetterboxdRatingReveal.svelte`).

--- a/changelogs/2026-05-30-utils-simplify-typeof-guard.md
+++ b/changelogs/2026-05-30-utils-simplify-typeof-guard.md
@@ -1,0 +1,17 @@
+# utils: drop redundant nested typeof guard in formatScreeningDate
+
+**PR**: #127
+**Date**: 2026-05-30
+
+## Changes
+- In `frontend/src/lib/utils.ts`, simplified line 52 of `formatScreeningDate`.
+- The expression `new Date(date + (typeof date === 'string' && !date.includes('T') ? 'T00:00:00' : ''))` sits inside the `typeof date === 'string' ? ... : date` branch, where TypeScript has already narrowed `date` to `string`. The inner `typeof date === 'string' &&` is therefore provably always `true`.
+- Reduced to `new Date(date + (!date.includes('T') ? 'T00:00:00' : ''))`.
+
+## Impact
+- Affects only the internal control flow of `formatScreeningDate`, a widely-imported date formatting helper used in the SvelteKit frontend.
+- No runtime behavior change for any caller.
+
+## Behavior preservation
+- The removed `typeof date === 'string' &&` term always evaluated to `true` at this point because the surrounding ternary branch guarantees `date` is a string. Removing an always-true `&&` operand leaves the conditional's result unchanged, so the concatenation argument passed to `new Date(...)` is byte-identical for every input.
+- Verified with `svelte-check --threshold error`: 0 errors.

--- a/changelogs/2026-05-30-watchlist-deadimport-union-and-now-hoist.md
+++ b/changelogs/2026-05-30-watchlist-deadimport-union-and-now-hoist.md
@@ -1,0 +1,20 @@
+# Watchlist: drop dead Badge import, narrow sortBy union, hoist now out of filter
+
+**PR**: #111
+**Date**: 2026-05-30
+
+## Changes
+Three small, behavior-preserving cleanups in `frontend/src/routes/watchlist/+page.svelte`:
+
+- Removed the unused `import Badge from '$lib/components/ui/Badge.svelte'`. The symbol was only referenced on its own import line (grep-confirmed) and never used in the template or script.
+- Narrowed the `sortBy` state type from `'next' | 'added' | 'title'` to `'next' | 'title'`. The `'added'` member was never assigned (only the NEXT and A–Z buttons set `'next'`/`'title'`) and `sortedFilms` has no `'added'` branch, so the value was unreachable.
+- Hoisted the current-time read out of the future-screenings filter: compute `const now = Date.now()` once and compare `new Date(s.datetime).getTime() > now`, instead of allocating a fresh `new Date()` per screening inside the predicate.
+
+## Impact
+- Affects only the Watchlist page. No change to rendered output, sort behaviour, or filtering results.
+- Slightly fewer allocations when computing future screenings; one less unused module import in the bundle.
+
+## Behavior preservation
+- Identical runtime behavior. Sorting still supports exactly the two values the UI can produce (`'next'`, `'title'`).
+- The filter still keeps screenings strictly after the current instant; `Date.now()` captured once at the start of `loadFilms` matches the practically-equal `new Date()` reads that previously ran microseconds apart within the same synchronous filter pass.
+- Removing the dead import has no effect on behavior or output.

--- a/frontend/src/lib/components/calendar/DayMasthead.svelte
+++ b/frontend/src/lib/components/calendar/DayMasthead.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 	import { filters } from '$lib/stores/filters.svelte';
 	import { today as todayStore } from '$lib/stores/today.svelte';
+	import { formatOrdinalDay } from '$lib/utils';
 	import CalendarPopover from '$lib/components/filters/CalendarPopover.svelte';
+
+	// Cached Intl formatters — hoisted to module scope so they are allocated
+	// once rather than per recompute (and, for WEEKDAY_SHORT, per day-strip cell).
+	const WEEKDAY_LONG = new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' });
+	const DAY_NUM = new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' });
+	const WEEKDAY_SHORT = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' });
 
 	// Effective date — filter if set, else today (London). Reads from the
 	// shared today store so a midnight rollover advances every consumer
@@ -13,24 +20,10 @@
 	// civil date regardless of the user's local timezone.
 	const activeDateObj = $derived(new Date(activeDate + 'T12:00:00Z'));
 
-	// Ordinal e.g. "nineteenth". Cover 1..31.
-	const ORDINALS: Record<number, string> = {
-		1: 'first', 2: 'second', 3: 'third', 4: 'fourth', 5: 'fifth', 6: 'sixth', 7: 'seventh',
-		8: 'eighth', 9: 'ninth', 10: 'tenth', 11: 'eleventh', 12: 'twelfth', 13: 'thirteenth',
-		14: 'fourteenth', 15: 'fifteenth', 16: 'sixteenth', 17: 'seventeenth', 18: 'eighteenth',
-		19: 'nineteenth', 20: 'twentieth', 21: 'twenty-first', 22: 'twenty-second',
-		23: 'twenty-third', 24: 'twenty-fourth', 25: 'twenty-fifth', 26: 'twenty-sixth',
-		27: 'twenty-seventh', 28: 'twenty-eighth', 29: 'twenty-ninth', 30: 'thirtieth',
-		31: 'thirty-first'
-	};
-
-	const weekday = $derived(
-		new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' }).format(activeDateObj)
-	);
-	const dayNum = $derived(Number(
-		new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' }).format(activeDateObj)
-	));
-	const ordinal = $derived(ORDINALS[dayNum] ?? `${dayNum}th`);
+	const weekday = $derived(WEEKDAY_LONG.format(activeDateObj));
+	const dayNum = $derived(Number(DAY_NUM.format(activeDateObj)));
+	// Ordinal e.g. "nineteenth". Cover 1..31 via the shared utils helper.
+	const ordinal = $derived(formatOrdinalDay(dayNum));
 
 	// Compose the day strip: prev arrow, Today, and next 4 days of the week.
 	interface StripItem { key: string; label: string; date: string; isActive: boolean; }
@@ -48,7 +41,7 @@
 		for (let i = 1; i <= 4; i++) {
 			const iso = addDays(todayISO, i);
 			const d = new Date(iso + 'T12:00:00Z');
-			const label = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' }).format(d);
+			const label = WEEKDAY_SHORT.format(d);
 			items.push({ key: iso, label, date: iso, isActive: activeDate === iso });
 		}
 		return items;

--- a/frontend/src/lib/components/film/LetterboxdRatingReveal.svelte
+++ b/frontend/src/lib/components/film/LetterboxdRatingReveal.svelte
@@ -31,7 +31,7 @@
 {#if isRevealed}
 	<div class="rating-revealed">
 		<div class="stars">
-			{#each Array(displayStars) as _, i}
+			{#each Array(displayStars) as _}
 				<svg viewBox="0 0 24 24" class="star" fill={LETTERBOXD_ORANGE} stroke={LETTERBOXD_ORANGE} stroke-width="1.5">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/>
 				</svg>
@@ -47,7 +47,7 @@
 					<path fill="url(#half-{filmId})" stroke={LETTERBOXD_ORANGE} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/>
 				</svg>
 			{/if}
-			{#each Array(Math.max(0, emptyStars)) as _, i}
+			{#each Array(Math.max(0, emptyStars)) as _}
 				<svg viewBox="0 0 24 24" class="star" fill="transparent" stroke="#666" stroke-width="1.5">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/>
 				</svg>

--- a/frontend/src/lib/components/filters/CalendarPopover.svelte
+++ b/frontend/src/lib/components/filters/CalendarPopover.svelte
@@ -25,6 +25,7 @@
 	});
 
 	const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+	const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su'];
 
 	// `$effect` re-syncs `viewMonth`/`viewYear` from `selected` whenever the
 	// parent prop changes — intentional: if the parent jumps the selected
@@ -93,7 +94,7 @@
 	</div>
 
 	<div class="cal-weekdays">
-		{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}
+		{#each WEEKDAYS as d, i (d + i)}
 			<div class="cal-weekday" class:is-weekend={i >= 5}>{d}</div>
 		{/each}
 	</div>

--- a/frontend/src/lib/components/filters/MobileDatePicker.svelte
+++ b/frontend/src/lib/components/filters/MobileDatePicker.svelte
@@ -16,6 +16,7 @@
 	let viewYear = $state(initial.getUTCFullYear());
 
 	const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+	const WEEKDAYS = ['Mo','Tu','We','Th','Fr','Sa','Su'];
 
 	function prev() { if (viewMonth === 0) { viewMonth = 11; viewYear--; } else viewMonth--; }
 	function next() { if (viewMonth === 11) { viewMonth = 0; viewYear++; } else viewMonth++; }
@@ -85,7 +86,7 @@
 		</div>
 
 		<div class="weekdays">
-			{#each ['Mo','Tu','We','Th','Fr','Sa','Su'] as d, i (d + i)}
+			{#each WEEKDAYS as d, i (d + i)}
 				<div class="wk" class:weekend={i >= 5}>{d}</div>
 			{/each}
 		</div>

--- a/frontend/src/lib/components/filters/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/filters/MobileFilterSheet.svelte
@@ -105,6 +105,8 @@
 	const dayFmt = new Intl.DateTimeFormat('en-GB', { weekday: 'short', timeZone: 'Europe/London' });
 	const todayLabel = dayFmt.format(new Date(today + 'T12:00:00Z'));
 	const tomorrowLabel = dayFmt.format(new Date(tomorrow + 'T12:00:00Z'));
+	const todayDay = new Date(today + 'T12:00:00Z').getUTCDate();
+	const tomorrowDay = new Date(tomorrow + 'T12:00:00Z').getUTCDate();
 
 	function pick(preset: 'today' | 'tomorrow' | 'weekend' | null) {
 		if (preset === 'today') {
@@ -214,8 +216,8 @@
 					<span class="hint">today</span>
 				</div>
 				<div class="chips">
-					<button type="button" class="chip" class:active={whenState === 'today'} onclick={() => pick(whenState === 'today' ? null : 'today')}>Today<span class="sub">{todayLabel} {new Date(today + 'T12:00:00Z').getUTCDate()}</span></button>
-					<button type="button" class="chip" class:active={whenState === 'tomorrow'} onclick={() => pick(whenState === 'tomorrow' ? null : 'tomorrow')}>Tomorrow<span class="sub">{tomorrowLabel} {new Date(tomorrow + 'T12:00:00Z').getUTCDate()}</span></button>
+					<button type="button" class="chip" class:active={whenState === 'today'} onclick={() => pick(whenState === 'today' ? null : 'today')}>Today<span class="sub">{todayLabel} {todayDay}</span></button>
+					<button type="button" class="chip" class:active={whenState === 'tomorrow'} onclick={() => pick(whenState === 'tomorrow' ? null : 'tomorrow')}>Tomorrow<span class="sub">{tomorrowLabel} {tomorrowDay}</span></button>
 					<button type="button" class="chip" class:active={whenState === 'weekend'} onclick={() => pick(whenState === 'weekend' ? null : 'weekend')}>This weekend</button>
 					<button type="button" class="chip" onclick={() => (datePickerOpen = true)}>Pick a date</button>
 				</div>

--- a/frontend/src/lib/components/layout/Header.svelte
+++ b/frontend/src/lib/components/layout/Header.svelte
@@ -40,6 +40,11 @@
 		{ href: '/directors', label: 'Directors', desktop: false, mobile: true }
 	];
 
+	// NAV_ITEMS is static and never mutated, so the per-surface filters are
+	// computed once here rather than re-run inline on every header re-render.
+	const DESKTOP_NAV = NAV_ITEMS.filter((n) => n.desktop);
+	const MOBILE_NAV = NAV_ITEMS.filter((n) => n.mobile);
+
 	function isActive(href: string, matchPrefix?: boolean): boolean {
 		return matchPrefix ? page.url.pathname.startsWith(href) : page.url.pathname === href;
 	}
@@ -82,7 +87,7 @@
 
 			<div class="brand-right">
 				<nav class="nav-links" aria-label="Main">
-					{#each NAV_ITEMS.filter((n) => n.desktop) as item (item.href)}
+					{#each DESKTOP_NAV as item (item.href)}
 						<a
 							href={item.href}
 							class="nav-link"
@@ -125,7 +130,7 @@
 		<!-- Mobile nav menu -->
 		{#if mobileMenuOpen}
 			<nav class="mobile-nav" aria-label="Mobile navigation">
-				{#each NAV_ITEMS.filter((n) => n.mobile) as item (item.href)}
+				{#each MOBILE_NAV as item (item.href)}
 					<a
 						href={item.href}
 						class="mobile-nav-link"

--- a/frontend/src/lib/components/map/CinemaMap.svelte
+++ b/frontend/src/lib/components/map/CinemaMap.svelte
@@ -1,3 +1,22 @@
+<script module lang="ts">
+	// Hoisted to module scope: createMarkerElement / createPopupContent run
+	// once per cinema, so these constant literal strings were rebuilt on every
+	// call. Shared here so the produced DOM is byte-identical to the inline form.
+	const MARKER_WIDTH = '20';
+	const MARKER_HEIGHT = '26';
+	const MARKER_VIEWBOX = '0 0 20 26';
+	const MARKER_PATH_D = 'M10 0C4.5 0 0 4.5 0 10C0 17.5 10 26 10 26S20 17.5 20 10C20 4.5 15.5 0 10 0Z';
+	const MARKER_PIN_FILL = '#1a1a1a';
+	const MARKER_CIRCLE_CX = '10';
+	const MARKER_CIRCLE_CY = '10';
+	const MARKER_CIRCLE_R = '4';
+	const MARKER_CIRCLE_FILL = '#fff';
+
+	const POPUP_DIV_PADDING = '4px';
+	const POPUP_LINK_CSS = 'font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:#1a1a1a;text-decoration:none';
+	const POPUP_AREA_CSS = 'font-size:11px;color:#666;margin-top:2px';
+</script>
+
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
@@ -7,20 +26,14 @@
 
 	let mapContainer = $state<HTMLDivElement>();
 
-	const validCinemas = $derived(
-		cinemas.filter((c): c is Cinema & { coordinates: { lat: number; lng: number } } =>
-			!!c.coordinates?.lat && !!c.coordinates?.lng
-		)
-	);
-
 	function createPopupContent(cinema: Cinema & { coordinates: { lat: number; lng: number } }): HTMLDivElement {
 		const div = document.createElement('div');
-		div.style.padding = '4px';
+		div.style.padding = POPUP_DIV_PADDING;
 
 		const link = document.createElement('a');
 		link.href = `/cinemas/${cinema.id}`;
 		link.textContent = cinema.name;
-		link.style.cssText = 'font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:#1a1a1a;text-decoration:none';
+		link.style.cssText = POPUP_LINK_CSS;
 		link.addEventListener('mouseenter', () => { link.style.textDecoration = 'underline'; });
 		link.addEventListener('mouseleave', () => { link.style.textDecoration = 'none'; });
 		div.appendChild(link);
@@ -28,7 +41,7 @@
 		if (cinema.address?.area) {
 			const area = document.createElement('p');
 			area.textContent = cinema.address.area;
-			area.style.cssText = 'font-size:11px;color:#666;margin-top:2px';
+			area.style.cssText = POPUP_AREA_CSS;
 			div.appendChild(area);
 		}
 
@@ -50,20 +63,20 @@
 		});
 
 		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-		svg.setAttribute('width', '20');
-		svg.setAttribute('height', '26');
-		svg.setAttribute('viewBox', '0 0 20 26');
+		svg.setAttribute('width', MARKER_WIDTH);
+		svg.setAttribute('height', MARKER_HEIGHT);
+		svg.setAttribute('viewBox', MARKER_VIEWBOX);
 
 		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-		path.setAttribute('d', 'M10 0C4.5 0 0 4.5 0 10C0 17.5 10 26 10 26S20 17.5 20 10C20 4.5 15.5 0 10 0Z');
-		path.setAttribute('fill', '#1a1a1a');
+		path.setAttribute('d', MARKER_PATH_D);
+		path.setAttribute('fill', MARKER_PIN_FILL);
 		svg.appendChild(path);
 
 		const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-		circle.setAttribute('cx', '10');
-		circle.setAttribute('cy', '10');
-		circle.setAttribute('r', '4');
-		circle.setAttribute('fill', '#fff');
+		circle.setAttribute('cx', MARKER_CIRCLE_CX);
+		circle.setAttribute('cy', MARKER_CIRCLE_CY);
+		circle.setAttribute('r', MARKER_CIRCLE_R);
+		circle.setAttribute('fill', MARKER_CIRCLE_FILL);
 		svg.appendChild(circle);
 
 		el.appendChild(svg);

--- a/frontend/src/lib/components/pretext/BreathingGrid.svelte
+++ b/frontend/src/lib/components/pretext/BreathingGrid.svelte
@@ -33,12 +33,17 @@
 	let animFrame: number;
 	let mounted = $state(false);
 
-	function getCharScale(cell: CharCell, time: number, mx: number, my: number): number {
+	function getCharScale(
+		cell: CharCell,
+		time: number,
+		mx: number,
+		my: number,
+		rect: DOMRect | null
+	): number {
 		const breathe = Math.sin((time / BREATHE_PERIOD) * Math.PI * 2 + cell.phase) * BREATHE_AMPLITUDE;
 		let scale = 1.0 + breathe;
 
-		if (mx > -500 && containerEl) {
-			const rect = containerEl.getBoundingClientRect();
+		if (mx > -500 && rect) {
 			const cx = rect.left + cell.col * CELL_SIZE + CELL_SIZE / 2;
 			const cy = rect.top + rect.height / 2;
 			const dist = Math.sqrt((mx - cx) ** 2 + (my - cy) ** 2);
@@ -51,6 +56,10 @@
 		}
 
 		return scale;
+	}
+
+	function getFrameRect(mx: number): DOMRect | null {
+		return mx > -500 && containerEl ? containerEl.getBoundingClientRect() : null;
 	}
 
 	function animate(timestamp: number) {
@@ -102,8 +111,9 @@
 	onmouseleave={handleMouseLeave}
 >
 	{#if mounted}
+		{@const frameRect = getFrameRect(mouseX)}
 		{#each chars as cell}
-			{@const scale = getCharScale(cell, animTime, mouseX, mouseY)}
+			{@const scale = getCharScale(cell, animTime, mouseX, mouseY, frameRect)}
 			<span class="grid-cell" class:separator={cell.isSeparator}>
 				<span class="grid-char font-display" style="transform: scale({scale});">
 					{cell.char}

--- a/frontend/src/lib/components/reachable/DeadlinePicker.svelte
+++ b/frontend/src/lib/components/reachable/DeadlinePicker.svelte
@@ -1,3 +1,23 @@
+<script module lang="ts">
+	// Hoisted to module scope: built once per module load and shared across
+	// every DeadlinePicker instead of reconstructed on each formatSelectedTime
+	// call. The configs are constant so the formatted output is byte-identical
+	// to the per-call builders they replace.
+	const LONDON_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+		timeZone: 'Europe/London'
+	});
+	const TIME_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false
+	});
+	const DAY_MONTH_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+		weekday: 'short',
+		day: 'numeric',
+		month: 'short'
+	});
+</script>
+
 <script lang="ts">
 	let {
 		value = null,
@@ -63,17 +83,17 @@
 
 	function formatSelectedTime(date: Date): string {
 		const now = new Date();
-		const todayStr = now.toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+		const todayStr = LONDON_DATE_FORMATTER.format(now);
 		const tomorrowDate = new Date(now);
 		tomorrowDate.setDate(tomorrowDate.getDate() + 1);
-		const tomorrowStr = tomorrowDate.toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
-		const targetStr = date.toLocaleDateString('en-CA', { timeZone: 'Europe/London' });
+		const tomorrowStr = LONDON_DATE_FORMATTER.format(tomorrowDate);
+		const targetStr = LONDON_DATE_FORMATTER.format(date);
 
-		const timeStr = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
+		const timeStr = TIME_FORMATTER.format(date);
 
 		if (targetStr === todayStr) return `Today at ${timeStr}`;
 		if (targetStr === tomorrowStr) return `Tomorrow at ${timeStr}`;
-		return date.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' }) + ` at ${timeStr}`;
+		return DAY_MONTH_FORMATTER.format(date) + ` at ${timeStr}`;
 	}
 </script>
 

--- a/frontend/src/lib/components/reachable/ReachableResults.svelte
+++ b/frontend/src/lib/components/reachable/ReachableResults.svelte
@@ -71,11 +71,12 @@
 
 		{#each urgencyOrder as urgency (urgency)}
 			{@const groupScreenings = groups[urgency]}
+			{@const urgencyCss = urgencyClass(urgency)}
 			{#if groupScreenings.length > 0}
 				<div class="urgency-group">
 					<!-- Group header -->
 					<div class="group-header">
-						<h2 class="group-label {urgencyClass(urgency)}">
+						<h2 class="group-label {urgencyCss}">
 							{getUrgencyLabel(urgency)}
 						</h2>
 						<span class="group-count">({groupScreenings.length})</span>
@@ -113,7 +114,7 @@
 								<!-- Content -->
 								<div class="card-content">
 									<!-- Leave-by badge -->
-									<div class="leave-badge {urgencyClass(urgency)}">
+									<div class="leave-badge {urgencyCss}">
 										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 											<circle cx="12" cy="12" r="10" />
 											<polyline points="12 6 12 12 16 14" />

--- a/frontend/src/lib/components/search/rows/FestivalRow.svelte
+++ b/frontend/src/lib/components/search/rows/FestivalRow.svelte
@@ -1,3 +1,14 @@
+<script module lang="ts">
+	// Hoisted to module scope: built once per module load and shared across
+	// every FestivalRow instead of reconstructed per recompute. The config is
+	// constant so the formatted output is byte-identical to the per-call builder.
+	const RANGE_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+		month: 'short',
+		day: 'numeric',
+		timeZone: 'Europe/London'
+	});
+</script>
+
 <script lang="ts">
 	import type { FestivalResult } from '$lib/search/result-types';
 
@@ -19,12 +30,7 @@
 	);
 
 	const dateRange = $derived.by(() => {
-		const fmt = new Intl.DateTimeFormat('en-GB', {
-			month: 'short',
-			day: 'numeric',
-			timeZone: 'Europe/London'
-		});
-		return `${fmt.format(new Date(festival.startDate))} – ${fmt.format(new Date(festival.endDate))}`;
+		return `${RANGE_FORMATTER.format(new Date(festival.startDate))} – ${RANGE_FORMATTER.format(new Date(festival.endDate))}`;
 	});
 </script>
 

--- a/frontend/src/lib/components/search/rows/FilmRow.svelte
+++ b/frontend/src/lib/components/search/rows/FilmRow.svelte
@@ -10,6 +10,8 @@
 	}
 
 	let { film, selected, id }: Props = $props();
+
+	const rating = $derived(film.tmdbRating != null ? film.tmdbRating.toFixed(1) : null);
 </script>
 
 <button
@@ -49,9 +51,9 @@
 			{#if film.directors.length}{film.directors[0]}{/if}
 		</span>
 	</div>
-	{#if film.tmdbRating != null && film.tmdbRating >= 7}
-		<span class="rating" aria-label="TMDB rating {film.tmdbRating.toFixed(1)}">
-			★ {film.tmdbRating.toFixed(1)}
+	{#if rating != null && film.tmdbRating != null && film.tmdbRating >= 7}
+		<span class="rating" aria-label="TMDB rating {rating}">
+			★ {rating}
 		</span>
 	{/if}
 </button>

--- a/frontend/src/lib/search/parse-query.ts
+++ b/frontend/src/lib/search/parse-query.ts
@@ -183,16 +183,40 @@ function addDaysToDateString(yyyyMmDd: string, days: number): string {
 
 // ===== Phrase scanning =====
 
+// `scanPhrases` runs ~9x per keystroke over constant module-level tables.
+// Memoize the derived `maxLen` and per-length `Set` lookups per table so the
+// constant data is only processed once, not rebuilt on every call.
+interface CompiledPhrases {
+  maxLen: number;
+  sets: Map<number, Set<string>>;
+}
+const COMPILED_PHRASES = new WeakMap<Record<number, string[]>, CompiledPhrases>();
+
+function compilePhrases(phrasesByLength: Record<number, string[]>): CompiledPhrases {
+  let compiled = COMPILED_PHRASES.get(phrasesByLength);
+  if (!compiled) {
+    const sets = new Map<number, Set<string>>();
+    let maxLen = 0;
+    for (const key of Object.keys(phrasesByLength)) {
+      const len = Number(key);
+      if (len > maxLen) maxLen = len;
+      sets.set(len, new Set(phrasesByLength[len]));
+    }
+    compiled = { maxLen, sets };
+    COMPILED_PHRASES.set(phrasesByLength, compiled);
+  }
+  return compiled;
+}
+
 function scanPhrases(
   tokens: Token[],
   phrasesByLength: Record<number, string[]>,
   onMatch: (matchedPhrase: string, startIdx: number, endIdx: number) => boolean,
 ) {
-  const maxLen = Math.max(0, ...Object.keys(phrasesByLength).map(Number));
+  const { maxLen, sets } = compilePhrases(phrasesByLength);
   for (let len = maxLen; len >= 2; len--) {
-    const phrases = phrasesByLength[len];
-    if (!phrases || phrases.length === 0) continue;
-    const phraseSet = new Set(phrases);
+    const phraseSet = sets.get(len);
+    if (!phraseSet || phraseSet.size === 0) continue;
     for (let i = 0; i <= tokens.length - len; i++) {
       if (tokens.slice(i, i + len).some((t) => t.consumed)) continue;
       const joined = tokens.slice(i, i + len).map((t) => t.lower).join(" ");
@@ -216,6 +240,15 @@ const DAY_NAMES: Record<string, number> = {
   thursday: 4, thu: 4, thur: 4, thurs: 4,
   friday: 5, fri: 5,
   saturday: 6, sat: 6,
+};
+
+// Short weekday labels indexed by day-of-week (Sun=0). Shared by the date
+// scanners so the literal is allocated once, not per call.
+const WEEKDAY_LABELS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+// "next <day>" phrases, precomputed once off the keystroke hot path.
+const NEXT_DAY_PHRASES_BY_LENGTH: Record<number, string[]> = {
+  2: Object.keys(DAY_NAMES).map((d) => `next ${d}`),
 };
 
 function applyTonight(intent: ParsedIntent, now: Date) {
@@ -273,7 +306,7 @@ function applyNextDay(intent: ParsedIntent, now: Date, dayIdx: number) {
   const target = addDaysToDateString(today, offset);
   intent.dateFrom = londonMidnight(target, 0);
   intent.dateTo = londonMidnight(addDaysToDateString(target, 1), 0);
-  const dayName = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"][dayIdx];
+  const dayName = WEEKDAY_LABELS[dayIdx];
   intent.chipDescriptors.push({
     id: `date:next-${dayIdx}`,
     kind: "date",
@@ -288,7 +321,7 @@ function applyDayThisWeek(intent: ParsedIntent, now: Date, dayIdx: number) {
   const target = addDaysToDateString(today, offset);
   intent.dateFrom = londonMidnight(target, 0);
   intent.dateTo = londonMidnight(addDaysToDateString(target, 1), 0);
-  const dayName = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"][dayIdx];
+  const dayName = WEEKDAY_LABELS[dayIdx];
   intent.chipDescriptors.push({ id: `date:${dayIdx}`, kind: "date", label: dayName });
 }
 
@@ -373,7 +406,7 @@ export function parseQuery(input: string, now: Date): ParsedIntent {
 
   scanPhrases(
     tokens,
-    { 2: Object.keys(DAY_NAMES).map((d) => `next ${d}`) },
+    NEXT_DAY_PHRASES_BY_LENGTH,
     (phrase) => {
       const dayPart = phrase.replace(/^next /, "");
       const idx = DAY_NAMES[dayPart];

--- a/frontend/src/lib/search/result-types.ts
+++ b/frontend/src/lib/search/result-types.ts
@@ -168,7 +168,3 @@ export function flattenResults(results: PaletteResults): ResultRow[] {
   }
   return flat;
 }
-
-export function totalResults(results: PaletteResults): number {
-  return flattenResults(results).length;
-}

--- a/frontend/src/lib/search/vocab/chains.ts
+++ b/frontend/src/lib/search/vocab/chains.ts
@@ -20,11 +20,6 @@ export const CHAIN_TOKENS: Record<string, string> = {
   odeon: "Odeon",
 };
 
-// Multi-word phrases for chains.
-export const CHAIN_PHRASES_BY_LENGTH: Record<number, string[]> = {
-  2: [],
-};
-
 // Specific cinema aliases → slug (cinemas.id).
 // IMPORTANT: these slugs must match real cinemas.id values in the
 // database. Verify with `SELECT id FROM cinemas` after any change.

--- a/frontend/src/lib/stores/filters.svelte.ts
+++ b/frontend/src/lib/stores/filters.svelte.ts
@@ -4,6 +4,17 @@ import type { ParsedIntent } from '$lib/search/parse-query';
 
 const STORAGE_KEY = 'pictures-filters';
 
+// Cached London-tz YYYY-MM-DD formatter reused across applyIntent calls.
+// Instantiating a fresh Intl.DateTimeFormat per call dominates the cost on
+// the cmd+k keystroke path; allocate once at module scope (mirrors the
+// DATE_LONDON_ISO hoist in utils.ts). Stateless — identical output across DST.
+const LONDON_YMD = new Intl.DateTimeFormat('en-CA', {
+	timeZone: 'Europe/London',
+	year: 'numeric',
+	month: '2-digit',
+	day: '2-digit'
+});
+
 interface PersistedFilters {
 	cinemaIds: string[];
 	formats: string[];
@@ -268,22 +279,8 @@ export const filters = {
 			// ParsedIntent.dateFrom/dateTo are JS Dates representing the
 			// London-midnight instant; the filters store uses YYYY-MM-DD
 			// strings in London tz. Round-trip via Intl so DST stays sane.
-			dateFrom = parsed.dateFrom
-				? new Intl.DateTimeFormat('en-CA', {
-						timeZone: 'Europe/London',
-						year: 'numeric',
-						month: '2-digit',
-						day: '2-digit'
-					}).format(parsed.dateFrom)
-				: null;
-			dateTo = parsed.dateTo
-				? new Intl.DateTimeFormat('en-CA', {
-						timeZone: 'Europe/London',
-						year: 'numeric',
-						month: '2-digit',
-						day: '2-digit'
-					}).format(parsed.dateTo)
-				: null;
+			dateFrom = parsed.dateFrom ? LONDON_YMD.format(parsed.dateFrom) : null;
+			dateTo = parsed.dateTo ? LONDON_YMD.format(parsed.dateTo) : null;
 		}
 		if (parsed.timeFrom !== undefined) timeFrom = parsed.timeFrom;
 		if (parsed.timeTo !== undefined) timeTo = parsed.timeTo;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -49,7 +49,7 @@ export function toLondonDateStr(date: Date | string): string {
 }
 
 export function formatScreeningDate(date: Date | string): string {
-	const d = typeof date === 'string' ? new Date(date + (typeof date === 'string' && !date.includes('T') ? 'T00:00:00' : '')) : date;
+	const d = typeof date === 'string' ? new Date(date + (!date.includes('T') ? 'T00:00:00' : '')) : date;
 	const todayStr = toLondonDateStr(new Date());
 	const targetStr = typeof date === 'string' && !date.includes('T') ? date : toLondonDateStr(d);
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -51,27 +51,7 @@
 
 <JsonLd data={organizationSchema()} />
 
-{#if clerkEnabled}
-	<ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
-		<PostHogProvider />
-		<SyncProvider />
-		<GlobalCmdkBinding />
-		{#if CommandPalette}
-			<CommandPalette />
-		{/if}
-		<a href="#main-content" class="skip-link">Skip to content</a>
-
-		<div class="min-h-dvh flex flex-col">
-			<Header cinemas={data?.cinemas ?? []} />
-			<main id="main-content" class="flex-1" tabindex="-1">
-				{@render children()}
-			</main>
-			<Footer />
-		</div>
-	</ClerkProvider>
-{:else}
-	<PostHogProvider />
-	<GlobalCmdkBinding />
+{#snippet shell()}
 	<a href="#main-content" class="skip-link">Skip to content</a>
 
 	<div class="min-h-dvh flex flex-col">
@@ -81,6 +61,22 @@
 		</main>
 		<Footer />
 	</div>
+{/snippet}
+
+{#if clerkEnabled}
+	<ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
+		<PostHogProvider />
+		<SyncProvider />
+		<GlobalCmdkBinding />
+		{#if CommandPalette}
+			<CommandPalette />
+		{/if}
+		{@render shell()}
+	</ClerkProvider>
+{:else}
+	<PostHogProvider />
+	<GlobalCmdkBinding />
+	{@render shell()}
 {/if}
 
 <style>

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -69,11 +69,6 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 				name: s.cinema.name,
 				shortName: s.cinema.shortName
 			}
-		})),
-		meta: {
-			total: data.meta.total,
-			startDate: data.meta.startDate,
-			endDate: data.meta.endDate
-		}
+		}))
 	};
 };

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -25,6 +25,16 @@
 	const dayHeaderWeekdayFmt = new Intl.DateTimeFormat('en-GB', { weekday: 'long', timeZone: 'Europe/London' });
 	const dayHeaderDayNumFmt = new Intl.DateTimeFormat('en-GB', { day: 'numeric', timeZone: 'Europe/London' });
 
+	// `tomorrowIso` depends only on `todayStore.value`, so compute it once per
+	// `today` change instead of inside the {#snippet dayHeader} IIFE that re-ran
+	// for every visible day header on every filter-change re-render. Output is
+	// byte-identical — same UTC-noon anchor + ISO-date slice as before.
+	const tomorrowIso = $derived.by(() => {
+		const t = new Date(todayStore.value + 'T12:00:00Z');
+		t.setUTCDate(t.getUTCDate() + 1);
+		return t.toISOString().split('T')[0];
+	});
+
 	// Sidebar collapsed state — persist across sessions.
 	const SIDEBAR_STORAGE_KEY = 'pictures-sidebar-collapsed';
 	function loadCollapsed(): boolean {
@@ -42,6 +52,7 @@
 		name: string;
 		shortName: string | null;
 		address: { area: string } | null;
+		coordinates: { lat: number; lng: number } | null;
 	}>);
 
 	let mobileFilterOpen = $state(false);
@@ -213,7 +224,6 @@
 	{@const weekday = dayHeaderWeekdayFmt.format(d)}
 	{@const dayNum = Number(dayHeaderDayNumFmt.format(d))}
 	{@const todayIso = todayStore.value}
-	{@const tomorrowIso = (() => { const t = new Date(todayIso + 'T12:00:00Z'); t.setUTCDate(t.getUTCDate() + 1); return t.toISOString().split('T')[0]; })()}
 	{@const relative = iso === todayIso ? 'Today' : iso === tomorrowIso ? 'Tomorrow' : null}
 	<h2 class="day-header">
 		{#if relative}<span class="day-header-relative">{relative}</span><span class="day-header-sep"> · </span>{/if}<span class="day-header-weekday">{weekday}</span><span class="italic-comma">,</span> <span class="day-header-ordinal">the {formatOrdinalDay(dayNum)}</span>

--- a/frontend/src/routes/cinemas/+page.svelte
+++ b/frontend/src/routes/cinemas/+page.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
 	import Badge from '$lib/components/ui/Badge.svelte';
-	import { groupBy } from '$lib/utils';
 
 	let { data } = $props();
 	let search = $state('');
 
-	const filtered = $derived(
-		search
-			? data.cinemas.filter((c) =>
-				c.name.toLowerCase().includes(search.toLowerCase()) ||
-				(c.address?.area.toLowerCase().includes(search.toLowerCase()) ?? false)
-			)
-			: data.cinemas
-	);
+	const filtered = $derived.by(() => {
+		if (!search) return data.cinemas;
+		const q = search.toLowerCase();
+		return data.cinemas.filter((c) =>
+			c.name.toLowerCase().includes(q) ||
+			(c.address?.area.toLowerCase().includes(q) ?? false)
+		);
+	});
 
 	const grouped = $derived.by(() => {
 		const groups: Record<string, typeof data.cinemas> = {};

--- a/frontend/src/routes/cinemas/[slug]/+page.server.ts
+++ b/frontend/src/routes/cinemas/[slug]/+page.server.ts
@@ -62,14 +62,10 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
 			datetime: s.datetime,
 			format: s.format,
 			bookingUrl: s.bookingUrl,
-			screen: s.screen,
 			film: {
 				id: s.film.id,
 				title: s.film.title,
-				year: s.film.year,
-				directors: s.film.directors,
-				runtime: s.film.runtime,
-				posterUrl: s.film.posterUrl
+				year: s.film.year
 			}
 		}))
 	};

--- a/frontend/src/routes/cinemas/[slug]/+page.svelte
+++ b/frontend/src/routes/cinemas/[slug]/+page.svelte
@@ -29,8 +29,13 @@
 	});
 
 	const groupedByDate = $derived.by(() => {
+		// `futureScreenings` is sorted strictly ascending by epoch-ms above and
+		// `toLondonDateStr` is monotonic non-decreasing in ms, so `groupBy`'s
+		// first-seen string-key insertion order (preserved by JS for these keys)
+		// is already chronological — the previous `.sort(localeCompare)` was a
+		// guaranteed no-op.
 		const grouped = groupBy(futureScreenings, (s) => toLondonDateStr(s.datetime));
-		return Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b));
+		return Object.entries(grouped);
 	});
 </script>
 

--- a/frontend/src/routes/directors/+page.svelte
+++ b/frontend/src/routes/directors/+page.svelte
@@ -10,11 +10,11 @@
 	let { data }: { data: { directors: DirectorEntry[] } } = $props();
 	let search = $state('');
 
-	const filtered = $derived(
-		search
-			? data.directors.filter((d) => d.name.toLowerCase().includes(search.toLowerCase()))
-			: data.directors
-	);
+	const filtered = $derived.by(() => {
+		if (!search) return data.directors;
+		const q = search.toLowerCase();
+		return data.directors.filter((d) => d.name.toLowerCase().includes(q));
+	});
 </script>
 
 <svelte:head>

--- a/frontend/src/routes/festivals/[slug]/+page.svelte
+++ b/frontend/src/routes/festivals/[slug]/+page.svelte
@@ -2,7 +2,6 @@
 	import FilmCard from '$lib/components/calendar/FilmCard.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import FollowButton from '$lib/components/festivals/FollowButton.svelte';
-	import type { ScreeningWithDetails } from '$lib/types';
 	import { groupBy } from '$lib/utils';
 
 	let { data } = $props();
@@ -10,10 +9,15 @@
 	const screenings = $derived(data.screenings ?? []);
 
 	const filmGroups = $derived.by(() => {
-		const grouped = groupBy(screenings, (s) => s.film?.id ?? 'unknown');
+		type DecoratedScreening = (typeof screenings)[number] & { _ms: number };
+		const decorated = screenings.map((s) => {
+			(s as DecoratedScreening)._ms = new Date(s.datetime).getTime();
+			return s as DecoratedScreening;
+		});
+		const grouped = groupBy(decorated, (s) => s.film?.id ?? 'unknown');
 		return Object.values(grouped).map((ss) => ({
 			film: ss[0].film,
-			screenings: ss.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime())
+			screenings: ss.sort((a, b) => a._ms - b._ms)
 		}));
 	});
 </script>

--- a/frontend/src/routes/film/[id]/+page.svelte
+++ b/frontend/src/routes/film/[id]/+page.svelte
@@ -8,7 +8,6 @@
 	import { today as todayStore } from '$lib/stores/today.svelte';
 	import {
 		formatTime,
-		formatScreeningDate,
 		toLondonDateStr,
 		groupBy,
 		getPosterImageAttributes,
@@ -102,7 +101,11 @@
 	// Day groups for the day strip
 	const groupedByDate = $derived.by(() => {
 		const grouped = groupBy(futureScreenings, (s) => toLondonDateStr(s.datetime));
-		return Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b));
+		// `futureScreenings` is already sorted ascending by epoch-ms and
+		// `toLondonDateStr` is monotonic in ms, so `groupBy` inserts day keys in
+		// chronological order — which JS preserves for string keys. The previous
+		// `.sort(localeCompare)` was therefore a no-op over YYYY-MM-DD keys.
+		return Object.entries(grouped);
 	});
 
 	let selectedDay = $state<string | null>(null);

--- a/frontend/src/routes/map/+page.svelte
+++ b/frontend/src/routes/map/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import CinemaMap from '$lib/components/map/CinemaMap.svelte';
-	import { page } from '$app/state';
 
 	// Cinemas are loaded in the root layout and available via parent data
 	let { data } = $props();
@@ -17,7 +16,7 @@
 		<h1 id="map-heading" class="font-display text-sm font-bold tracking-wide-swiss uppercase">
 			CINEMA MAP
 		</h1>
-		<span class="text-xs text-[var(--color-muted)] font-mono">{cinemas.filter((c: any) => c.coordinates).length} VENUES</span>
+		<span class="text-xs text-[var(--color-muted)] font-mono">{cinemas.filter((c) => c.coordinates).length} VENUES</span>
 	</div>
 	<div class="map-body">
 		<CinemaMap {cinemas} />

--- a/frontend/src/routes/reachable/+page.server.ts
+++ b/frontend/src/routes/reachable/+page.server.ts
@@ -59,10 +59,8 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
 				id: s.film.id,
 				title: s.film.title,
 				year: s.film.year,
-				director: s.film.directors?.[0] ?? null,
 				runtime: s.film.runtime,
-				posterUrl: s.film.posterUrl,
-				isRepertory: s.film.isRepertory
+				posterUrl: s.film.posterUrl
 			},
 			cinema: {
 				id: s.cinema.id,

--- a/frontend/src/routes/search/+page.server.ts
+++ b/frontend/src/routes/search/+page.server.ts
@@ -40,7 +40,6 @@ export const load: PageServerLoad = async ({ url, fetch, setHeaders }) => {
 		cinemas: data.cinemas.map((c) => ({
 			id: c.id,
 			name: c.name,
-			shortName: c.shortName,
 			area: c.address
 		})),
 		query: q

--- a/frontend/src/routes/watchlist/+page.svelte
+++ b/frontend/src/routes/watchlist/+page.svelte
@@ -2,7 +2,6 @@
 	import { filmStatuses } from '$lib/stores/film-status.svelte';
 	import { apiGet } from '$lib/api/client';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
-	import Badge from '$lib/components/ui/Badge.svelte';
 	import { formatTime, getPosterImageAttributes } from '$lib/utils';
 	import { onMount } from 'svelte';
 
@@ -19,7 +18,7 @@
 
 	let films = $state<WatchlistFilm[]>([]);
 	let loading = $state(true);
-	let sortBy = $state<'next' | 'added' | 'title'>('next');
+	let sortBy = $state<'next' | 'title'>('next');
 
 	const wantToSeeIds = $derived(filmStatuses.getFilmIdsByStatus('want_to_see'));
 
@@ -39,8 +38,9 @@
 						film: { id: string; title: string; year: number | null; directors: string[]; runtime: number | null; posterUrl: string | null };
 						screenings: Array<{ id: string; datetime: string; bookingUrl: string }>;
 					}>(`/api/films/${id}`);
+					const now = Date.now();
 					const futureScreenings = res.screenings
-						.filter((s) => new Date(s.datetime) > new Date())
+						.filter((s) => new Date(s.datetime).getTime() > now)
 						.sort((a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime());
 
 					return {


### PR DESCRIPTION
Consolidates **30** open, CI-green, file-disjoint refactor/perf PRs into one integration branch so they ship in a single CI cycle. The repo enforces "branch must be up-to-date with base", which makes 30 individual merges an O(n²) rebase problem; merging them together collapses that to one.

All 30 `rf/*` branches (created 2026-05-30, mapping to PRs **#606–#636 excluding the already-merged #619**) were merged one at a time onto current `origin/main` with `git merge --no-edit`.

## Result
- **30/30 landed cleanly. Zero conflicts. Zero skips. Zero reverts.**
- None of the refactors' intents had been obsoleted by newer `main`.

## Verification (run from `frontend/`)
- `npm run check` → **exit 0** — 0 errors, 2 warnings (both pre-existing `state_referenced_locally` in `FollowButton.svelte` / `LetterboxdRatingReveal.svelte`, neither touched by this work).
- `npm run build` (vite + adapter-vercel) → **exit 0** — built successfully.

## Branches landed (all 30)
1. `rf/result-types-delete-totalresults`
2. `rf/chains-vocab-delete-empty-placeholder`
3. `rf/utils-simplify-typeof-guard`
4. `rf/letterboxd-drop-unused-each-index`
5. `rf/filmrow-dedupe-rating-format`
6. `rf/layout-extract-shell-snippet`
7. `rf/calendarpopover-hoist-weekdays`
8. `rf/mobiledatepicker-hoist-weekdays`
9. `rf/directors-hoist-search-lowercase`
10. `rf/filters-store-hoist-london-ymd`
11. `rf/mobilefiltersheet-hoist-day-numbers`
12. `rf/header-hoist-nav-filters`
13. `rf/festivalrow-hoist-formatter`
14. `rf/reachable-results-group-urgency-const`
15. `rf/deadlinepicker-cached-formatters`
16. `rf/map-deadimport-and-any-cast`
17. `rf/cinemamap-deadcode-and-loop-constants`
18. `rf/cinema-slug-drop-redundant-sort`
19. `rf/watchlist-deadimport-union-and-now-hoist`
20. `rf/home-server-drop-meta`
21. `rf/festival-slug-deadimport-and-sort-hoist`
22. `rf/cinema-slug-server-trim-payload`
23. `rf/reachable-server-trim-payload`
24. `rf/search-server-trim-shortname`
25. `rf/film-detail-deadimport-and-sort`
26. `rf/cinemas-index-deadimport-and-search-hoist`
27. `rf/breathinggrid-rect-per-frame`
28. `rf/parse-query-hotpath-hoists`
29. `rf/daymasthead-ordinals-and-formatters`
30. `rf/home-dayheader-formatters-and-types`

## Skipped
None.

## Supersedes
This PR supersedes the individual PRs **#606–#636** (excluding #619, already merged). Those PRs are intentionally left open and unmodified; close them once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
