### PR TITLE
feat(search): remove 30-day coverage cap + exact-match relevance boost

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,9 @@
+## 2026-05-31: Search — remove 30-day coverage cap + exact-match relevance boost
+**PR**: TBD | **Files**: `src/app/api/films/search/route.ts`, `scripts/verify-search-coverage.ts`
+- **Coverage fix**: the films search dropped its hard `ns.next_dt < now() + 30 days` upper bound. Verified against prod: **256 of 1,082 upcoming films (24%) had their earliest screening >30 days out and were unsearchable** — repertory titles, retrospectives announced early, festival films. They are now findable; the recency boost keeps soon-showing films at the top.
+- **Relevance**: added an exact-title boost (`0.20`, dominates the ~0.03 RRF ceiling so e.g. "amelie" → Amélie #1) and a prefix-title boost (`0.08`). Verified: `D.E.B.S.`, `Possession`, `Ghatak Was Here` now return rank #1 for an exact query (all returned 0 results before).
+- The `screenings` result sub-query keeps its near-term window (intentional: a film is findable forever-out and links to its detail page, which lists every screening; individual booking rows stay near-term). No response-contract change; code-reviewed clean.
+
 ## 2026-05-30: Scraper coverage + freshness pass — end of June 2026
 **PR**: TBD | **Files**: `src/scrapers/pipeline.ts`, `src/scrapers/chains/everyman.ts`, `src/scrapers/cinemas/bfi.ts`, `src/scrapers/cinemas/olympic.ts`, `src/scrapers/cinemas/david-lean.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
 - **42P10 upsert keystone**: `(cinema_id, source_id)` upsert lacked `targetWhere source_id IS NOT NULL` for its partial index → Postgres silently dropped every fresh INSERT across all source_id scrapers (Everyman/Curzon/Picturehouse), freezing forward coverage. Re-applied the lost 2026-05-27 fix.

--- a/changelogs/2026-05-31-search-coverage-relevance.md
+++ b/changelogs/2026-05-31-search-coverage-relevance.md
@@ -1,0 +1,34 @@
+# Search — remove 30-day coverage cap + exact-match relevance boost
+
+**PR**: TBD
+**Date**: 2026-05-31
+
+## Changes
+- `src/app/api/films/search/route.ts` — films query:
+  - Removed the `AND ns.next_dt < now() + interval '30 days'` upper bound. The
+    query now returns every film with **any** future screening (still requires
+    `ns.next_dt IS NOT NULL`, so only films a user can actually go and see).
+  - Added a `CROSS JOIN params p` (params is a one-row CTE) to bring the bound
+    query string into the final score, plus two boost terms:
+    - `0.20 * (lower(f.title) = lower(p.q))::int` — exact title match. Dominates
+      the RRF ceiling (~0.03 for a dual-list #1), guaranteeing exact-title #1.
+    - `0.08 * (f.title ILIKE p.q || '%')::int` — prefix title match.
+  - Recency (1-week half-life) and popularity boosts unchanged.
+- `scripts/verify-search-coverage.ts` (new) — read-only verification that
+  censuses far-out films, then proves OLD-cap search returns 0 while NEW search
+  returns them at rank #1.
+
+## Verification
+- Census (prod DB): 1,082 upcoming films; **256 (24%) earliest screening >30d out**.
+- `D.E.B.S.` / `Possession` / `Ghatak Was Here`: NEW found rank #1; OLD found=false.
+- `tsc --noEmit`: no errors in changed files. Code-reviewed: clean, no blockers.
+- Response contract `{ results, cinemas, screenings, festivals, seasons }` unchanged;
+  palette + `/search` consumers verified intact. `nextScreeningAt` is server-side
+  ranking only (not rendered), so far-future values have no UI impact.
+
+## Impact
+- Anyone searching for a repertory title, retrospective, or festival film
+  screening more than 30 days out — previously zero results, now found.
+- Exact-title queries are deterministically ranked first.
+- Performance neutral: candidate set still bounded by the two `LIMIT 200` CTEs;
+  the per-candidate LATERAL was already computed before the removed filter.

--- a/scripts/verify-search-coverage.ts
+++ b/scripts/verify-search-coverage.ts
@@ -1,0 +1,104 @@
+/**
+ * Verification for feat/search-coverage-relevance.
+ *
+ * Proves two things against the live DB (READ-ONLY):
+ *   1. COVERAGE: films whose earliest upcoming screening is >30 days out were
+ *      invisible to the old search (hard `< now()+30d` cap) but are found now.
+ *   2. RELEVANCE: an exact title query ranks that film #1 via the new boost.
+ *
+ * Run: npx tsx scripts/verify-search-coverage.ts
+ */
+import { sql } from "drizzle-orm";
+import { db } from "../src/db";
+
+// Mirrors the route's films CTE. `cap` toggles the old 30-day upper bound;
+// `boost` toggles the new exact/prefix title boost.
+function filmsQuery(q: string, { cap, boost }: { cap: boolean; boost: boolean }) {
+  const capClause = cap ? sql`AND ns.next_dt < now() + interval '30 days'` : sql``;
+  const boostExpr = boost
+    ? sql`+ 0.20 * (lower(f.title) = lower(p.q))::int + 0.08 * (f.title ILIKE p.q || '%')::int`
+    : sql``;
+  return db.execute(sql`
+    WITH params AS (
+      SELECT ${q}::text AS q, websearch_to_tsquery('pictures', ${q}) AS tsq
+    ),
+    lexical AS (
+      SELECT f.id, row_number() OVER (ORDER BY ts_rank_cd(f.search_tsv, p.tsq) DESC) AS r
+      FROM films f, params p WHERE f.search_tsv @@ p.tsq
+      ORDER BY ts_rank_cd(f.search_tsv, p.tsq) DESC LIMIT 200
+    ),
+    trgm AS (
+      SELECT f.id, row_number() OVER (ORDER BY word_similarity(p.q, f.search_text) DESC) AS r
+      FROM films f, params p WHERE f.search_text % p.q
+      ORDER BY word_similarity(p.q, f.search_text) DESC LIMIT 200
+    ),
+    fused AS (
+      SELECT id, sum(rrf) AS rrf_score FROM (
+        SELECT id, 1.0/(60 + r) AS rrf FROM lexical
+        UNION ALL SELECT id, 1.0/(60 + r) AS rrf FROM trgm
+      ) u GROUP BY id
+    )
+    SELECT f.title, f.year, ns.next_dt AS next_screening_at,
+      (fused.rrf_score ${boostExpr}
+        + 0.05 * coalesce(exp(-extract(epoch FROM (ns.next_dt - now()))/604800.0), 0)
+        + 0.02 * ln(1 + coalesce(f.tmdb_popularity, 0))) AS score
+    FROM fused JOIN films f ON f.id = fused.id CROSS JOIN params p
+    LEFT JOIN LATERAL (
+      SELECT min(s.datetime) AS next_dt FROM screenings s WHERE s.film_id = f.id AND s.datetime > now()
+    ) ns ON true
+    WHERE ns.next_dt IS NOT NULL ${capClause}
+    ORDER BY score DESC LIMIT 12
+  `);
+}
+
+function rows<T>(r: unknown): T[] {
+  return Array.isArray(r) ? (r as T[]) : ((r as { rows?: T[] }).rows ?? []);
+}
+type Row = { title: string; year: number | null; next_screening_at: string; score: number };
+
+async function main() {
+  // 1. Census: how many distinct films are only screening >30 days out?
+  const censusRes = await db.execute(sql`
+    WITH next AS (
+      SELECT f.id, f.title, min(s.datetime) AS next_dt
+      FROM films f JOIN screenings s ON s.film_id = f.id
+      WHERE s.datetime > now()
+      GROUP BY f.id, f.title
+    )
+    SELECT count(*) FILTER (WHERE next_dt >= now() + interval '30 days') AS beyond_30d,
+           count(*) AS total_upcoming
+    FROM next
+  `);
+  const census = rows<{ beyond_30d: number; total_upcoming: number }>(censusRes)[0];
+  console.log(`\n📊 Upcoming films: ${census.total_upcoming} total; ` +
+    `${census.beyond_30d} have their EARLIEST screening >30 days out (invisible to old search).`);
+
+  // Find a concrete far-out film to use as the search probe.
+  const farRes = await db.execute(sql`
+    WITH next AS (
+      SELECT f.id, f.title, f.year, min(s.datetime) AS next_dt
+      FROM films f JOIN screenings s ON s.film_id = f.id
+      WHERE s.datetime > now() GROUP BY f.id, f.title, f.year
+    )
+    SELECT title, year, next_dt FROM next
+    WHERE next_dt >= now() + interval '30 days'
+    ORDER BY next_dt ASC LIMIT 8
+  `);
+  const farFilms = rows<{ title: string; year: number | null; next_dt: string }>(farRes);
+  console.log(`\n🔭 Sample far-out films (earliest screening >30d):`);
+  farFilms.forEach((f) => console.log(`   • ${f.title} (${f.year ?? "?"}) — ${new Date(f.next_dt).toDateString()}`));
+
+  // 2. Coverage proof: search a far-out film's title, old vs new.
+  for (const probe of farFilms.slice(0, 3)) {
+    const newR = rows<Row>(await filmsQuery(probe.title, { cap: false, boost: true }));
+    const oldR = rows<Row>(await filmsQuery(probe.title, { cap: true, boost: false }));
+    const inNew = newR.some((r) => r.title.toLowerCase() === probe.title.toLowerCase());
+    const inOld = oldR.some((r) => r.title.toLowerCase() === probe.title.toLowerCase());
+    const rank = newR.findIndex((r) => r.title.toLowerCase() === probe.title.toLowerCase()) + 1;
+    console.log(`\n🔎 query="${probe.title}"  NEW: found=${inNew} (rank ${rank || "-"}, ${newR.length} results) | OLD: found=${inOld} (${oldR.length} results)`);
+    if (inNew && !inOld) console.log(`   ✅ COVERAGE WIN: now findable, was hidden by the 30-day cap.`);
+    if (inNew && rank === 1) console.log(`   ✅ RELEVANCE: exact-title query ranks it #1.`);
+  }
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/api/films/search/route.ts
+++ b/src/app/api/films/search/route.ts
@@ -137,8 +137,10 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // RRF k=60 over tsvector + trigram, with recency + popularity boosts.
-    // Filters to films with screenings in the next 30 days (existing UX promise).
+    // RRF k=60 over tsvector + trigram, with exact-match + recency + popularity boosts.
+    // Returns ALL films with ANY upcoming screening (no fixed window) so a
+    // repertory title screening weeks out — or a retrospective announced early —
+    // is findable; the recency boost keeps soon-showing films at the top.
     // The CTEs limit pre-fusion candidates to 200 each so the planner can
     // use the GIN indexes efficiently before the JOIN to films.
     const [filmsRes, cinemasRes, screeningsRes, festivalsRes, seasonsRes] =
@@ -190,18 +192,25 @@ export async function GET(request: NextRequest) {
             ns.next_dt AS "nextScreeningAt",
             (
               fused.rrf_score
+              -- Exact title match dominates RRF (~0.016 max) so "amelie" → Amélie #1.
+              + 0.20 * (lower(f.title) = lower(p.q))::int
+              -- Prefix title match is the next-strongest signal.
+              + 0.08 * (f.title ILIKE p.q || '%')::int
+              -- Recency: 1-week half-life keeps soon-showing films near the top.
               + 0.05 * coalesce(exp(-extract(epoch FROM (ns.next_dt - now()))/604800.0), 0)
               + 0.02 * ln(1 + coalesce(f.tmdb_popularity, 0))
             ) AS score
           FROM fused
           JOIN films f ON f.id = fused.id
+          CROSS JOIN params p
           LEFT JOIN LATERAL (
             SELECT min(s.datetime) AS next_dt
             FROM screenings s
             WHERE s.film_id = f.id AND s.datetime > now()
           ) ns ON true
+          -- Only require a FUTURE screening (no upper bound): every film a user
+          -- can actually still go and see is findable, not just the next 30 days.
           WHERE ns.next_dt IS NOT NULL
-            AND ns.next_dt < now() + interval '${sql.raw(String(SCREENING_WINDOW_DAYS))} days'
           ORDER BY score DESC
           LIMIT ${FILMS_LIMIT}
         `),


### PR DESCRIPTION
## What & why
Search lever #1 of the "improve search significantly" program.

**Coverage:** the films search had a hard \`AND ns.next_dt < now() + interval '30 days'\` upper bound, so any film whose earliest upcoming screening was >30 days out was **completely unsearchable**. Verified against prod: **256 of 1,082 upcoming films (24%)** fall into that bucket — repertory titles, early-announced retrospectives, festival films. Now every film with any future screening is findable; the existing recency boost keeps soon-showing films at the top.

**Relevance:** added an exact-title boost (\`0.20\`, which dominates the ~0.03 RRF ceiling) and a prefix-title boost (\`0.08\`), so an exact query deterministically returns that film at rank #1.

## Verification
\`scripts/verify-search-coverage.ts\` (read-only) censuses far-out films, then proves OLD-cap search returns 0 while NEW search returns them rank #1:
- `D.E.B.S.` / `Possession` / `Ghatak Was Here` → NEW rank #1; OLD found=false.
- `tsc --noEmit`: no errors in changed files.
- Code-reviewed (Code Reviewer agent): clean, no blockers — SQL correct, parameterization intact (no injection/ReDoS), perf neutral (candidate set still bounded by the two LIMIT-200 CTEs; the LATERAL ran before the removed filter), response contract `{results,cinemas,screenings,festivals,seasons}` unchanged.

## Notes
- The `screenings` result sub-query keeps its near-term window intentionally: a film is findable forever-out and links to its detail page (which lists every screening), while individual booking rows stay near-term.
- `nextScreeningAt` is server-side ranking only (not rendered), so far-future values have no UI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)