### PR TITLE
chore(auth): temporarily remove sign-in from the site

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,10 @@
+## 2026-06-01: Temporarily remove sign-in from the site
+**PR**: TBD | **Files**: `frontend/src/lib/components/layout/Header.svelte`, `frontend/src/routes/sign-in/[...rest]/+page.ts` (new), `frontend/src/routes/sign-up/[...rest]/+page.ts` (new), `frontend/src/routes/sitemap.xml/+server.ts`
+- The prod **frontend** Clerk key is a dev `pk_test_` key, so the hosted SignIn widget renders blank. Until a `pk_live_` key is set, remove sign-in from the UI: dropped the desktop + mobile "Sign in" links from the header (+ their dead CSS), and `/sign-in` / `/sign-up` now `307`-redirect home so the broken widget isn't reachable. `ClerkProvider` stays mounted so watchlist (localStorage) + festival-follow degrade cleanly. Fully reversible (restore the links, delete the two redirect files).
+- Drive-by fix: `sitemap.xml` had a `svelte-check` type error (`'updatedAt' in f` narrowed the no-updatedAt union branch to `unknown`) — collapsed both film sources to one `FilmRef` type. `vite build` was lenient so it shipped + is live; svelte-check now clean (0 errors).
+
 ## 2026-06-01: SEO — dynamic sitemap.xml + robots Sitemap directive
-**PR**: TBD | **Files**: `frontend/src/routes/sitemap.xml/+server.ts` (new), `frontend/static/robots.txt`
+**PR**: #642 | **Files**: `frontend/src/routes/sitemap.xml/+server.ts` (new), `frontend/static/robots.txt`
 - **First sitemap the site has ever had.** New SvelteKit endpoint emits ~995 crawlable URLs: 13 static
   routes + 64 cinemas + 17 festivals + 701 people (`/people/[name]`, 60-day window — verified the people
   endpoint serves 200 across it) + films. Auth/user pages (sign-in, settings, watchlist) excluded.

--- a/changelogs/2026-06-01-remove-signin.md
+++ b/changelogs/2026-06-01-remove-signin.md
@@ -1,0 +1,32 @@
+# Temporarily remove sign-in from the site
+
+**PR**: TBD
+**Date**: 2026-06-01
+
+## Why
+The production **frontend** Vercel project's `PUBLIC_CLERK_PUBLISHABLE_KEY` is a development
+`pk_test_…smooth-prawn-4` key, so Clerk's hosted `<SignIn />` widget renders blank/broken. Rather
+than ship a dead sign-in flow, sign-in is removed from the UI until a `pk_live_` key is configured.
+
+## Changes
+- `frontend/src/lib/components/layout/Header.svelte`: removed the desktop and mobile "Sign in" links
+  and their now-dead `.sign-in-link` CSS. (Kept the nav divider as a separator before the controls.)
+- `frontend/src/routes/sign-in/[...rest]/+page.ts` (new) and `sign-up/[...rest]/+page.ts` (new):
+  `load` that `307`-redirects to `/`, so direct navigation to the broken widget isn't possible.
+- `frontend/src/routes/sitemap.xml/+server.ts`: drive-by fix of a `svelte-check` type error — the
+  film source was a union of two array shapes, and `'updatedAt' in f` narrowed the no-`updatedAt`
+  branch to `unknown`. Collapsed both sources to a single `FilmRef` type and read `f.updatedAt`
+  directly (guarded by `toLastmod`).
+
+## What is intentionally NOT changed
+- `ClerkProvider` / `SyncProvider` stay mounted in `+layout.svelte`. Components that depend on Clerk
+  context (e.g. `FollowButton`, status sync) keep working; they simply render nothing / no-op while
+  no one is signed in. The watchlist still works via localStorage. Re-enabling auth = set the
+  `pk_live_` key, restore the header links, and delete the two redirect files.
+
+## Verification
+- `npx svelte-check` → 0 errors (was 1, now fixed; 2 pre-existing unrelated warnings remain).
+- Header grep confirms no `sign-in` / `SIGN IN` references remain.
+
+## Impact
+- Frontend-only → auto-deploys on merge. Users no longer see a broken sign-in entry point.

--- a/frontend/src/lib/components/layout/Header.svelte
+++ b/frontend/src/lib/components/layout/Header.svelte
@@ -99,8 +99,6 @@
 
 				<div class="nav-divider"></div>
 
-					<a href="/sign-in" class="nav-link sign-in-link">Sign in</a>
-
 				<DimmerDial />
 
 				<button
@@ -137,7 +135,6 @@
 						aria-current={isActive(item.href, item.matchPrefix) ? 'page' : undefined}
 					>{item.label.toUpperCase()}</a>
 				{/each}
-				<a href="/sign-in" class="mobile-nav-link">SIGN IN</a>
 			</nav>
 		{/if}
 	</div>
@@ -231,21 +228,6 @@
 		font-family: var(--font-serif-italic);
 		font-style: italic;
 		font-size: 13px;
-	}
-
-	.nav-link.sign-in-link {
-		color: var(--color-text);
-	}
-
-	.sign-in-link {
-		display: none;
-	}
-
-	@media (min-width: 768px) {
-		.sign-in-link {
-			display: inline-flex;
-			align-items: center;
-		}
 	}
 
 	.nav-divider {

--- a/frontend/src/routes/sign-in/[...rest]/+page.ts
+++ b/frontend/src/routes/sign-in/[...rest]/+page.ts
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit';
+
+// Sign-in is temporarily removed from the site (the prod Clerk key is a dev
+// `pk_test_` key, so the hosted SignIn widget renders blank). Redirect any
+// direct navigation home until auth is re-enabled. Reverting = delete this file.
+export const load = () => {
+	redirect(307, '/');
+};

--- a/frontend/src/routes/sign-up/[...rest]/+page.ts
+++ b/frontend/src/routes/sign-up/[...rest]/+page.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+
+// Sign-up is temporarily removed from the site (see sign-in/[...rest]/+page.ts).
+// Redirect any direct navigation home until auth is re-enabled. Revert = delete.
+export const load = () => {
+	redirect(307, '/');
+};

--- a/frontend/src/routes/sitemap.xml/+server.ts
+++ b/frontend/src/routes/sitemap.xml/+server.ts
@@ -120,36 +120,36 @@ async function peopleEntries(fetch: typeof globalThis.fetch): Promise<UrlEntry[]
 		}));
 }
 
+// One consistent shape for both film sources. The fallback's `results` items
+// just lack `updatedAt` at runtime — `toLastmod` already guards undefined.
+// (Keeping a single type avoids a union where `'updatedAt' in f` would narrow
+// the no-updatedAt branch to `unknown`.)
+interface FilmRef {
+	id: string;
+	updatedAt?: string;
+}
+
 async function filmEntries(fetch: typeof globalThis.fetch): Promise<UrlEntry[]> {
 	// Preferred: full enumerator (lands with the next backend promote).
 	const full = await safe(
-		() =>
-			apiFetch<{ films: Array<{ id: string; updatedAt?: string }> }>(
-				'/api/films/sitemap',
-				fetch
-			),
-		null as { films: Array<{ id: string; updatedAt?: string }> } | null
+		() => apiFetch<{ films: FilmRef[] }>('/api/films/sitemap', fetch),
+		null as { films: FilmRef[] } | null
 	);
-	const films =
-		full?.films?.length
-			? full.films
-			: // Fallback: top-200 from the unified browse payload (`results` key).
-				(
-					await safe(
-						() =>
-							apiFetch<{ results: Array<{ id: string }> }>(
-								'/api/films/search?browse=true',
-								fetch
-							),
-						{ results: [] }
-					)
-				).results;
+	const films: FilmRef[] = full?.films?.length
+		? full.films
+		: // Fallback: top-200 from the unified browse payload (`results` key).
+			(
+				await safe(
+					() => apiFetch<{ results: FilmRef[] }>('/api/films/search?browse=true', fetch),
+					{ results: [] as FilmRef[] }
+				)
+			).results;
 
 	return films
 		.filter((f) => f.id)
 		.map((f) => ({
 			loc: `/film/${encodeURIComponent(f.id)}`,
-			lastmod: toLastmod('updatedAt' in f ? f.updatedAt : undefined),
+			lastmod: toLastmod(f.updatedAt),
 			changefreq: 'weekly' as const,
 			priority: 0.6
 		}));


### PR DESCRIPTION
## What
Removes sign-in from the UI until the prod **frontend** Clerk key is switched from the dev `pk_test_` key to a `pk_live_` key (the hosted `<SignIn />` widget currently renders blank).

- Dropped desktop + mobile **"Sign in"** links from the header (+ their dead CSS).
- `/sign-in` and `/sign-up` now **307-redirect to `/`** so the broken widget isn't reachable.
- `ClerkProvider` / `SyncProvider` **stay mounted** → watchlist (localStorage) and festival-follow degrade cleanly; nothing depending on Clerk context breaks.
- **Fully reversible**: restore the links + delete the two redirect files when a `pk_live_` key is set.

## Drive-by fix
`sitemap.xml/+server.ts` had a `svelte-check` type error — the film source was a union of two array shapes and `'updatedAt' in f` narrowed the no-`updatedAt` branch to `unknown`. Collapsed both sources to one `FilmRef` type. (`vite build` was lenient so it shipped + is live; svelte-check now 0 errors.)

## Verification
- `npx svelte-check` → **0 errors** (2 pre-existing unrelated warnings).
- No `sign-in` references remain in the header.

Frontend-only → auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)