### PR TITLE
feat(search): read-only /api/search/catalog endpoint (enables instant in-browser search)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-06-03: Search — read-only catalog endpoint (enables instant in-browser search)
+**PR**: TBD | **Files**: `src/app/api/search/catalog/route.ts` (new), `src/lib/cache-headers.ts`
+- New `GET /api/search/catalog` returns a lean snapshot — **films** (with a future screening) + active
+  **cinemas** + **directors** — so the frontend can build a MiniSearch index and serve instant,
+  typo-tolerant suggestions with zero per-keystroke server round-trips (frontend lands next).
+- Mirrors the live search's `screenings.datetime > now()` filter (every film result is actionable),
+  the `/api/directors` `unnest` pattern (no day cap), and `getActiveCinemas()`. Rate-limited like
+  `/api/cinemas`; cached **1h edge / 24h SWR** (catalog changes slowly). New `CACHE_1HOUR` constant.
+- Verified vs prod DB: 1090 films / 65 cinemas / 717 directors; tsc clean.
+
 ## 2026-06-01: Temporarily remove sign-in from the site
 **PR**: TBD | **Files**: `frontend/src/lib/components/layout/Header.svelte`, `frontend/src/routes/sign-in/[...rest]/+page.ts` (new), `frontend/src/routes/sign-up/[...rest]/+page.ts` (new), `frontend/src/routes/sitemap.xml/+server.ts`
 - The prod **frontend** Clerk key is a dev `pk_test_` key, so the hosted SignIn widget renders blank. Until a `pk_live_` key is set, remove sign-in from the UI: dropped the desktop + mobile "Sign in" links from the header (+ their dead CSS), and `/sign-in` / `/sign-up` now `307`-redirect home so the broken widget isn't reachable. `ClerkProvider` stays mounted so watchlist (localStorage) + festival-follow degrade cleanly. Fully reversible (restore the links, delete the two redirect files).

--- a/changelogs/2026-06-03-search-catalog-api.md
+++ b/changelogs/2026-06-03-search-catalog-api.md
@@ -1,0 +1,35 @@
+# Search — read-only catalog endpoint
+
+**PR**: TBD
+**Date**: 2026-06-03
+
+## Why
+To make film search **lightning-fast and typo-tolerant**, the frontend will build an in-browser fuzzy
+index (MiniSearch) and search it client-side — 0ms per keystroke, no server round-trip. That needs a
+single lean endpoint that returns the whole searchable catalog at once. This PR ships that endpoint; the
+frontend instant-search lands in a follow-up.
+
+## Changes
+- `src/app/api/search/catalog/route.ts` (new) — `GET /api/search/catalog`, read-only. Returns:
+  ```
+  { films:  [{id, title, year, directors, posterUrl}],   // films with a FUTURE screening
+    cinemas:[{id, name, shortName, area}],                // active cinemas
+    people: [{name, role:"director", filmCount}],         // directors of those films
+    generatedAt }                                         // ISO, for client staleness
+  ```
+  - Films: `selectDistinct` over films ⨝ screenings where `datetime >= now()` (mirrors the live search's
+    future-screening filter, so every result is actionable). Cinemas: `getActiveCinemas()` (same repo as
+    `/api/cinemas`), `area` from the address jsonb. People: the `/api/directors` `unnest` pattern with no
+    day cap. All three run in `Promise.all`.
+  - Rate-limited (`RATE_LIMITS.public`, prefix `search-catalog`) like `/api/cinemas`/`/api/directors`.
+- `src/lib/cache-headers.ts` — new `CACHE_1HOUR` (`s-maxage=3600, stale-while-revalidate=86400`). The
+  catalog only changes when scrapes add/remove screenings, so it's cached hard at the edge.
+
+## Verification
+- `tsc --noEmit` — clean (no errors in the new files).
+- Queries verified vs prod DB: **1090 films / 65 cinemas / 717 directors**.
+
+## Impact
+- Backend-only, additive (new route). No change to existing endpoints. Goes live on the next
+  `api.pictures.london` promote; the frontend instant search degrades gracefully (falls back to the
+  existing server search) until it's live.

--- a/src/app/api/search/catalog/route.ts
+++ b/src/app/api/search/catalog/route.ts
@@ -1,0 +1,121 @@
+/**
+ * Search Catalog API Route
+ * GET /api/search/catalog
+ *
+ * Returns a lean snapshot of the searchable entities so the frontend can build
+ * an in-browser fuzzy index (MiniSearch) and serve INSTANT, typo-tolerant
+ * suggestions with zero per-keystroke server round-trips.
+ *
+ * Scope (decided): films + cinemas + people (directors) — all internal-linking.
+ * Only films with a FUTURE screening are included (mirrors the live search's
+ * `screenings.datetime > now()` filter) so every result is actionable. People
+ * are the directors of those films.
+ *
+ * Slow-changing data (only moves when scrapes add/remove screenings) → cached
+ * hard at the edge (1h) with a long stale-while-revalidate (24h).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { asc, eq, gte, sql } from "drizzle-orm";
+
+import { db } from "@/db";
+import { films, screenings } from "@/db/schema";
+import { getActiveCinemas } from "@/db/repositories/cinema";
+import { CACHE_1HOUR } from "@/lib/cache-headers";
+import { checkRateLimit, getClientIP, RATE_LIMITS } from "@/lib/rate-limit";
+import type { CinemaAddress } from "@/types/cinema";
+
+export async function GET(request: NextRequest) {
+  const ip = getClientIP(request);
+  const rateLimitResult = await checkRateLimit(ip, {
+    ...RATE_LIMITS.public,
+    prefix: "search-catalog",
+  });
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: "Too many requests", films: [], cinemas: [], people: [] },
+      { status: 429, headers: { "Retry-After": String(rateLimitResult.resetIn) } }
+    );
+  }
+
+  try {
+    const now = new Date();
+
+    const [filmRows, cinemaList, peopleRows] = await Promise.all([
+      // Films with any future screening (no upper bound — mirrors the live
+      // search). selectDistinct dedupes a film across its many screenings.
+      // NB: no content_type filter here (matches the live search's film
+      // results, which include events/live-broadcasts). The people query below
+      // intentionally restricts to content_type='film' so only real directors
+      // surface — same asymmetry as /api/films/search.
+      db
+        .selectDistinct({
+          id: films.id,
+          title: films.title,
+          year: films.year,
+          directors: films.directors,
+          posterUrl: films.posterUrl,
+        })
+        .from(films)
+        .innerJoin(screenings, eq(films.id, screenings.filmId))
+        .where(gte(screenings.datetime, now))
+        .orderBy(asc(films.title)),
+
+      // Active cinemas (reuses the same repository the /api/cinemas route uses).
+      getActiveCinemas(),
+
+      // Directors of films with a future screening — mirrors /api/directors'
+      // unnest pattern, but with no day cap (the full upcoming horizon).
+      db.execute<{ director: string; film_count: number }>(sql`
+        SELECT
+          d.director,
+          COUNT(DISTINCT f.id)::int AS film_count
+        FROM films f
+        JOIN screenings s ON s.film_id = f.id
+        CROSS JOIN LATERAL unnest(f.directors) AS d(director)
+        WHERE s.datetime >= NOW()
+          AND f.content_type = 'film'
+          AND d.director <> ''
+        GROUP BY d.director
+        ORDER BY film_count DESC, d.director ASC
+      `),
+    ]);
+
+    const filmsOut = filmRows.map((f) => ({
+      id: f.id,
+      title: f.title,
+      year: f.year,
+      directors: f.directors,
+      posterUrl: f.posterUrl,
+    }));
+
+    const cinemasOut = cinemaList.map((c) => ({
+      id: c.id,
+      name: c.name,
+      shortName: c.shortName,
+      area: (c.address as CinemaAddress | null)?.area ?? null,
+    }));
+
+    const peopleOut = peopleRows.map((p) => ({
+      name: p.director,
+      role: "director" as const,
+      filmCount: p.film_count,
+    }));
+
+    return NextResponse.json(
+      {
+        films: filmsOut,
+        cinemas: cinemasOut,
+        people: peopleOut,
+        generatedAt: now.toISOString(),
+      },
+      { headers: CACHE_1HOUR }
+    );
+  } catch (error) {
+    console.error("Search catalog error:", error);
+    return NextResponse.json(
+      { error: "Failed to build catalog", films: [], cinemas: [], people: [] },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/cache-headers.ts
+++ b/src/lib/cache-headers.ts
@@ -14,3 +14,9 @@ export const CACHE_10MIN = {
 export const CACHE_2MIN = {
   "Cache-Control": "public, s-maxage=120, stale-while-revalidate=300",
 } as const;
+
+/** 1-hour edge cache, 24-hour stale-while-revalidate. For slow-changing snapshots
+ * like the search catalog (only changes when scrapes add/remove screenings). */
+export const CACHE_1HOUR = {
+  "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+} as const;


### PR DESCRIPTION
## What
New read-only **`GET /api/search/catalog`** — a lean snapshot of the searchable catalog so the frontend can build an in-browser fuzzy index (MiniSearch) and serve **instant, typo-tolerant** film/cinema/people suggestions with **zero per-keystroke server round-trips**. (Frontend instant-search lands in a follow-up PR.)

Returns:
```
{ films:  [{id, title, year, directors, posterUrl}],   // films with a FUTURE screening
  cinemas:[{id, name, shortName, area}],                // active cinemas
  people: [{name, role:"director", filmCount}],         // directors of those films
  generatedAt }
```

## How
- **Films**: `selectDistinct` films ⨝ screenings `WHERE datetime >= now()` — mirrors the live search's future-screening filter so every result is actionable.
- **Cinemas**: `getActiveCinemas()` (same repo as `/api/cinemas`); `area` from the address jsonb.
- **People**: the `/api/directors` `unnest(directors)` pattern, no day cap, `content_type='film'`.
- All three in `Promise.all`. Rate-limited (`RATE_LIMITS.public`, prefix `search-catalog`). Cached **1h edge / 24h SWR** (new `CACHE_1HOUR`) — catalog changes slowly.

## Verification
- `tsc --noEmit` clean; **code-reviewed** (fixed an unused-import lint blocker the reviewer caught).
- Queries verified vs prod DB: **1090 films / 65 cinemas / 717 directors**.

## Deploy note
Backend-only + additive. Goes live on the next `api.pictures.london` **promote**. The upcoming frontend search degrades gracefully (falls back to the existing server search) until this is live, so there's no ordering hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)