### PR TITLE
refactor(frontend): consolidate Figma cards onto card-shapes.ts

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-06-05: Card components consolidated onto card-shapes.ts (+ formatLabel helper)
+**PR**: TBD | **Files**: `frontend/src/lib/components/calendar/card-shapes.ts`, `frontend/src/lib/components/calendar/FigmaFilmCard.svelte`, `frontend/src/lib/components/calendar/FigmaTextDay.svelte`, `frontend/src/lib/components/calendar/card-shapes.test.ts` (new)
+- FigmaFilmCard/FigmaTextDay re-declared inline `Film`/`Screening` interfaces — the exact field-by-field drift `card-shapes.ts` was created to prevent (flagged by the PR #646 type-design review). Both now import `CardFilm`/`CardScreening`.
+- The duplicated format-cleaning logic (filter `unknown`/`dcp`, `_`→space, uppercase) is extracted to a single `formatLabel()` in card-shapes.ts, with unit tests (71/71 passing, 4 new).
+
+---
+
 ## 2026-06-05: PR-review fixes — dimmer boot/runtime coherence, lazy-import catch, tablet text grid
 **PR**: #646 | **Files**: `frontend/src/app.html`, `frontend/src/lib/components/ui/DimmerDial.svelte`, `frontend/src/routes/+page.svelte`, `frontend/src/routes/film/[id]/+page.svelte`, `frontend/src/lib/components/calendar/FigmaTextDay.svelte`, `frontend/src/lib/server/api.ts`, `frontend/src/lib/components/filters/FigmaToolbar.svelte`, `changelogs/2026-06-05-pr-review-fixes.md`
 - Five-agent PR review (code/comments/silent-failures/types/tests) found and we fixed:

--- a/changelogs/2026-06-05-card-shapes-consolidation.md
+++ b/changelogs/2026-06-05-card-shapes-consolidation.md
@@ -1,0 +1,23 @@
+# Card Components Consolidated onto card-shapes.ts
+
+**PR**: TBD
+**Date**: 2026-06-05
+
+## Changes
+
+- `FigmaFilmCard.svelte` and `FigmaTextDay.svelte` re-declared their own inline `Film`/`Screening` interfaces instead of importing `CardFilm`/`CardScreening` from `card-shapes.ts` — reintroducing the exact field-by-field drift that module's header comment says it was created to kill. Both now import the shared view-model types (their inline shapes were strict subsets, so no behavior change).
+- The format-cleaning logic duplicated across both components (`distinctFormats` in the card, `fmt()` in the text day: filter `unknown`/`dcp`, underscore→space, uppercase) is extracted to one `formatLabel()` helper in `card-shapes.ts`.
+- New `card-shapes.test.ts`: `formatLabel` no-signal/real-format cases + `toCardScreening` adaptation and null-cinema fallback.
+
+## Verification
+
+- svelte-check 0 errors; vitest 71/71 (4 new)
+- Browser: poster mode (62 cards, format chips render) and text mode (315 rows, correct cell content) on the dev server
+
+## Impact
+
+- Single source of truth for card view-model shapes; future field additions happen in one place.
+
+## Context
+
+- Follow-up flagged by the five-agent PR review of #646 (type-design lens).

--- a/frontend/src/lib/components/calendar/FigmaFilmCard.svelte
+++ b/frontend/src/lib/components/calendar/FigmaFilmCard.svelte
@@ -1,24 +1,7 @@
 <script lang="ts">
 	import { formatTime, getPosterImageAttributes } from '$lib/utils';
 	import { trackScreeningClick } from '$lib/analytics/posthog';
-
-	interface Screening {
-		id: string;
-		datetime: string;
-		cinemaName: string;
-		cinemaSlug?: string;
-		format?: string | null;
-		bookingUrl?: string;
-	}
-
-	interface Film {
-		id: string | number;
-		title: string;
-		year?: number | null;
-		director?: string | null;
-		runtime?: number | null;
-		posterUrl?: string | null;
-	}
+	import { formatLabel, type CardFilm, type CardScreening } from './card-shapes';
 
 	let {
 		film,
@@ -26,8 +9,8 @@
 		maxScreenings = 3,
 		priority = false
 	}: {
-		film: Film;
-		screenings: Screening[];
+		film: CardFilm;
+		screenings: CardScreening[];
 		maxScreenings?: number;
 		priority?: boolean;
 	} = $props();
@@ -44,8 +27,8 @@
 	const distinctFormats = $derived.by(() => {
 		const seen = new Set<string>();
 		for (const s of upcoming) {
-			if (!s.format || s.format === 'unknown' || s.format === 'dcp') continue;
-			seen.add(s.format.toUpperCase().replace('_', ' '));
+			const label = formatLabel(s.format);
+			if (label) seen.add(label);
 		}
 		return [...seen].slice(0, 2);
 	});
@@ -63,7 +46,7 @@
 		})
 	);
 
-	function handleClick(s: Screening) {
+	function handleClick(s: CardScreening) {
 		trackScreeningClick(
 			{
 				filmId: String(film.id),

--- a/frontend/src/lib/components/calendar/FigmaTextDay.svelte
+++ b/frontend/src/lib/components/calendar/FigmaTextDay.svelte
@@ -1,31 +1,17 @@
 <script lang="ts">
 	import { formatTime } from '$lib/utils';
 	import { trackScreeningClick } from '$lib/analytics/posthog';
-
-	interface Screening {
-		id: string;
-		datetime: string;
-		cinemaName: string;
-		format?: string | null;
-		bookingUrl?: string;
-	}
-
-	interface Film {
-		id: string | number;
-		title: string;
-		year?: number | null;
-		director?: string | null;
-	}
+	import { formatLabel, type CardFilm, type CardScreening } from './card-shapes';
 
 	let {
 		films
 	}: {
-		films: Array<{ film: Film; screenings: Screening[] }>;
+		films: Array<{ film: CardFilm; screenings: CardScreening[] }>;
 	} = $props();
 
 	// Flatten film+screenings into one row per upcoming screening, sorted by time.
 	const rows = $derived.by(() => {
-		const out: Array<{ film: Film; screening: Screening }> = [];
+		const out: Array<{ film: CardFilm; screening: CardScreening }> = [];
 		for (const { film, screenings } of films) {
 			for (const s of screenings) {
 				if (new Date(s.datetime) <= new Date()) continue;
@@ -36,12 +22,7 @@
 		return out;
 	});
 
-	function fmt(f: string | null | undefined): string {
-		if (!f || f === 'unknown' || f === 'dcp') return '';
-		return f.toUpperCase().replace('_', ' ');
-	}
-
-	function clickRow(film: Film, s: Screening) {
+	function clickRow(film: CardFilm, s: CardScreening) {
 		trackScreeningClick(
 			{
 				filmId: String(film.id),
@@ -79,7 +60,7 @@
 			<span class="cell title">{film.title.toUpperCase()}</span>
 			<span class="cell director hide-md">{(film.director ?? '').toUpperCase()}</span>
 			<span class="cell year hide-sm">{film.year ?? ''}</span>
-			<span class="cell format hide-sm">{fmt(screening.format)}</span>
+			<span class="cell format hide-sm">{formatLabel(screening.format)}</span>
 			<span class="cell cinema">{screening.cinemaName.toUpperCase()}</span>
 		</a>
 	{/each}

--- a/frontend/src/lib/components/calendar/card-shapes.test.ts
+++ b/frontend/src/lib/components/calendar/card-shapes.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { formatLabel, toCardScreening } from './card-shapes';
+
+describe('formatLabel', () => {
+	it('renders nothing for the no-signal default formats', () => {
+		expect(formatLabel('unknown')).toBe('');
+		expect(formatLabel('dcp')).toBe('');
+		expect(formatLabel(null)).toBe('');
+		expect(formatLabel(undefined)).toBe('');
+		expect(formatLabel('')).toBe('');
+	});
+
+	it('uppercases and replaces underscores for real formats', () => {
+		expect(formatLabel('35mm')).toBe('35MM');
+		expect(formatLabel('70mm')).toBe('70MM');
+		expect(formatLabel('imax_70mm')).toBe('IMAX 70MM');
+		expect(formatLabel('digital')).toBe('DIGITAL');
+	});
+});
+
+describe('toCardScreening', () => {
+	it('adapts a raw API screening', () => {
+		expect(
+			toCardScreening({
+				id: 's1',
+				datetime: '2026-06-06T18:00:00Z',
+				format: '35mm',
+				bookingUrl: 'https://example.com/book',
+				cinema: { id: 'pcc', name: 'Prince Charles Cinema', shortName: 'PCC' }
+			})
+		).toEqual({
+			id: 's1',
+			datetime: '2026-06-06T18:00:00Z',
+			cinemaName: 'Prince Charles Cinema',
+			cinemaSlug: 'pcc',
+			format: '35mm',
+			bookingUrl: 'https://example.com/book'
+		});
+	});
+
+	it('falls back gracefully when cinema is null', () => {
+		const out = toCardScreening({ id: 's2', datetime: '2026-06-06T18:00:00Z', cinema: null });
+		expect(out.cinemaName).toBe('Unknown');
+		expect(out.cinemaSlug).toBe('');
+		expect(out.format).toBeNull();
+	});
+});

--- a/frontend/src/lib/components/calendar/card-shapes.ts
+++ b/frontend/src/lib/components/calendar/card-shapes.ts
@@ -63,3 +63,14 @@ export function toCardScreening(s: SourceScreening): CardScreening {
 		bookingUrl: s.bookingUrl
 	};
 }
+
+/**
+ * Display label for a screening format. `unknown` and `dcp` are the default
+ * projection values most venues report — they carry no signal, so they render
+ * as nothing rather than as noise on every row. Underscores become spaces
+ * (`SEVENTY_MM` → `SEVENTY MM`), output is uppercased.
+ */
+export function formatLabel(format: string | null | undefined): string {
+	if (!format || format === 'unknown' || format === 'dcp') return '';
+	return format.toUpperCase().replace('_', ' ');
+}


### PR DESCRIPTION
## Summary
- `FigmaFilmCard`/`FigmaTextDay` re-declared inline `Film`/`Screening` interfaces — the exact field-by-field drift `card-shapes.ts` was created to prevent (flagged by the five-agent review of #646). Both now import `CardFilm`/`CardScreening`; their inline shapes were verified strict subsets, so this is behavior-preserving.
- Duplicated format-cleaning (`unknown`/`dcp` filter, `_`→space, uppercase) extracted to one `formatLabel()` in `card-shapes.ts` — semantics verified identical to both replaced implementations, including the first-underscore-only quirk.
- New `card-shapes.test.ts` (4 tests).

## Test plan
- [x] svelte-check: 0 errors
- [x] vitest: 71/71 (4 new)
- [x] Browser: poster mode (62 cards, format chips) + text mode (315 rows) render on dev server
- [x] Pre-PR code-reviewer agent: zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)