### PR TITLE
fix: make mobile filter sheet accessible

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-06-10: Mobile filter sheet gains real focus management and cinema search
+**Files**: `frontend/src/lib/components/filters/MobileFilterSheet.svelte`, `frontend/src/lib/components/filters/FigmaToolbar.svelte`, `frontend/src/routes/+page.svelte`, `frontend/src/lib/utils.ts`, `frontend/tests/mobile.spec.ts`
+- The mobile filter sheet and nested date picker now move, trap, and restore keyboard focus correctly.
+- Replaced the decorative cinema-search row with a labeled search input and selectable matching cinema results.
+
+---
+
 ## 2026-06-10: Frontend filter vocabulary consolidated and dead filter components removed
 **Files**: `frontend/src/lib/constants/filters.ts`, `frontend/src/lib/components/filters/FigmaToolbar.svelte`, `frontend/src/lib/components/filters/MobileFilterSheet.svelte`, `frontend/src/lib/search/vocab/formats.ts`, three deleted filter components
 - Desktop and mobile filter surfaces now share canonical genre, decade, and format options. “Sci-fi” stores `science fiction`, Animation is available everywhere, and 4K stores the valid `dcp_4k` screening format.

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-06-10: Mobile filter sheet gains real focus management and cinema search
-**Files**: `frontend/src/lib/components/filters/MobileFilterSheet.svelte`, `frontend/src/lib/components/filters/FigmaToolbar.svelte`, `frontend/src/routes/+page.svelte`, `frontend/src/lib/utils.ts`, `frontend/tests/mobile.spec.ts`
+**PR**: #656 | **Files**: `frontend/src/lib/components/filters/MobileFilterSheet.svelte`, `frontend/src/lib/components/filters/FigmaToolbar.svelte`, `frontend/src/routes/+page.svelte`, `frontend/src/lib/utils.ts`, `frontend/tests/mobile.spec.ts`
 - The mobile filter sheet and nested date picker now move, trap, and restore keyboard focus correctly.
 - Replaced the decorative cinema-search row with a labeled search input and selectable matching cinema results.
 

--- a/changelogs/2026-06-10-mobile-filter-sheet-accessibility.md
+++ b/changelogs/2026-06-10-mobile-filter-sheet-accessibility.md
@@ -1,0 +1,15 @@
+# Mobile Filter Sheet Accessibility
+
+**PR**: TBD
+**Date**: 2026-06-10
+
+## Changes
+- Added initial focus, focus trapping, Escape handling, and trigger-focus restoration to the mobile filter sheet.
+- Added an independent focus lifecycle for the nested date-picker dialog.
+- Passed explicit opener elements into both modal focus traps so restoration also works in touch-mode browsers that do not focus clicked buttons.
+- Replaced the decorative cinema-search row with a labeled search input and selectable matching cinema results.
+- Added mobile Playwright coverage for modal focus behavior, nested-dialog focus restoration, and cinema search.
+
+## Impact
+- Keyboard and assistive-technology users can operate the mobile filter sheet without focus escaping behind the modal.
+- Mobile users can now search for and select individual cinemas from the filter sheet.

--- a/changelogs/2026-06-10-mobile-filter-sheet-accessibility.md
+++ b/changelogs/2026-06-10-mobile-filter-sheet-accessibility.md
@@ -1,6 +1,6 @@
 # Mobile Filter Sheet Accessibility
 
-**PR**: TBD
+**PR**: #656
 **Date**: 2026-06-10
 
 ## Changes

--- a/frontend/src/lib/components/filters/FigmaToolbar.svelte
+++ b/frontend/src/lib/components/filters/FigmaToolbar.svelte
@@ -30,7 +30,7 @@
 		cinemas?: FilterCinema[];
 		displayMode?: DisplayMode;
 		onDisplayModeChange?: (m: DisplayMode) => void;
-		onOpenFilters?: () => void;
+		onOpenFilters?: (trigger: HTMLButtonElement) => void;
 	} = $props();
 
 	// — Mobile FILTERS chip: count of active non-search, non-date filters —
@@ -333,7 +333,7 @@
 				type="button"
 				class="chip chip-full chip-mobile-filters"
 				class:active={mobileFilterCount > 0}
-				onclick={() => onOpenFilters?.()}
+				onclick={(event) => onOpenFilters?.(event.currentTarget)}
 				aria-label="Open filters"
 			>
 				<span class="chip-label">

--- a/frontend/src/lib/components/filters/MobileFilterSheet.svelte
+++ b/frontend/src/lib/components/filters/MobileFilterSheet.svelte
@@ -21,22 +21,46 @@
 		cinemas = [],
 		filmCount = 0,
 		open,
-		onClose
+		onClose,
+		returnFocusTo
 	}: {
 		cinemas?: SheetCinema[];
 		filmCount?: number;
 		open: boolean;
 		onClose: () => void;
+		returnFocusTo?: HTMLElement;
 	} = $props();
 
 	let datePickerOpen = $state(false);
+	let cinemaSearch = $state('');
+	let sheetEl = $state<HTMLDivElement>();
+	let dateDialogEl = $state<HTMLDivElement>();
+	let datePickerTriggerEl = $state<HTMLButtonElement>();
 
-	// Modal a11y — Escape closes the sheet and body scroll is locked while
-	// it's open. The shared helper handles both concerns and restores prior
-	// `body.style.overflow` on close.
+	function closeSheet() {
+		datePickerOpen = false;
+		cinemaSearch = '';
+		onClose();
+	}
+
+	function closeDatePicker() {
+		datePickerOpen = false;
+	}
+
 	$effect(() => {
-		if (!open) return;
-		return useModalKeyboardTrap(onClose);
+		if (!open || !sheetEl) return;
+		return useModalKeyboardTrap(sheetEl, closeSheet, {
+			isActive: () => !datePickerOpen,
+			returnFocusTo
+		});
+	});
+
+	$effect(() => {
+		if (!datePickerOpen || !dateDialogEl) return;
+		return useModalKeyboardTrap(dateDialogEl, closeDatePicker, {
+			lockBodyScroll: false,
+			returnFocusTo: datePickerTriggerEl
+		});
 	});
 
 	// Area cluster definitions + helpers live in `./area-clusters` so the
@@ -65,6 +89,15 @@
 			? filters.cinemaIds.filter((id) => !ids.includes(id))
 			: Array.from(new Set([...filters.cinemaIds, ...ids]));
 	}
+	const matchingCinemas = $derived.by(() => {
+		const query = cinemaSearch.trim().toLocaleLowerCase('en-GB');
+		if (!query) return [];
+		return cinemas.filter((cinema) =>
+			[cinema.name, cinema.shortName]
+				.filter((name): name is string => Boolean(name))
+				.some((name) => name.toLocaleLowerCase('en-GB').includes(query))
+		);
+	});
 
 	// "Within 2 miles" — browser geolocation required.
 	const WITHIN_RADIUS = 2;
@@ -160,10 +193,17 @@
 </script>
 
 {#if open}
-	<div class="sheet" role="dialog" aria-label="Filter programme" aria-modal="true">
+	<div
+		bind:this={sheetEl}
+		class="sheet"
+		role="dialog"
+		aria-label="Filter programme"
+		aria-modal="true"
+		tabindex="-1"
+	>
 		<header class="sheet-head">
 			<h2 class="sheet-title">Filter</h2>
-			<button class="close" onclick={onClose} aria-label="Close filters" type="button">×</button>
+			<button class="close" onclick={closeSheet} aria-label="Close filters" type="button">×</button>
 		</header>
 
 		<div class="sheet-body">
@@ -173,13 +213,44 @@
 					<h4>Where</h4>
 					<span class="hint">anywhere in London</span>
 				</div>
-				<div class="mini-search">
+				<label class="mini-search">
 					<svg width="11" height="11" viewBox="0 0 14 14" aria-hidden="true">
 						<circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.2" fill="none"/>
 						<path d="M9.5 9.5L13 13" stroke="currentColor" stroke-width="1.2"/>
 					</svg>
-					<span>Search cinemas by name…</span>
-				</div>
+					<input
+						type="search"
+						autocomplete="off"
+						placeholder="Search cinemas by name…"
+						aria-label="Search cinemas by name"
+						bind:value={cinemaSearch}
+					/>
+				</label>
+				{#if cinemaSearch.trim()}
+					<div class="cinema-results">
+						<p class="sr-only" aria-live="polite">
+							{matchingCinemas.length} {matchingCinemas.length === 1 ? 'cinema' : 'cinemas'} found
+						</p>
+						{#if matchingCinemas.length > 0}
+							<div class="chips" aria-label="Cinema search results">
+								{#each matchingCinemas as cinema (cinema.id)}
+									{@const active = filters.cinemaIds.includes(cinema.id)}
+									<button
+										type="button"
+										class="chip"
+										class:active
+										onclick={() => filters.toggleCinema(cinema.id)}
+										aria-pressed={active}
+									>
+										{cinema.shortName ?? cinema.name}
+									</button>
+								{/each}
+							</div>
+						{:else}
+							<p class="cinema-empty">No cinemas found</p>
+						{/if}
+					</div>
+				{/if}
 				<div class="chips">
 					{#each AREA_CLUSTERS as cluster (cluster.label)}
 						{@const active = isAreaActive(cluster.label)}
@@ -208,7 +279,14 @@
 					<button type="button" class="chip" class:active={whenState === 'today'} onclick={() => pick(whenState === 'today' ? null : 'today')}>Today<span class="sub">{todayLabel} {todayDay}</span></button>
 					<button type="button" class="chip" class:active={whenState === 'tomorrow'} onclick={() => pick(whenState === 'tomorrow' ? null : 'tomorrow')}>Tomorrow<span class="sub">{tomorrowLabel} {tomorrowDay}</span></button>
 					<button type="button" class="chip" class:active={whenState === 'weekend'} onclick={() => pick(whenState === 'weekend' ? null : 'weekend')}>This weekend</button>
-					<button type="button" class="chip" onclick={() => (datePickerOpen = true)}>Pick a date</button>
+					<button
+						bind:this={datePickerTriggerEl}
+						type="button"
+						class="chip"
+						onclick={() => (datePickerOpen = true)}
+					>
+						Pick a date
+					</button>
 				</div>
 			</section>
 
@@ -266,7 +344,7 @@
 
 		<footer class="sheet-foot">
 			<button class="reset" type="button" onclick={() => filters.clearAll()}>Reset</button>
-			<button class="show" type="button" onclick={onClose}>
+			<button class="show" type="button" onclick={closeSheet}>
 				Show <span class="show-count">{filmCount}</span> films
 			</button>
 		</footer>
@@ -275,12 +353,20 @@
 
 {#if datePickerOpen}
 	<div
+		bind:this={dateDialogEl}
 		class="cal-overlay"
 		role="dialog"
 		aria-modal="true"
 		aria-label="Pick a date"
-		onclick={(e) => { if (e.target === e.currentTarget) datePickerOpen = false; }}
-		onkeydown={() => {}}
+		tabindex="-1"
+		onclick={(e) => { if (e.target === e.currentTarget) closeDatePicker(); }}
+		onkeydown={(e) => {
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				e.stopPropagation();
+				closeDatePicker();
+			}
+		}}
 	>
 		<div class="cal-wrap">
 			<CalendarPopover
@@ -290,9 +376,9 @@
 				onSelect={(iso) => {
 					filters.dateFrom = iso;
 					filters.dateTo = iso;
-					datePickerOpen = false;
+					closeDatePicker();
 				}}
-				onClose={() => (datePickerOpen = false)}
+				onClose={closeDatePicker}
 			/>
 		</div>
 	</div>
@@ -394,7 +480,7 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		padding: 10px 12px;
+		padding: 0 12px;
 		background: var(--color-surface);
 		border: 1px solid var(--color-border);
 		border-radius: 4px;
@@ -404,6 +490,30 @@
 		font-size: 13px;
 		font-weight: 500;
 		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+	.mini-search:focus-within { box-shadow: var(--shadow-brutalist-sm); }
+	.mini-search input {
+		width: 100%;
+		min-width: 0;
+		padding: 10px 0;
+		border: 0;
+		outline: 0;
+		background: transparent;
+		color: var(--color-text);
+		font: inherit;
+		letter-spacing: inherit;
+		text-transform: inherit;
+	}
+	.mini-search input::placeholder { color: var(--color-text-tertiary); opacity: 1; }
+	.cinema-results { margin-bottom: 12px; }
+	.cinema-empty {
+		margin: 0;
+		padding: 10px 12px;
+		color: var(--color-text-tertiary);
+		font-size: 12px;
+		font-weight: 500;
+		letter-spacing: 0.06em;
 		text-transform: uppercase;
 	}
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -209,30 +209,95 @@ export function toISODate(year: number, monthZeroIndexed: number, day: number): 
 	return `${year}-${padTwo(monthZeroIndexed + 1)}-${padTwo(day)}`;
 }
 
+const MODAL_FOCUSABLE_SELECTOR = [
+	'a[href]',
+	'button:not([disabled])',
+	'input:not([disabled])',
+	'select:not([disabled])',
+	'textarea:not([disabled])',
+	'[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+interface ModalKeyboardTrapOptions {
+	/** Lets a parent modal yield keyboard handling while a nested modal is open. */
+	isActive?: () => boolean;
+	lockBodyScroll?: boolean;
+	returnFocusTo?: HTMLElement;
+}
+
+function modalFocusableElements(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>(MODAL_FOCUSABLE_SELECTOR))
+		.filter((element) => element.getClientRects().length > 0 && element.getAttribute('aria-hidden') !== 'true');
+}
+
 /**
- * Run the standard mobile-modal a11y wiring while `open` is true:
- *   - Escape closes the modal.
- *   - Body scroll is locked (with the previous overflow restored on close).
- *
- * Returns a cleanup callback suitable for use inside a `$effect`. Designed for
- * reuse by modal surfaces such as `MobileFilterSheet`.
- *
- * @example
- *   $effect(() => {
- *     if (!open) return;
- *     return useModalKeyboardTrap(onClose);
- *   });
+ * Run the standard modal focus lifecycle while the modal is mounted:
+ *   - Move initial focus inside and trap Tab/Shift+Tab.
+ *   - Escape closes the active modal.
+ *   - Restore focus to the trigger on cleanup.
+ *   - Lock body scroll unless a nested modal delegates that to its parent.
  */
-export function useModalKeyboardTrap(onClose: () => void): () => void {
-	const handler = (e: KeyboardEvent) => {
-		if (e.key === 'Escape') onClose();
-	};
-	document.addEventListener('keydown', handler);
+export function useModalKeyboardTrap(
+	container: HTMLElement,
+	onClose: () => void,
+	options: ModalKeyboardTrapOptions = {}
+): () => void {
+	const trigger = options.returnFocusTo
+		?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+	const isActive = options.isActive ?? (() => true);
+	const lockBodyScroll = options.lockBodyScroll ?? true;
 	const prevOverflow = document.body.style.overflow;
-	document.body.style.overflow = 'hidden';
+
+	if (lockBodyScroll) document.body.style.overflow = 'hidden';
+
+	queueMicrotask(() => {
+		if (!isActive() || !container.isConnected) return;
+		(modalFocusableElements(container)[0] ?? container).focus({ preventScroll: true });
+	});
+
+	const handler = (event: KeyboardEvent) => {
+		if (!isActive()) return;
+
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			// Only the top-most active modal handles this Escape. Without this,
+			// closing a nested modal can make its parent active for later
+			// document listeners handling the same key event.
+			event.stopImmediatePropagation();
+			onClose();
+			return;
+		}
+
+		if (event.key !== 'Tab') return;
+
+		const focusable = modalFocusableElements(container);
+		if (focusable.length === 0) {
+			event.preventDefault();
+			container.focus({ preventScroll: true });
+			return;
+		}
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		const current = document.activeElement;
+
+		if (event.shiftKey && (current === first || !container.contains(current))) {
+			event.preventDefault();
+			last.focus({ preventScroll: true });
+		} else if (!event.shiftKey && (current === last || !container.contains(current))) {
+			event.preventDefault();
+			first.focus({ preventScroll: true });
+		}
+	};
+
+	document.addEventListener('keydown', handler);
+
 	return () => {
 		document.removeEventListener('keydown', handler);
-		document.body.style.overflow = prevOverflow;
+		if (lockBodyScroll) document.body.style.overflow = prevOverflow;
+		if (trigger?.isConnected) {
+			queueMicrotask(() => trigger.focus({ preventScroll: true }));
+		}
 	};
 }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -26,6 +26,7 @@
 	}>);
 
 	let mobileFilterOpen = $state(false);
+	let mobileFilterTrigger = $state<HTMLButtonElement>();
 	let displayMode = $state<DisplayMode>('posters');
 
 	// Lazy-load the mobile filter sheet on first open. It never renders until
@@ -222,7 +223,8 @@
 		{cinemas}
 		{displayMode}
 		onDisplayModeChange={(m) => (displayMode = m)}
-		onOpenFilters={() => {
+		onOpenFilters={(trigger) => {
+			mobileFilterTrigger = trigger;
 			if (MobileFilterSheet) {
 				mobileFilterOpen = true;
 				return;
@@ -317,6 +319,7 @@
 		filmCount={filmMap.size}
 		open={mobileFilterOpen}
 		onClose={() => (mobileFilterOpen = false)}
+		returnFocusTo={mobileFilterTrigger}
 	/>
 {/if}
 

--- a/frontend/tests/mobile.spec.ts
+++ b/frontend/tests/mobile.spec.ts
@@ -163,6 +163,24 @@ test.describe('Mobile Responsive — iPhone 12 Pro (390x844)', () => {
 			await expect(sheet).toBeHidden();
 		});
 
+		test('filter sheet traps focus and restores it to the trigger', async ({ page }) => {
+			await gotoHomeHydrated(page);
+			const trigger = page.getByRole('button', { name: 'Open filters' });
+			const sheet = await openFilterSheet(page);
+			const close = page.getByRole('button', { name: 'Close filters' });
+			const show = sheet.locator('.show');
+
+			await expect(close).toBeFocused();
+			await page.keyboard.press('Shift+Tab');
+			await expect(show).toBeFocused();
+			await page.keyboard.press('Tab');
+			await expect(close).toBeFocused();
+
+			await close.click();
+			await expect(sheet).toBeHidden();
+			await expect(trigger).toBeFocused();
+		});
+
 		test('Escape key dismisses the filter sheet', async ({ page }) => {
 			await gotoHomeHydrated(page);
 			const sheet = await openFilterSheet(page);
@@ -182,11 +200,36 @@ test.describe('Mobile Responsive — iPhone 12 Pro (390x844)', () => {
 			expect(restored).toBe(prev);
 		});
 
+		test('cinema search exposes selectable matching cinemas', async ({ page }) => {
+			await gotoHomeHydrated(page);
+			const sheet = await openFilterSheet(page);
+			await sheet.getByRole('searchbox', { name: 'Search cinemas by name' }).fill('Curzon');
+
+			const results = sheet.locator('.cinema-results .chip');
+			await expect(results.first()).toBeVisible();
+			expect(await results.count()).toBeGreaterThan(0);
+
+			const labels = await results.allTextContents();
+			expect(labels.every((label) => label.toLowerCase().includes('curzon'))).toBe(true);
+
+			await results.first().click();
+			await expect(results.first()).toHaveAttribute('aria-pressed', 'true');
+		});
+
 		test('Pick a date chip inside sheet opens mobile date picker', async ({ page }) => {
 			await gotoHomeHydrated(page);
-			await openFilterSheet(page);
-			await page.getByRole('button', { name: 'Pick a date' }).click();
-			await expect(page.getByRole('dialog', { name: 'Pick a date' })).toBeVisible();
+			const sheet = await openFilterSheet(page);
+			const trigger = sheet.getByRole('button', { name: 'Pick a date' });
+			await trigger.click();
+
+			const datePicker = page.getByRole('dialog', { name: 'Pick a date' });
+			await expect(datePicker).toBeVisible();
+			await expect(datePicker.getByRole('button', { name: 'Previous month' })).toBeFocused();
+
+			await page.keyboard.press('Escape');
+			await expect(datePicker).toBeHidden();
+			await expect(trigger).toBeFocused();
+			await expect(sheet).toBeVisible();
 		});
 	});
 


### PR DESCRIPTION
## Summary
- add initial focus, Tab trapping, Escape handling, and explicit trigger-focus restoration to the mobile filter sheet
- give the nested date picker an independent focus lifecycle without closing its parent dialog
- replace the decorative cinema-search row with a labeled, functional cinema selector

## Verification
- frontend npm test: 78 passed
- frontend npm run check: 0 errors, 2 pre-existing warnings
- focused mobile Playwright filter-sheet suite: 14 passed
- production client/SSR bundles compiled; prerender stopped at the existing isolated-worktree /about fetch failure
- full mobile Playwright run: changed cases passed; 55 passed, 4 skipped, 2 unrelated mobile-navigation flakes remained after retries

## Audit
Addresses quality-frontend-8 from the 2026-06-09 security and quality review.