### PR TITLE
fix(scrape): run-level circuit breaker + per-venue wall-clock cap (plan 001)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-06-12: Scrape circuit breaker and per-venue wall-clock cap
+**PR**: pending | **Files**: `src/lib/jobs/scrape-all.ts`, `src/scrapers/runner-factory.ts`, `src/lib/jobs/scrape-all.test.ts`, `src/scrapers/runner-factory.test.ts`
+- Added a run-level circuit breaker to the scrape orchestrator: after 3 consecutive connection-level scraper failures (override via `SCRAPE_BREAKER_THRESHOLD`) the run aborts, remaining scrapers and enrichment are skipped, and a Telegram alert fires.
+- Added a hard per-venue wall-clock cap (default 10 min, override via `SCRAPE_VENUE_TIMEOUT_MS`) around the entire venue unit — scrape, pipeline phases, retries — so awaits not covered by `withDbTimeout` can no longer wedge the run; chain scrapers get the cap scaled by venue count.
+- Why: on 2026-06-09 a wedged Supabase pooler turned four venue scrapes into 13.4h retry loops and took the production DB offline for 13.7h; on 2026-06-11 two runs hung 50/25 min on inter-phase awaits. A wedged DB now costs minutes, not hours.
+
+---
+
 ## 2026-06-12: Scrape accuracy audit — handoff plans 004–010
 **PR**: TBD | **Files**: `plans/HANDOFF-2026-06-11.md`, `plans/004-…010-*.md`, `plans/README.md`
 - Master handoff report + seven self-contained implementation plans from the 2026-06-11 live `/scrape` run and four-way audit (TMDB matching, Letterboxd, scraper metadata, live-DB evidence).

--- a/changelogs/2026-06-12-scrape-circuit-breaker.md
+++ b/changelogs/2026-06-12-scrape-circuit-breaker.md
@@ -1,0 +1,71 @@
+# Scrape Circuit Breaker and Per-Venue Wall-Clock Cap
+
+**PR**: pending
+**Date**: 2026-06-12
+**Plan**: `plans/001-scrape-run-circuit-breaker.md`
+
+## Changes
+
+### Run-level circuit breaker (`src/lib/jobs/scrape-all.ts`)
+- New `createRunBreaker(threshold, onTrip)`: tracks consecutive connection-level
+  scraper failures across all waves. Default threshold 3, override via
+  `SCRAPE_BREAKER_THRESHOLD` (floored at 1).
+- `runWithConcurrency` now accepts a `shouldStop` callback. Once the breaker
+  trips, workers stop pulling new tasks and unstarted entries are recorded as
+  rejected with reason `circuit breaker tripped`.
+- `runScraperEntry` feeds the breaker after every entry: connection errors
+  (detected from per-venue error messages and the thrown-error path) increment
+  the consecutive counter; any success or ordinary site failure resets it to 0.
+- Tripping emits a structured console error and a Telegram alert naming the
+  failure count and the last failing cinema. Subsequent waves and the
+  enrichment wave are skipped once tripped (they would only hammer the same
+  wedged database).
+
+### Per-venue wall-clock cap (`src/scrapers/runner-factory.ts`)
+- New exported `isConnectionError(err)`: classifies DB connection/pooler
+  failures (client-side timeouts, `ECONNREFUSED`, pool exhaustion, Postgres
+  `57014`, terminated connections) as non-retryable at run level, distinct
+  from ordinary per-site scrape errors.
+- New hard wall-clock cap around the entire venue unit (`runSingleVenue`:
+  health check, scrape, pipeline phases including `cleanup-superseded`, and
+  all retries). Default 10 minutes; override via `SCRAPE_VENUE_TIMEOUT_MS`
+  (floored at 60s). On expiry the venue is recorded as a failed scraper run
+  and the loop continues to the next venue.
+- Chain scrapers (`scrapeVenues` fetches all venues in one call) get the same
+  cap scaled by venue count; a timeout flows into the existing chain catch
+  that marks all requested venues failed.
+- The cap's error message intentionally contains "timeout" so capped venues
+  count toward the run-level breaker.
+
+### Tests
+- `src/scrapers/runner-factory.test.ts` (new): `isConnectionError`
+  classification (connection vs site errors vs non-Error values) and a
+  fake-timer test proving a venue wedged forever is aborted at the cap while
+  the next venue still runs.
+- `src/lib/jobs/scrape-all.test.ts` (new): breaker trips after K consecutive
+  connection failures, resets on interleaved success, ignores ordinary site
+  failures, and `runWithConcurrency` stops pulling tasks once tripped while
+  recording the remainder as `circuit breaker tripped`.
+
+## Impact
+- **Operators**: a `/scrape` run against a wedged Supabase pooler now aborts
+  in minutes with a Telegram alert, instead of the 13.7-hour cascade of
+  2026-06-09 (four venues looping ~13.4h each, pooler slots exhausted,
+  production DB offline) or the 50/25-minute silent hangs of 2026-06-11.
+- **Data**: no behavioural change for healthy runs — successful venues and
+  ordinary site failures behave exactly as before; the breaker counter resets
+  on any non-connection outcome.
+- **Tuning knobs**: `SCRAPE_VENUE_TIMEOUT_MS` (per-venue cap, min 60s) and
+  `SCRAPE_BREAKER_THRESHOLD` (consecutive connection failures before abort).
+
+## Context
+- The 2026-06-11 wedge happened on an await *between* pipeline phases (after
+  the film loop, before `cleanup-superseded`) with zero log output for 50
+  minutes. That code path runs inside `processScreenings`, which is called
+  from `runSingleVenue` — i.e. inside the new venue cap — so the watchdog
+  requirement is covered by the cap for single/multi-venue scrapers. For
+  chain scrapers, post-`scrapeVenues` per-venue pipeline processing sits
+  outside the scaled chain cap; its inner DB calls remain bounded by
+  `withDbTimeout` only (noted as a residual gap).
+- `src/db/index.ts` (`withDbTimeout`, pool settings) intentionally untouched —
+  the breaker and cap are separate layers above the per-query ceiling.

--- a/plans/README.md
+++ b/plans/README.md
@@ -19,7 +19,7 @@ Recommended order: 004 → 001 (+002/003) → 005 → 006 ∥ 007 → 008 → 00
 | Plan | Title | Priority | Effort | Depends on | Status |
 |------|-------|----------|--------|------------|--------|
 | 004 | Enrich run + production data repairs (operational) | P0 | S–M | — | TODO |
-| 001 | Scrape run-level circuit breaker + per-venue wall-clock cap | P1 | M | — | TODO |
+| 001 | Scrape run-level circuit breaker + per-venue wall-clock cap | P1 | M | — | DONE (pending PR) |
 | 002 | Consolidate behaviorally-equivalent `normalizeTitle` copies | P2 | M | — | TODO |
 | 003 | Eliminate per-film N+1 queries in the season linker | P2 | M | 002 | TODO |
 | 005 | TMDB matcher: audit trail, year discipline, runtime/director/language signals | P1 | L | — | TODO |

--- a/src/lib/jobs/scrape-all.test.ts
+++ b/src/lib/jobs/scrape-all.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/scrape-progress", () => ({
   stampProgress: vi.fn(async () => {}),
 }));
 
-import { createRunBreaker, runWithConcurrency } from "./scrape-all";
+import { breakerOutcomeFor, createRunBreaker, runWithConcurrency } from "./scrape-all";
 
 const CONN_ERROR = "getOrCreateFilm: Film X timeout after 20000ms (client-side)";
 const SITE_ERROR = "Health check failed - site not accessible";
@@ -71,6 +71,51 @@ describe("createRunBreaker", () => {
     breaker.record("cinema-d", { succeeded: false, errors: [CONN_ERROR] });
     breaker.record("cinema-e", { succeeded: false, errors: [CONN_ERROR] });
 
+    expect(breaker.isTripped()).toBe(false);
+  });
+});
+
+describe("breakerOutcomeFor (entry → breaker seam)", () => {
+  it("treats a failed entry that still wrote screenings as breaker-success", () => {
+    // 12-venue chain, 11 ok + 1 site timeout: the DB demonstrably works.
+    const outcome = breakerOutcomeFor({
+      success: false,
+      totalScreeningsAdded: 14,
+      totalScreeningsUpdated: 230,
+      venueResults: [
+        { success: true },
+        { success: false, error: "page.goto: Timeout 30000ms exceeded" },
+      ],
+    });
+    expect(outcome.succeeded).toBe(true);
+  });
+
+  it("feeds a zero-write failure's errors to the breaker, and a wall-clock-capped venue counts toward a trip", () => {
+    const capError = "Venue rio-dalston timeout after 600000ms (venue wall-clock cap)";
+    const outcome = breakerOutcomeFor({
+      success: false,
+      totalScreeningsAdded: 0,
+      totalScreeningsUpdated: 0,
+      venueResults: [{ success: false, error: capError }],
+    });
+    expect(outcome).toEqual({ succeeded: false, errors: [capError] });
+
+    const breaker = createRunBreaker(3);
+    breaker.record("a", outcome);
+    breaker.record("b", outcome);
+    breaker.record("c", outcome);
+    expect(breaker.isTripped()).toBe(true);
+  });
+
+  it("does not let a venue-website nav timeout count toward the breaker", () => {
+    const outcome = breakerOutcomeFor({
+      success: false,
+      totalScreeningsAdded: 0,
+      totalScreeningsUpdated: 0,
+      venueResults: [{ success: false, error: "page.goto: Timeout 30000ms exceeded" }],
+    });
+    const breaker = createRunBreaker(1);
+    breaker.record("a", outcome);
     expect(breaker.isTripped()).toBe(false);
   });
 });

--- a/src/lib/jobs/scrape-all.test.ts
+++ b/src/lib/jobs/scrape-all.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the scrape-all run-level circuit breaker (plan 001).
+ *
+ * Exercises createRunBreaker + runWithConcurrency directly with synthetic
+ * tasks — the same machinery runScrapeAll threads through its waves.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// scrape-all imports the DB, registry, and runner factory at module level.
+// None of them should touch real infrastructure in unit tests.
+vi.mock("@/db", () => ({
+  db: {},
+  isDatabaseAvailable: false,
+  withDbTimeout: <T>(p: Promise<T>) => p,
+  schema: {},
+}));
+vi.mock("@/scrapers/pipeline", () => ({
+  processScreenings: vi.fn(),
+  saveScreenings: vi.fn(),
+  ensureCinemaExists: vi.fn(),
+}));
+vi.mock("@/scrapers/registry", () => ({
+  SCRAPER_REGISTRY: [],
+}));
+vi.mock("@/lib/telegram", () => ({
+  sendTelegramAlert: vi.fn(async () => true),
+}));
+vi.mock("@/lib/scrape-progress", () => ({
+  stampProgress: vi.fn(async () => {}),
+}));
+
+import { createRunBreaker, runWithConcurrency } from "./scrape-all";
+
+const CONN_ERROR = "getOrCreateFilm: Film X timeout after 20000ms (client-side)";
+const SITE_ERROR = "Health check failed - site not accessible";
+
+describe("createRunBreaker", () => {
+  it("trips after K consecutive connection failures", () => {
+    const onTrip = vi.fn();
+    const breaker = createRunBreaker(3, onTrip);
+
+    breaker.record("cinema-a", { succeeded: false, errors: [CONN_ERROR] });
+    breaker.record("cinema-b", { succeeded: false, errors: [CONN_ERROR] });
+    expect(breaker.isTripped()).toBe(false);
+
+    breaker.record("cinema-c", { succeeded: false, errors: [CONN_ERROR] });
+    expect(breaker.isTripped()).toBe(true);
+    expect(onTrip).toHaveBeenCalledTimes(1);
+    expect(onTrip).toHaveBeenCalledWith("cinema-c", 3, CONN_ERROR);
+  });
+
+  it("resets the counter on an interleaved success", () => {
+    const breaker = createRunBreaker(3);
+
+    breaker.record("cinema-a", { succeeded: false, errors: [CONN_ERROR] });
+    breaker.record("cinema-b", { succeeded: false, errors: [CONN_ERROR] });
+    breaker.record("cinema-c", { succeeded: true });
+    breaker.record("cinema-d", { succeeded: false, errors: [CONN_ERROR] });
+    breaker.record("cinema-e", { succeeded: false, errors: [CONN_ERROR] });
+
+    expect(breaker.isTripped()).toBe(false);
+  });
+
+  it("does not count ordinary site failures toward the breaker", () => {
+    const breaker = createRunBreaker(3);
+
+    breaker.record("cinema-a", { succeeded: false, errors: [CONN_ERROR] });
+    breaker.record("cinema-b", { succeeded: false, errors: [CONN_ERROR] });
+    // A normal scrape failure resets the consecutive-connection count.
+    breaker.record("cinema-c", { succeeded: false, errors: [SITE_ERROR] });
+    breaker.record("cinema-d", { succeeded: false, errors: [CONN_ERROR] });
+    breaker.record("cinema-e", { succeeded: false, errors: [CONN_ERROR] });
+
+    expect(breaker.isTripped()).toBe(false);
+  });
+});
+
+describe("runWithConcurrency with a breaker", () => {
+  it("stops pulling new tasks once tripped and records the rest as tripped", async () => {
+    const breaker = createRunBreaker(3);
+    const started: number[] = [];
+
+    const tasks = Array.from({ length: 6 }, (_, i) => async () => {
+      started.push(i);
+      breaker.record(`cinema-${i}`, { succeeded: false, errors: [CONN_ERROR] });
+      return { succeeded: false as const };
+    });
+
+    // limit 1 → deterministic sequential order
+    const results = await runWithConcurrency(tasks, 1, breaker.isTripped);
+
+    expect(started).toEqual([0, 1, 2]);
+    expect(breaker.isTripped()).toBe(true);
+    expect(results).toHaveLength(6);
+    for (const i of [0, 1, 2]) {
+      expect(results[i].status).toBe("fulfilled");
+    }
+    for (const i of [3, 4, 5]) {
+      const r = results[i];
+      expect(r.status).toBe("rejected");
+      if (r.status === "rejected") {
+        expect(String(r.reason)).toMatch(/circuit breaker tripped/);
+      }
+    }
+  });
+
+  it("completes all tasks when the breaker never trips", async () => {
+    const breaker = createRunBreaker(3);
+    const started: number[] = [];
+
+    const tasks = Array.from({ length: 4 }, (_, i) => async () => {
+      started.push(i);
+      // connection failure followed by a success resets the counter
+      breaker.record(
+        `cinema-${i}`,
+        i % 2 === 0 ? { succeeded: false, errors: [CONN_ERROR] } : { succeeded: true },
+      );
+      return { succeeded: true as const };
+    });
+
+    const results = await runWithConcurrency(tasks, 2, breaker.isTripped);
+
+    expect(started.sort()).toEqual([0, 1, 2, 3]);
+    expect(breaker.isTripped()).toBe(false);
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+  });
+});

--- a/src/lib/jobs/scrape-all.ts
+++ b/src/lib/jobs/scrape-all.ts
@@ -98,9 +98,13 @@ interface WaveSummary {
  * Breaker threshold K: abort the run after K consecutive connection-level
  * scraper failures. Default 3; override via SCRAPE_BREAKER_THRESHOLD.
  */
-const BREAKER_THRESHOLD = process.env.SCRAPE_BREAKER_THRESHOLD
-  ? Math.max(1, Number(process.env.SCRAPE_BREAKER_THRESHOLD))
-  : 3;
+const BREAKER_THRESHOLD = (() => {
+  const parsed = Number(process.env.SCRAPE_BREAKER_THRESHOLD);
+  // A malformed value must fall back to the default, never NaN — a NaN
+  // threshold makes `consecutive >= NaN` always false, silently disabling
+  // the breaker.
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : 3;
+})();
 
 /** Run-scoped circuit breaker shared across all scrape waves. */
 export interface RunBreaker {
@@ -117,9 +121,12 @@ export interface RunBreaker {
 /**
  * Create a run-level circuit breaker. After 2026-06-09's 13.7h stall (a
  * wedged Supabase pooler turned four venue scrapes into futile 13.4h retry
- * loops and took the whole DB offline), a run with a dead DB must abort in
- * minutes: K consecutive connection failures trip the breaker and the
- * remaining scrapers are skipped.
+ * loops and took the whole DB offline), K consecutive connection failures
+ * trip the breaker and the remaining scrapers + enrichment are skipped.
+ * Worst-case time-to-trip is bounded by the venue wall-clock caps of the
+ * entries in flight (a chain-heavy first wave can take a couple of hours,
+ * since each entry only records its outcome on completion) — a huge
+ * improvement on 13.7h, but not literally "minutes" in every shape of run.
  *
  * NOTE: the counter is mutated cooperatively by the wave worker pool
  * (concurrency cap 4) — fine single-threaded; revisit if scraping ever
@@ -194,6 +201,34 @@ export async function runWithConcurrency<T>(
 }
 
 /** Run a single scraper-registry entry and return wave-summary contribution. */
+/**
+ * Compute the breaker outcome for a completed scraper entry.
+ *
+ * Any write proves the DB is alive — a wedged pooler can't write — so a
+ * 12-venue chain with 11 successes and one site timeout counts as
+ * breaker-success, not as a consecutive connection failure. Only entries
+ * that failed AND wrote nothing feed their per-venue error messages to the
+ * breaker (where isConnectionError decides if they count).
+ *
+ * Exported for tests: this is the seam between runScraper's results and the
+ * run-level circuit breaker.
+ */
+export function breakerOutcomeFor(result: {
+  success: boolean;
+  totalScreeningsAdded: number;
+  totalScreeningsUpdated: number;
+  venueResults: Array<{ success: boolean; error?: string }>;
+}): { succeeded: boolean; errors: string[] } {
+  return {
+    succeeded:
+      result.success ||
+      result.totalScreeningsAdded + result.totalScreeningsUpdated > 0,
+    errors: result.venueResults
+      .filter((v) => !v.success && v.error)
+      .map((v) => v.error as string),
+  };
+}
+
 async function runScraperEntry(
   entry: ScraperRegistryEntry,
   waveLabel: string,
@@ -233,12 +268,7 @@ async function runScraperEntry(
     // Feed the circuit breaker: runScraper rarely throws (venue failures —
     // including wall-clock-cap timeouts — are folded into venueResults), so
     // connection errors must be detected from the per-venue error messages.
-    breaker?.record(taskId, {
-      succeeded: result.success,
-      errors: result.venueResults
-        .filter((v) => !v.success && v.error)
-        .map((v) => v.error as string),
-    });
+    breaker?.record(taskId, breakerOutcomeFor(result));
     return { succeeded: result.success };
   } catch (err) {
     const ms = Date.now() - startedAt.getTime();

--- a/src/lib/jobs/scrape-all.ts
+++ b/src/lib/jobs/scrape-all.ts
@@ -24,7 +24,7 @@ import { cinemas } from "@/db/schema/cinemas";
 import { screenings } from "@/db/schema/screenings";
 import { sendTelegramAlert } from "@/lib/telegram";
 import { stampProgress } from "@/lib/scrape-progress";
-import { runScraper } from "@/scrapers/runner-factory";
+import { runScraper, isConnectionError } from "@/scrapers/runner-factory";
 import {
   SCRAPER_REGISTRY,
   type ScraperRegistryEntry,
@@ -90,19 +90,86 @@ interface WaveSummary {
   total: number;
 }
 
+// ============================================================================
+// Run-level circuit breaker (plan 001)
+// ============================================================================
+
+/**
+ * Breaker threshold K: abort the run after K consecutive connection-level
+ * scraper failures. Default 3; override via SCRAPE_BREAKER_THRESHOLD.
+ */
+const BREAKER_THRESHOLD = process.env.SCRAPE_BREAKER_THRESHOLD
+  ? Math.max(1, Number(process.env.SCRAPE_BREAKER_THRESHOLD))
+  : 3;
+
+/** Run-scoped circuit breaker shared across all scrape waves. */
+export interface RunBreaker {
+  /** True once the breaker has tripped — workers stop pulling new tasks. */
+  isTripped: () => boolean;
+  /**
+   * Record one scraper-entry outcome. Connection-level failures (see
+   * isConnectionError) increment the consecutive-failure counter; any
+   * success or ordinary site failure resets it to 0.
+   */
+  record: (source: string, outcome: { succeeded: boolean; errors?: string[] }) => void;
+}
+
+/**
+ * Create a run-level circuit breaker. After 2026-06-09's 13.7h stall (a
+ * wedged Supabase pooler turned four venue scrapes into futile 13.4h retry
+ * loops and took the whole DB offline), a run with a dead DB must abort in
+ * minutes: K consecutive connection failures trip the breaker and the
+ * remaining scrapers are skipped.
+ *
+ * NOTE: the counter is mutated cooperatively by the wave worker pool
+ * (concurrency cap 4) — fine single-threaded; revisit if scraping ever
+ * moves to true parallelism.
+ */
+export function createRunBreaker(
+  threshold: number = BREAKER_THRESHOLD,
+  onTrip?: (source: string, count: number, lastError: string) => void,
+): RunBreaker {
+  let consecutive = 0;
+  let tripped = false;
+  return {
+    isTripped: () => tripped,
+    record(source, outcome) {
+      if (outcome.succeeded) {
+        consecutive = 0;
+        return;
+      }
+      const connError = (outcome.errors ?? []).find((e) => isConnectionError(e));
+      if (connError === undefined) {
+        consecutive = 0;
+        return;
+      }
+      consecutive++;
+      if (!tripped && consecutive >= threshold) {
+        tripped = true;
+        onTrip?.(source, consecutive, connError);
+      }
+    },
+  };
+}
+
 /**
  * Run an array of async tasks with a concurrency cap. Resolves once all
  * tasks settle — never rejects (errors are surfaced via task return values).
+ *
+ * If `shouldStop` returns true, workers stop pulling new tasks; entries that
+ * never started are recorded as rejected with "circuit breaker tripped".
  */
-async function runWithConcurrency<T>(
+export async function runWithConcurrency<T>(
   tasks: Array<() => Promise<T>>,
   limit: number,
+  shouldStop?: () => boolean,
 ): Promise<PromiseSettledResult<T>[]> {
   const results: PromiseSettledResult<T>[] = new Array(tasks.length);
   let cursor = 0;
 
   async function worker(): Promise<void> {
     while (true) {
+      if (shouldStop?.()) return;
       const idx = cursor++;
       if (idx >= tasks.length) return;
       try {
@@ -116,6 +183,13 @@ async function runWithConcurrency<T>(
 
   const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => worker());
   await Promise.all(workers);
+
+  // Mark tasks the breaker prevented from starting.
+  for (let i = 0; i < tasks.length; i++) {
+    if (results[i] === undefined) {
+      results[i] = { status: "rejected", reason: new Error("circuit breaker tripped") };
+    }
+  }
   return results;
 }
 
@@ -123,6 +197,7 @@ async function runWithConcurrency<T>(
 async function runScraperEntry(
   entry: ScraperRegistryEntry,
   waveLabel: string,
+  breaker?: RunBreaker,
 ): Promise<{ succeeded: boolean; error?: string }> {
   const taskId = entry.taskId.replace(/^scraper-/, "");
   const startedAt = new Date();
@@ -155,6 +230,15 @@ async function runScraperEntry(
         updated: result.totalScreeningsUpdated,
       },
     });
+    // Feed the circuit breaker: runScraper rarely throws (venue failures —
+    // including wall-clock-cap timeouts — are folded into venueResults), so
+    // connection errors must be detected from the per-venue error messages.
+    breaker?.record(taskId, {
+      succeeded: result.success,
+      errors: result.venueResults
+        .filter((v) => !v.success && v.error)
+        .map((v) => v.error as string),
+    });
     return { succeeded: result.success };
   } catch (err) {
     const ms = Date.now() - startedAt.getTime();
@@ -168,6 +252,7 @@ async function runScraperEntry(
       durationMs: ms,
       error: message,
     });
+    breaker?.record(taskId, { succeeded: false, errors: [message] });
     return { succeeded: false, error: message };
   }
 }
@@ -268,7 +353,13 @@ async function runWave(
   concurrency: number,
   freshness: FreshnessMap,
   countMap: ScreeningCountMap,
+  breaker: RunBreaker,
 ): Promise<WaveSummary> {
+  if (breaker.isTripped()) {
+    const count = SCRAPER_REGISTRY.filter((e) => e.wave === wave).length;
+    console.log(`[scrape-all] ${label}: skipped (circuit breaker tripped) — ${count} scrapers`);
+    return { label, succeeded: 0, failed: count, total: count };
+  }
   // Sort by screening count ASC (fewest first — broken scrapers surface fast),
   // staleness ASC as tiebreaker (preserve rotation when counts are equal).
   // Compute both keys once per entry; sort + log share the results.
@@ -289,8 +380,8 @@ async function runWave(
     console.log(`[scrape-all] ${label} order (fewest screenings, then stalest): ${orderStr}`);
   }
   const entries = ranked.map((r) => r.entry);
-  const tasks = entries.map((entry) => () => runScraperEntry(entry, label));
-  const settled = await runWithConcurrency(tasks, concurrency);
+  const tasks = entries.map((entry) => () => runScraperEntry(entry, label, breaker));
+  const settled = await runWithConcurrency(tasks, concurrency, breaker.isTripped);
 
   let succeeded = 0;
   let failed = 0;
@@ -360,6 +451,22 @@ export async function runScrapeAll(): Promise<ScrapeAllResult> {
   const startedAt = new Date(startTime);
   const waveSummaries: WaveSummary[] = [];
 
+  // Run-level circuit breaker: K consecutive connection failures abort the
+  // run in minutes instead of cascading into a multi-hour DB outage.
+  const breaker = createRunBreaker(BREAKER_THRESHOLD, (source, count, lastError) => {
+    console.error(
+      `[scrape-all] CIRCUIT BREAKER TRIPPED after ${count} consecutive connection failures ` +
+        `(last failing cinema: ${source} — ${lastError}). Skipping remaining scrapers.`,
+    );
+    void sendTelegramAlert({
+      title: "Scrape circuit breaker tripped",
+      message:
+        `${count} consecutive connection-level failures — aborting the run.\n` +
+        `Last failing cinema: ${source}\n${lastError}`,
+      level: "error",
+    }).catch(() => {});
+  });
+
   // Load sort signals once, up front. Within each wave, entries are sorted
   // fewest-screenings first (broken scrapers surface fast) with staleness as
   // a tiebreaker (preserves the rotation behaviour from commit 712ee16).
@@ -369,16 +476,22 @@ export async function runScrapeAll(): Promise<ScrapeAllResult> {
   ]);
 
   // Wave 1: Chain scrapers (3 — fully parallel)
-  waveSummaries.push(await runWave("chain", "Chains", 4, freshness, countMap));
+  waveSummaries.push(await runWave("chain", "Chains", 4, freshness, countMap, breaker));
 
   // Wave 2: Playwright independents (7 — cap at 4 for memory headroom)
-  waveSummaries.push(await runWave("playwright", "Playwright", 4, freshness, countMap));
+  waveSummaries.push(await runWave("playwright", "Playwright", 4, freshness, countMap, breaker));
 
   // Wave 3: Cheerio / API independents (16 — cap at 4 to mirror prior chunking)
-  waveSummaries.push(await runWave("cheerio", "Cheerio", 4, freshness, countMap));
+  waveSummaries.push(await runWave("cheerio", "Cheerio", 4, freshness, countMap, breaker));
 
-  // Wave 4: Post-scrape enrichment (Letterboxd ratings)
-  waveSummaries.push(await runEnrichmentWave());
+  // Wave 4: Post-scrape enrichment (Letterboxd ratings). Skipped when the
+  // breaker tripped — enrichment would only hammer the same wedged DB.
+  if (breaker.isTripped()) {
+    console.log("[scrape-all] Enrichment: skipped (circuit breaker tripped)");
+    waveSummaries.push({ label: "Enrichment", succeeded: 0, failed: 1, total: 1 });
+  } else {
+    waveSummaries.push(await runEnrichmentWave());
+  }
 
   const totalSucceeded = waveSummaries.reduce((s, w) => s + w.succeeded, 0);
   const totalFailed = waveSummaries.reduce((s, w) => s + w.failed, 0);

--- a/src/scrapers/runner-factory.test.ts
+++ b/src/scrapers/runner-factory.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for runner-factory: connection-error classification and the
+ * per-venue wall-clock cap (plan 001 — scrape circuit breaker).
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// Keep the runner away from any real database: recordScraperRun/getBaseline
+// short-circuit when isDatabaseAvailable is false.
+vi.mock("../db", () => ({
+  db: {},
+  isDatabaseAvailable: false,
+}));
+
+// The pipeline is exercised by its own tests; here we only need
+// deterministic stubs so runScraper can complete without a DB.
+vi.mock("./pipeline", () => ({
+  processScreenings: vi.fn(async (cinemaId: string, screenings: unknown[]) => ({
+    cinemaId,
+    added: screenings.length,
+    updated: 0,
+    failed: 0,
+    rejected: 0,
+    blocked: false,
+    scrapedAt: new Date(),
+  })),
+  saveScreenings: vi.fn(async () => ({ added: 0, blocked: false })),
+  ensureCinemaExists: vi.fn(async () => {}),
+}));
+
+import { isConnectionError } from "./runner-factory";
+
+describe("isConnectionError", () => {
+  it("classifies DB connection/pooler failures as connection errors", () => {
+    expect(
+      isConnectionError(
+        new Error("getOrCreateFilm: Some Film timeout after 20000ms (client-side)"),
+      ),
+    ).toBe(true);
+    expect(isConnectionError(new Error("connect ECONNREFUSED 1.2.3.4:5432"))).toBe(true);
+    expect(isConnectionError(new Error("Connection terminated unexpectedly"))).toBe(true);
+    expect(isConnectionError(new Error("remaining connection slots are reserved"))).toBe(true);
+    expect(isConnectionError(new Error("timeout exceeded when trying to connect"))).toBe(true);
+    expect(isConnectionError(new Error("max client connections reached (pool)"))).toBe(true);
+    expect(isConnectionError(new Error("canceling statement due to user request (57014)"))).toBe(
+      true,
+    );
+    expect(
+      isConnectionError(new Error("terminating connection due to administrator command")),
+    ).toBe(true);
+  });
+
+  it("does not classify ordinary scrape/site errors as connection errors", () => {
+    expect(isConnectionError(new Error("Found 0 screenings"))).toBe(false);
+    expect(isConnectionError(new Error("Health check failed - site not accessible"))).toBe(false);
+    expect(isConnectionError(new Error("scrape_blocked_by_diff_check"))).toBe(false);
+    expect(isConnectionError(new Error("Cloudflare challenge page detected"))).toBe(false);
+  });
+
+  it("handles non-Error values", () => {
+    expect(isConnectionError("ETIMEDOUT: socket timeout")).toBe(true);
+    expect(isConnectionError("no showtimes found")).toBe(false);
+    expect(isConnectionError(undefined)).toBe(false);
+  });
+});

--- a/src/scrapers/runner-factory.test.ts
+++ b/src/scrapers/runner-factory.test.ts
@@ -2,7 +2,7 @@
  * Tests for runner-factory: connection-error classification and the
  * per-venue wall-clock cap (plan 001 — scrape circuit breaker).
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 // Keep the runner away from any real database: recordScraperRun/getBaseline
 // short-circuit when isDatabaseAvailable is false.
@@ -27,7 +27,8 @@ vi.mock("./pipeline", () => ({
   ensureCinemaExists: vi.fn(async () => {}),
 }));
 
-import { isConnectionError } from "./runner-factory";
+import { isConnectionError, runScraper, type MultiVenueConfig } from "./runner-factory";
+import type { CinemaScraper } from "./types";
 
 describe("isConnectionError", () => {
   it("classifies DB connection/pooler failures as connection errors", () => {
@@ -60,5 +61,46 @@ describe("isConnectionError", () => {
     expect(isConnectionError("ETIMEDOUT: socket timeout")).toBe(true);
     expect(isConnectionError("no showtimes found")).toBe(false);
     expect(isConnectionError(undefined)).toBe(false);
+  });
+});
+
+describe("per-venue wall-clock cap", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aborts a venue that exceeds the cap and continues to the next venue", async () => {
+    vi.useFakeTimers();
+
+    const makeVenue = (id: string) => ({ id, name: id, shortName: id });
+    const hangingScraper = {
+      healthCheck: vi.fn(async () => true),
+      // Wedges forever — simulates the 2026-06-09/11 hangs on an await the
+      // per-query withDbTimeout does not cover.
+      scrape: vi.fn(() => new Promise<never>(() => {})),
+    } as unknown as CinemaScraper;
+    const quickScraper = {
+      healthCheck: vi.fn(async () => true),
+      scrape: vi.fn(async () => []),
+    } as unknown as CinemaScraper;
+
+    const config: MultiVenueConfig = {
+      type: "multi",
+      venues: [makeVenue("wedged-venue"), makeVenue("healthy-venue")],
+      createScraper: (venueId: string) =>
+        venueId === "wedged-venue" ? hangingScraper : quickScraper,
+    };
+
+    const resultPromise = runScraper(config, { useValidation: true });
+    // Default cap is 10 minutes — advance past it so the race rejects.
+    await vi.advanceTimersByTimeAsync(10 * 60_000 + 1_000);
+    const result = await resultPromise;
+
+    expect(result.venueResults).toHaveLength(2);
+    expect(result.venueResults[0]).toMatchObject({ venueId: "wedged-venue", success: false });
+    expect(result.venueResults[0].error).toMatch(/timeout/i);
+    // The wedged venue did not block the rest of the run.
+    expect(result.venueResults[1]).toMatchObject({ venueId: "healthy-venue", success: true });
+    expect(result.success).toBe(false);
   });
 });

--- a/src/scrapers/runner-factory.test.ts
+++ b/src/scrapers/runner-factory.test.ts
@@ -40,8 +40,11 @@ describe("isConnectionError", () => {
     expect(isConnectionError(new Error("connect ECONNREFUSED 1.2.3.4:5432"))).toBe(true);
     expect(isConnectionError(new Error("Connection terminated unexpectedly"))).toBe(true);
     expect(isConnectionError(new Error("remaining connection slots are reserved"))).toBe(true);
-    expect(isConnectionError(new Error("timeout exceeded when trying to connect"))).toBe(true);
-    expect(isConnectionError(new Error("max client connections reached (pool)"))).toBe(true);
+    expect(isConnectionError(new Error("write CONNECT_TIMEOUT 1.2.3.4:6543"))).toBe(true);
+    expect(isConnectionError(new Error("Max client connections reached"))).toBe(true);
+    expect(
+      isConnectionError(new Error("Venue rio-dalston timeout after 600000ms (venue wall-clock cap)")),
+    ).toBe(true);
     expect(isConnectionError(new Error("canceling statement due to user request (57014)"))).toBe(
       true,
     );
@@ -55,10 +58,17 @@ describe("isConnectionError", () => {
     expect(isConnectionError(new Error("Health check failed - site not accessible"))).toBe(false);
     expect(isConnectionError(new Error("scrape_blocked_by_diff_check"))).toBe(false);
     expect(isConnectionError(new Error("Cloudflare challenge page detected"))).toBe(false);
+    // A Playwright nav timeout is the venue's WEBSITE being slow, not the DB —
+    // it must not count toward a breaker that aborts the whole run.
+    expect(isConnectionError(new Error("page.goto: Timeout 30000ms exceeded"))).toBe(false);
+    // A venue site refusing connections is not the DB (no Postgres port).
+    expect(isConnectionError(new Error("connect ECONNREFUSED 93.184.216.34:443"))).toBe(false);
   });
 
   it("handles non-Error values", () => {
-    expect(isConnectionError("ETIMEDOUT: socket timeout")).toBe(true);
+    // Ambiguous-origin socket timeouts no longer count (could be a venue
+    // site); the breaker's progress-based success guard compensates.
+    expect(isConnectionError("ETIMEDOUT: socket timeout")).toBe(false);
     expect(isConnectionError("no showtimes found")).toBe(false);
     expect(isConnectionError(undefined)).toBe(false);
   });

--- a/src/scrapers/runner-factory.ts
+++ b/src/scrapers/runner-factory.ts
@@ -294,18 +294,29 @@ async function recordScraperRun(params: {
  * True if the error looks like a DB connection/pooler failure (non-retryable
  * at run level). Used by the scrape-all circuit breaker to distinguish a
  * wedged database (abort the run) from ordinary per-site scrape failures
- * (keep going). Deliberately matches the venue wall-clock cap's "timeout"
- * message so capped venues count toward the breaker.
+ * (keep going).
+ *
+ * Deliberately narrow: a Playwright nav timeout ("page.goto: Timeout 30000ms
+ * exceeded") or a venue site refusing connections must NOT count — only
+ * markers that can solely originate from the DB path or the venue cap:
+ * withDbTimeout rejects with "... (client-side)" (src/db/index.ts) and the
+ * venue wall-clock cap appends "(venue wall-clock cap)". ECONNREFUSED counts
+ * only on the Postgres ports (5432 direct / 6543 pooler), not a website's
+ * 80/443.
  */
 export function isConnectionError(err: unknown): boolean {
   const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
   return (
-    msg.includes("timeout") || // withDbTimeout / venue-cap client-side reject
-    msg.includes("econnrefused") ||
-    msg.includes("connection") ||
+    msg.includes("(client-side)") || // withDbTimeout reject marker
+    msg.includes("wall-clock cap") || // venue cap expiry
+    (msg.includes("econnrefused") && (msg.includes(":5432") || msg.includes(":6543"))) ||
+    msg.includes("connect_timeout") || // postgres-js connect timeout
     msg.includes("pool") ||
+    msg.includes("max client connections") || // Supavisor at capacity
+    msg.includes("remaining connection slots") || // Postgres at capacity
     msg.includes("57014") || // query_canceled (statement_timeout)
-    msg.includes("terminating connection")
+    msg.includes("terminating connection") ||
+    msg.includes("connection terminated") // postgres-js mid-query drop
   );
 }
 
@@ -320,14 +331,17 @@ export function isConnectionError(err: unknown): boolean {
  * on 2026-06-11 two runs hung 50/25 min on awaits not covered by the
  * per-query withDbTimeout. This cap bounds the whole venue unit instead.
  */
-const VENUE_TIMEOUT_MS = process.env.SCRAPE_VENUE_TIMEOUT_MS
-  ? Math.max(60_000, Number(process.env.SCRAPE_VENUE_TIMEOUT_MS))
-  : 10 * 60_000;
+const VENUE_TIMEOUT_MS = (() => {
+  const parsed = Number(process.env.SCRAPE_VENUE_TIMEOUT_MS);
+  // A malformed value must fall back to the default, never NaN — setTimeout
+  // coerces NaN to 0, which would cap every venue instantly.
+  return Number.isFinite(parsed) && parsed > 0 ? Math.max(60_000, parsed) : 10 * 60_000;
+})();
 
 /**
- * Race `p` against a wall-clock cap. Rejects with a "timeout" error on
- * expiry (the message intentionally matches isConnectionError so capped
- * venues count toward the run-level breaker). Like withDbTimeout, this
+ * Race `p` against a wall-clock cap. Rejects on expiry with a message
+ * containing "(venue wall-clock cap)" — intentionally matched by
+ * isConnectionError so capped venues count toward the breaker. Like withDbTimeout, this
  * stops *waiting* on the promise — the abandoned work keeps running in the
  * background until its own cleanup; that's acceptable because the goal is
  * to unblock the run, not to reclaim the socket.

--- a/src/scrapers/runner-factory.ts
+++ b/src/scrapers/runner-factory.ts
@@ -310,6 +310,86 @@ export function isConnectionError(err: unknown): boolean {
 }
 
 // ============================================================================
+// Per-venue wall-clock cap (plan 001)
+// ============================================================================
+
+/**
+ * Hard wall-clock cap for a single venue's scrape + pipeline + retries.
+ * Default 10 minutes; override via SCRAPE_VENUE_TIMEOUT_MS (floored at 60s).
+ * On 2026-06-09 four venues each ran ~13.4h against a wedged Supabase pooler;
+ * on 2026-06-11 two runs hung 50/25 min on awaits not covered by the
+ * per-query withDbTimeout. This cap bounds the whole venue unit instead.
+ */
+const VENUE_TIMEOUT_MS = process.env.SCRAPE_VENUE_TIMEOUT_MS
+  ? Math.max(60_000, Number(process.env.SCRAPE_VENUE_TIMEOUT_MS))
+  : 10 * 60_000;
+
+/**
+ * Race `p` against a wall-clock cap. Rejects with a "timeout" error on
+ * expiry (the message intentionally matches isConnectionError so capped
+ * venues count toward the run-level breaker). Like withDbTimeout, this
+ * stops *waiting* on the promise — the abandoned work keeps running in the
+ * background until its own cleanup; that's acceptable because the goal is
+ * to unblock the run, not to reclaim the socket.
+ */
+function withWallClockCap<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timeout after ${ms}ms (venue wall-clock cap)`)),
+      ms,
+    );
+  });
+  return Promise.race([p, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
+ * Run one venue under the wall-clock cap. `runSingleVenue` never rejects
+ * (it catches internally and returns a failed VenueResult), so the only
+ * rejection path here is the cap itself — record it as a failed venue and
+ * let the caller continue to the next one.
+ */
+async function runVenueWithCap(
+  venue: VenueDefinition,
+  run: () => Promise<VenueResult>,
+): Promise<VenueResult> {
+  const startTime = Date.now();
+  try {
+    return await withWallClockCap(run(), VENUE_TIMEOUT_MS, `venue ${venue.id}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const durationMs = Date.now() - startTime;
+    log({
+      level: "error",
+      event: "venue_timeout",
+      data: { venueId: venue.id, capMs: VENUE_TIMEOUT_MS, durationMs },
+    });
+    pushPendingRecord(recordScraperRun({
+      cinemaId: venue.id,
+      startedAt: new Date(startTime),
+      status: "failed",
+      screeningCount: 0,
+      durationMs,
+      error: message,
+    }));
+    return {
+      venueId: venue.id,
+      venueName: venue.name,
+      success: false,
+      screeningsFound: 0,
+      screeningsAdded: 0,
+      screeningsUpdated: 0,
+      screeningsFailed: 0,
+      durationMs,
+      error: message,
+      retryCount: 0,
+    };
+  }
+}
+
+// ============================================================================
 // Core Runner
 // ============================================================================
 
@@ -554,7 +634,9 @@ async function runScraperInner(
       });
 
       const scraper = config.createScraper();
-      const result = await runSingleVenue(config.venue, scraper, options);
+      const result = await runVenueWithCap(config.venue, () =>
+        runSingleVenue(config.venue, scraper, options),
+      );
       venueResults.push(result);
 
     } else if (config.type === "multi") {
@@ -575,7 +657,9 @@ async function runScraperInner(
         });
 
         const scraper = config.createScraper(venue.id);
-        const result = await runSingleVenue(venue, scraper, options);
+        const result = await runVenueWithCap(venue, () =>
+          runSingleVenue(venue, scraper, options),
+        );
         venueResults.push(result);
 
         // Continue on error (retry-then-continue behavior)
@@ -610,7 +694,15 @@ async function runScraperInner(
       const startTime = Date.now();
 
       try {
-        const results = await chainScraper.scrapeVenues(activeVenueIds);
+        // Chain scrapers fetch every venue in one call, so the wall-clock
+        // cap scales with venue count (e.g. Curzon ~15 venues). A timeout
+        // rejects into the catch below, which marks all venues failed.
+        const chainCapMs = VENUE_TIMEOUT_MS * Math.max(1, venuesToScrape.length);
+        const results = await withWallClockCap(
+          chainScraper.scrapeVenues(activeVenueIds),
+          chainCapMs,
+          `chain ${config.chainName}`,
+        );
 
         // Process every requested venue so omitted results become explicit failures.
         for (const venue of venuesToScrape) {

--- a/src/scrapers/runner-factory.ts
+++ b/src/scrapers/runner-factory.ts
@@ -287,6 +287,29 @@ async function recordScraperRun(params: {
 }
 
 // ============================================================================
+// Connection-error classification (run-level circuit breaker, plan 001)
+// ============================================================================
+
+/**
+ * True if the error looks like a DB connection/pooler failure (non-retryable
+ * at run level). Used by the scrape-all circuit breaker to distinguish a
+ * wedged database (abort the run) from ordinary per-site scrape failures
+ * (keep going). Deliberately matches the venue wall-clock cap's "timeout"
+ * message so capped venues count toward the breaker.
+ */
+export function isConnectionError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    msg.includes("timeout") || // withDbTimeout / venue-cap client-side reject
+    msg.includes("econnrefused") ||
+    msg.includes("connection") ||
+    msg.includes("pool") ||
+    msg.includes("57014") || // query_canceled (statement_timeout)
+    msg.includes("terminating connection")
+  );
+}
+
+// ============================================================================
 // Core Runner
 // ============================================================================
 


### PR DESCRIPTION
## Summary
Implements `plans/001-scrape-run-circuit-breaker.md`: a run-level circuit breaker in the scrape orchestrator (abort after 3 consecutive connection-level failures, override `SCRAPE_BREAKER_THRESHOLD`) and a hard per-venue wall-clock cap (default 10 min, override `SCRAPE_VENUE_TIMEOUT_MS`; chains scaled by venue count) wrapping the entire venue unit — scrape, pipeline phases, retries.

## Why
- 2026-06-09: a wedged Supabase pooler turned four venue scrapes into 13.4h retry loops and took the production DB offline for 13.7h.
- 2026-06-11: two consecutive `/scrape` runs hung 50/25 min with zero output on inter-phase awaits not covered by `withDbTimeout`. Verified: the cap wraps `runSingleVenue` whole, which contains the exact 2026-06-11 hang point.

## Code-review hardening (review verdict applied)
- `isConnectionError` narrowed to DB-path-only markers — Playwright nav timeouts and venue-site ECONNREFUSED no longer count toward the breaker (spurious-abort risk eliminated).
- Progress-based success: any entry that wrote screenings proves the DB is alive and resets the counter (`breakerOutcomeFor` seam, tested).
- `Number.isFinite` guards on both env knobs (NaN previously meant instant venue caps / silently disabled breaker).
- Honest worst-case time-to-trip documented (bounded by in-flight venue caps).

## Known follow-ups (non-blocking, from review)
- A capped-but-eventually-completing venue can write a late contradictory `scraper_runs` success row (run-record flushing controls flushing, not execution).
- Post-trip Telegram summary counts skipped venues as failed; a `skipped` field would be more honest.
- Chain inner per-venue pipeline processing sits outside the scaled cap (bounded only by `withDbTimeout`).

## Verification
- `npm run test:run`: **113 files, 1708 tests, all pass** (12 new: classifier incl. realistic Playwright/postgres-js messages, fake-timer venue cap, breaker trip/reset semantics, entry→breaker seam)
- `npx tsc --noEmit`: clean · `npm run lint`: 0 errors (60 pre-existing warnings, none in touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)