### PR TITLE
feat(tmdb): matcher accuracy — audit trail, year discipline, runtime/director/language signals (plan 005)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-06-12: TMDB matcher — audit trail persisted, year discipline, runtime/director/language signals
+**PR**: pending | **Files**: `src/lib/tmdb/match.ts`, `src/scrapers/utils/film-matching.ts`, `src/scrapers/pipeline.ts`, `src/scrapers/types.ts`, `src/config/cinema-registry.ts`
+- Fixed the films INSERT silently dropping `matchConfidence`/`matchStrategy`/`matchedAt`/`letterboxdUrl` — only 4.3% of matched films had any audit trail.
+- Current-year hints (screening-year pollution) are stripped before TMDB matching; historical years pass through.
+- New match signals: runtime cross-check (rejects stubs/shorts vs features, −0.15 on >30min mismatch), director credit tie-break (+0.15/−0.1, tie-situations only so typical matches add zero API calls), venue original-language prior (+0.05, Ciné Lumière → fr).
+- Fixes the class of wrong matches behind Joyland → Kansas doc and Dracula → Besson-instead-of-Jude. The 0.6 confidence floor is unchanged.
+- Review hardening: director tie-break no-ops on non-discriminating (dirty/namesake) hints; runtime check survives transient TMDB failures; matchStrategy reflects the hints that actually applied.
+
+---
+
 ## 2026-06-12: Scrape circuit breaker and per-venue wall-clock cap
 **PR**: pending | **Files**: `src/lib/jobs/scrape-all.ts`, `src/scrapers/runner-factory.ts`, `src/lib/jobs/scrape-all.test.ts`, `src/scrapers/runner-factory.test.ts`
 - Added a run-level circuit breaker to the scrape orchestrator: after 3 consecutive connection-level scraper failures (override via `SCRAPE_BREAKER_THRESHOLD`) the run aborts, remaining scrapers and enrichment are skipped, and a Telegram alert fires.

--- a/changelogs/2026-06-12-tmdb-matcher-signals.md
+++ b/changelogs/2026-06-12-tmdb-matcher-signals.md
@@ -1,0 +1,78 @@
+# TMDB Matcher Signals — Audit Trail, Year Discipline, Runtime/Director/Language
+
+**PR**: pending
+**Date**: 2026-06-12
+**Plan**: `plans/005-tmdb-matcher-signals.md` (planned at `716e543`)
+
+## Changes
+
+### Bug fix: match audit trail persisted (step 1)
+- `matchAndCreateFromTMDB` (`src/scrapers/utils/film-matching.ts`) computed
+  `matchConfidence`, `matchStrategy`, `matchedAt`, and `letterboxdUrl` and
+  wrote them to the in-memory film cache — but the `db.insert(films)` block
+  omitted all four. Only 43 of 685 matched upcoming films (4.3%) had any
+  recorded confidence. The insert now mirrors the cache record.
+
+### Year discipline (step 2)
+- `scraperYear` is sanitized at the matcher boundary with the same rule
+  `createFilmWithoutTMDB` already used: only years `>= 1900 && < currentYear`
+  reach `matchFilmToTMDB`. A screening-year hint (indistinguishable from a
+  `(YYYY)` title suffix for the current year) previously handed current-year
+  junk stubs a +0.2/+0.3 exact-year bonus over the real, older film.
+
+### Runtime cross-check (step 3)
+- `MatchHints` gains `runtime?: number`; `RawScreening` gains `runtime?:
+  number` (populated by plan 006 — undefined until then, so zero extra API
+  calls today).
+- After `findBestMatch` picks a winner and a feature-plausible runtime hint
+  (>= 40 min) exists, the candidate's TMDB details are fetched once:
+  - TMDB runtime < 30 min vs venue runtime >= 60 min → reject (stub/short
+    vs feature; TMDB junk stubs have runtime 0/null).
+  - Runtimes differing by > 30 min → −0.15 confidence, re-gated on the 0.6
+    floor (e.g. Nosferatu 2024's 131 min vs the 1922 original's 97 min).
+
+### Director credit tie-break (step 4)
+- When >= 2 candidates score within `competitorThresholdRatio` of the best
+  AND a director hint exists, the director is resolved via the existing
+  `findDirectorId` / `getPersonCredits` client methods: +0.15 to candidates
+  they actually directed, −0.1 to the rest of the tied set, then re-rank.
+- Gated to tie situations only — typical matches make zero extra API calls.
+  Failures are best-effort (logged warning, match proceeds without the signal).
+- `findBestMatch` is now async; its only caller is `matchFilmToTMDB` (verified).
+
+### Venue language prior (step 5)
+- `MatchHints` gains `venueLanguages?: string[]`; candidates whose TMDB
+  `original_language` matches get +0.05 in scoring — enough to beat the
+  popularity bonus (max 0.03) on otherwise-tied candidates. Zero API cost.
+- Priors live in `VENUE_LANGUAGE_PRIORS` in `src/config/cinema-registry.ts`
+  (the canonical cinema registry). Only `cine-lumiere → ["fr"]` for now;
+  a registry test guards that prior keys are real venue ids.
+
+### Hint threading (step 6)
+- `pipeline.ts getOrCreateFilm` → `matchAndCreateFromTMDB` gain
+  `scraperRuntime` and `venueLanguages` parameters, sourced from
+  `rawScreening.runtime` and `VENUE_LANGUAGE_PRIORS[cinemaId]`.
+
+## Tests
+- `src/lib/tmdb/match.test.ts` (new): runtime stub-reject / penalty /
+  pass-through / floor-reject / API-call gating; director tie-break picks
+  the credited director, gate stays tie-only, graceful failure; language
+  prior boosts only with a matching venue prior. All TMDB client methods
+  mocked — no live API calls.
+- `src/scrapers/utils/film-matching-tmdb.test.ts` (new): insert payload
+  carries the four audit-trail fields; current-year/future/pre-1900 hints
+  stripped, historical years kept; hint threading into `matchFilmToTMDB`.
+- `src/config/cinema-registry.test.ts`: `VENUE_LANGUAGE_PRIORS` keys must
+  be registered venue ids, values lowercase ISO 639-1.
+- No existing test's expected match outcome changed.
+
+## Impact
+- Newly matched films now carry a complete audit trail (confidence /
+  strategy / matchedAt / letterboxd URL), enabling the weekly wrong-match
+  review query planned in the 2026-06-11 audit.
+- Wrong-match classes fixed at the matcher level: screening-year stubs
+  beating classics ("Cronos"), same-title same-year popularity coin-flips
+  ("Dracula" → Besson instead of Radu Jude), docs/stubs colliding with
+  features ("Joyland"). Runtime signal activates fully once plan 006 has
+  scrapers populate `RawScreening.runtime`.
+- Threshold values unchanged — the 0.6 confidence floor is untouched.

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,7 +22,7 @@ Recommended order: 004 → 001 (+002/003) → 005 → 006 ∥ 007 → 008 → 00
 | 001 | Scrape run-level circuit breaker + per-venue wall-clock cap | P1 | M | — | DONE (pending PR) |
 | 002 | Consolidate behaviorally-equivalent `normalizeTitle` copies | P2 | M | — | TODO |
 | 003 | Eliminate per-film N+1 queries in the season linker | P2 | M | 002 | TODO |
-| 005 | TMDB matcher: audit trail, year discipline, runtime/director/language signals | P1 | L | — | TODO |
+| 005 | TMDB matcher: audit trail, year discipline, runtime/director/language signals | P1 | L | — | DONE (pending PR) |
 | 006 | Scraper metadata capture (runtime at Rio/ICA/Garden/Curzon) | P1 | M | 005 | TODO |
 | 007 | Letterboxd integrity: no-anchor guard, canonical slug, year tolerance | P1 | M | — | TODO |
 | 008 | Unmatched re-match sweep + preventive blocklist + prefix single-sourcing | P1 | M–L | 005 | TODO |

--- a/src/config/cinema-registry.test.ts
+++ b/src/config/cinema-registry.test.ts
@@ -14,6 +14,7 @@ import {
   getLegacyIdMappings,
   getPlaywrightCinemas,
   isLegacyId,
+  VENUE_LANGUAGE_PRIORS,
 } from "./cinema-registry";
 
 describe("getCinemaById", () => {
@@ -172,5 +173,22 @@ describe("chain getters", () => {
       0,
     );
     expect(independentCount + chainedCount).toBe(CINEMA_REGISTRY.length);
+  });
+});
+
+describe("VENUE_LANGUAGE_PRIORS", () => {
+  it("only contains venue ids that exist in the registry", () => {
+    const registeredIds = new Set(CINEMA_REGISTRY.map((c) => c.id));
+    for (const venueId of Object.keys(VENUE_LANGUAGE_PRIORS)) {
+      expect(registeredIds.has(venueId), `unknown venue id: ${venueId}`).toBe(true);
+    }
+  });
+
+  it("uses lowercase ISO 639-1 language codes", () => {
+    for (const languages of Object.values(VENUE_LANGUAGE_PRIORS)) {
+      for (const lang of languages) {
+        expect(lang).toMatch(/^[a-z]{2}$/);
+      }
+    }
   });
 });

--- a/src/config/cinema-registry.ts
+++ b/src/config/cinema-registry.ts
@@ -1454,6 +1454,23 @@ export function getChainIds(): ChainId[] {
 }
 
 // ============================================================================
+// Venue Language Priors
+// ============================================================================
+
+/**
+ * ISO 639-1 original-language priors for venues that program a specific
+ * national cinema. Used by the TMDB matcher as a small scoring nudge
+ * (plan 005, step 5) — a same-language candidate beats an otherwise-tied
+ * one at these venues.
+ *
+ * Only add venue ids that exist in CINEMA_REGISTRY (tested in
+ * cinema-registry.test.ts).
+ */
+export const VENUE_LANGUAGE_PRIORS: Record<string, string[]> = {
+  "cine-lumiere": ["fr"], // Institut français — predominantly French programming
+};
+
+// ============================================================================
 // Database Seed Functions
 // ============================================================================
 

--- a/src/lib/tmdb/match.test.ts
+++ b/src/lib/tmdb/match.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for matchFilmToTMDB / findBestMatch in src/lib/tmdb/match.ts.
+ *
+ * Mocks the TMDB client (no live API calls) and the blocklist. Covers
+ * plan 005 signals:
+ *  - Step 3: runtime cross-check (stub-reject / penalty / pass-through,
+ *    gated so no extra API call without a runtime hint)
+ *  - Step 4: director credit tie-break for close competitors
+ *  - Step 5: venue original-language prior
+ *  - Regression: title+year scoring behaviour unchanged when no new hints
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TMDBSearchResult } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  searchFilms: vi.fn(),
+  getFilmDetails: vi.fn(),
+  findDirectorId: vi.fn(),
+  getPersonCredits: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  getTMDBClient: () => ({
+    searchFilms: mocks.searchFilms,
+    getFilmDetails: mocks.getFilmDetails,
+    findDirectorId: mocks.findDirectorId,
+    getPersonCredits: mocks.getPersonCredits,
+  }),
+}));
+
+vi.mock("./blocklist", () => ({
+  getBlockedTmdbIds: () => new Set<number>(),
+  checkTitleBlocklist: () => null,
+  incrementBlocklistUsage: vi.fn(),
+}));
+
+import { matchFilmToTMDB } from "./match";
+
+function makeResult(overrides: Partial<TMDBSearchResult> = {}): TMDBSearchResult {
+  return {
+    id: 1,
+    title: "Joyland",
+    original_title: "Joyland",
+    release_date: "2022-11-18",
+    poster_path: "/p.jpg",
+    backdrop_path: null,
+    overview: "",
+    popularity: 10,
+    vote_average: 7,
+    vote_count: 100,
+    genre_ids: [],
+    original_language: "ur",
+    adult: false,
+    video: false,
+    ...overrides,
+  } as TMDBSearchResult;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.searchFilms.mockResolvedValue({ results: [] });
+});
+
+describe("matchFilmToTMDB — runtime cross-check (step 3)", () => {
+  it("rejects a stub candidate (runtime 0) when the venue says it is a feature", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+    mocks.getFilmDetails.mockResolvedValue({ runtime: 0 });
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 100 });
+
+    expect(mocks.getFilmDetails).toHaveBeenCalledWith(11);
+    expect(match).toBeNull();
+  });
+
+  it("rejects a short (runtime 12) when the venue says it is a feature", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+    mocks.getFilmDetails.mockResolvedValue({ runtime: 12 });
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 100 });
+
+    expect(match).toBeNull();
+  });
+
+  it("passes a close runtime through unchanged", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+
+    const control = await matchFilmToTMDB("Joyland", { year: 2022 });
+
+    mocks.getFilmDetails.mockResolvedValue({ runtime: 97 });
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 100 });
+
+    expect(match).not.toBeNull();
+    expect(match!.confidence).toBeCloseTo(control!.confidence, 10);
+  });
+
+  it("applies a -0.15 penalty when runtimes differ by more than 30 minutes", async () => {
+    // Nosferatu 2024 (131 min) vs the venue's 1922 original (97 min)
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+
+    const control = await matchFilmToTMDB("Joyland", { year: 2022 });
+
+    mocks.getFilmDetails.mockResolvedValue({ runtime: 131 });
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 97 });
+
+    expect(match).not.toBeNull();
+    expect(match!.confidence).toBeCloseTo(control!.confidence - 0.15, 10);
+  });
+
+  it("rejects when the runtime penalty drops confidence below the floor", async () => {
+    // Weak title match + no year bonus → base confidence just above 0.6;
+    // −0.15 sinks it below the 0.6 floor.
+    mocks.searchFilms.mockResolvedValue({
+      results: [
+        makeResult({
+          id: 11,
+          title: "Joyland Forever",
+          original_title: "Joyland Forever",
+          release_date: "2019-01-01",
+        }),
+      ],
+    });
+    mocks.getFilmDetails.mockResolvedValue({ runtime: 200 });
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 97 });
+
+    expect(match).toBeNull();
+  });
+
+  it("makes zero extra API calls when no runtime hint is provided", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022 });
+
+    expect(match).not.toBeNull();
+    expect(mocks.getFilmDetails).not.toHaveBeenCalled();
+  });
+
+  it("skips the cross-check for short-programme hints (< 40 min)", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 25 });
+
+    expect(match).not.toBeNull();
+    expect(mocks.getFilmDetails).not.toHaveBeenCalled();
+  });
+
+  it("leaves the match unchanged when TMDB has no runtime and the hint is sub-feature", async () => {
+    // tmdbRuntime 0 with hint 45 (< 60): not a stub-vs-feature situation
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+    mocks.getFilmDetails.mockResolvedValue({ runtime: null });
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 45 });
+
+    expect(match).not.toBeNull();
+  });
+});

--- a/src/lib/tmdb/match.test.ts
+++ b/src/lib/tmdb/match.test.ts
@@ -93,6 +93,18 @@ describe("matchFilmToTMDB — runtime cross-check (step 3)", () => {
     expect(match!.confidence).toBeCloseTo(control!.confidence, 10);
   });
 
+  it("keeps the match when the runtime-check getFilmDetails call fails", async () => {
+    // A transient TMDB failure must skip verification, not convert a
+    // successful match into a TMDB-less film via the pipeline fallback.
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+    mocks.getFilmDetails.mockRejectedValue(new Error("TMDB API error: 503"));
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, runtime: 100 });
+
+    expect(match).not.toBeNull();
+    expect(match!.tmdbId).toBe(11);
+  });
+
   it("applies a -0.15 penalty when runtimes differ by more than 30 minutes", async () => {
     // Nosferatu 2024 (131 min) vs the venue's 1922 original (97 min)
     mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
@@ -234,6 +246,29 @@ describe("matchFilmToTMDB — director credit tie-break (step 4)", () => {
 
     expect(match).not.toBeNull();
     expect(match!.tmdbId).toBe(100);
+  });
+
+  it("ignores a director hint that matches no close candidate (dirty hint / namesake)", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: draculaTie() });
+    // findDirectorId resolved SOMEONE (e.g. a namesake), but they directed
+    // neither close candidate — the adjustment must be a no-op, not a
+    // blanket penalty that could reject a correct match or promote a weaker
+    // never-examined candidate.
+    mocks.findDirectorId.mockResolvedValue(99);
+    mocks.getPersonCredits.mockResolvedValue({
+      cast: [],
+      crew: [{ id: 555, job: "Director", title: "An Unrelated Film" }],
+    });
+
+    const withDirtyHint = await matchFilmToTMDB("Dracula", {
+      year: 2025,
+      director: "Misspelled Namesake",
+    });
+    const control = await matchFilmToTMDB("Dracula", { year: 2025 });
+
+    expect(withDirtyHint).not.toBeNull();
+    expect(withDirtyHint!.tmdbId).toBe(control!.tmdbId);
+    expect(withDirtyHint!.confidence).toBeCloseTo(control!.confidence, 5);
   });
 });
 

--- a/src/lib/tmdb/match.test.ts
+++ b/src/lib/tmdb/match.test.ts
@@ -217,11 +217,77 @@ describe("matchFilmToTMDB — director credit tie-break (step 4)", () => {
     expect(mocks.getPersonCredits).not.toHaveBeenCalled();
   });
 
+  it("does not fetch director credits when there is no director hint, even on ties", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: draculaTie() });
+
+    const match = await matchFilmToTMDB("Dracula", { year: 2025 });
+
+    expect(match).not.toBeNull();
+    expect(mocks.findDirectorId).not.toHaveBeenCalled();
+  });
+
   it("survives a director-credit API failure and still returns a match", async () => {
     mocks.searchFilms.mockResolvedValue({ results: draculaTie() });
     mocks.findDirectorId.mockRejectedValue(new Error("TMDB API error: 500"));
 
     const match = await matchFilmToTMDB("Dracula", { year: 2025, director: "Radu Jude" });
+
+    expect(match).not.toBeNull();
+    expect(match!.tmdbId).toBe(100);
+  });
+});
+
+describe("matchFilmToTMDB — venue language prior (step 5)", () => {
+  /** Same-title same-year candidates: an English one (more popular) and a French one. */
+  function languageTie() {
+    return [
+      makeResult({
+        id: 100,
+        title: "La Piscine",
+        original_title: "The Swimming Pool",
+        release_date: "2003-05-14",
+        popularity: 400,
+        original_language: "en",
+      }),
+      makeResult({
+        id: 200,
+        title: "La Piscine",
+        original_title: "La Piscine",
+        release_date: "2003-05-14",
+        popularity: 8,
+        original_language: "fr",
+      }),
+    ];
+  }
+
+  it("boosts the venue-language candidate past an otherwise-tied one", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: languageTie() });
+
+    const match = await matchFilmToTMDB("La Piscine", {
+      year: 2003,
+      venueLanguages: ["fr"],
+    });
+
+    expect(match).not.toBeNull();
+    expect(match!.tmdbId).toBe(200);
+  });
+
+  it("has no effect when no venue languages are provided", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: languageTie() });
+
+    const match = await matchFilmToTMDB("La Piscine", { year: 2003 });
+
+    expect(match).not.toBeNull();
+    expect(match!.tmdbId).toBe(100);
+  });
+
+  it("has no effect when the venue languages do not include the candidate's language", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: languageTie() });
+
+    const match = await matchFilmToTMDB("La Piscine", {
+      year: 2003,
+      venueLanguages: ["de"],
+    });
 
     expect(match).not.toBeNull();
     expect(match!.tmdbId).toBe(100);

--- a/src/lib/tmdb/match.test.ts
+++ b/src/lib/tmdb/match.test.ts
@@ -154,3 +154,76 @@ describe("matchFilmToTMDB — runtime cross-check (step 3)", () => {
     expect(match).not.toBeNull();
   });
 });
+
+describe("matchFilmToTMDB — director credit tie-break (step 4)", () => {
+  /** Two same-title same-year candidates: the Besson (high popularity) and the Jude. */
+  function draculaTie() {
+    return [
+      makeResult({
+        id: 100,
+        title: "Dracula",
+        original_title: "Dracula",
+        release_date: "2025-07-30",
+        popularity: 900, // popularity alone would pick this one
+        original_language: "en",
+      }),
+      makeResult({
+        id: 200,
+        title: "Dracula",
+        original_title: "Dracula",
+        release_date: "2025-07-30",
+        popularity: 5,
+        original_language: "ro",
+      }),
+    ];
+  }
+
+  it("picks the film the hinted director actually directed when candidates tie", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: draculaTie() });
+    mocks.findDirectorId.mockResolvedValue(77);
+    mocks.getPersonCredits.mockResolvedValue({
+      cast: [],
+      crew: [
+        { id: 200, job: "Director", title: "Dracula" },
+        { id: 300, job: "Writer", title: "Something Else" },
+      ],
+    });
+
+    const match = await matchFilmToTMDB("Dracula", { year: 2025, director: "Radu Jude" });
+
+    expect(mocks.findDirectorId).toHaveBeenCalledWith("Radu Jude");
+    expect(match).not.toBeNull();
+    expect(match!.tmdbId).toBe(200);
+  });
+
+  it("does not fetch director credits when there is a single dominant candidate", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: [makeResult({ id: 11 })] });
+
+    const match = await matchFilmToTMDB("Joyland", { year: 2022, director: "Saim Sadiq" });
+
+    expect(match).not.toBeNull();
+    expect(mocks.findDirectorId).not.toHaveBeenCalled();
+    expect(mocks.getPersonCredits).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the popularity winner when the director cannot be resolved", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: draculaTie() });
+    mocks.findDirectorId.mockResolvedValue(null);
+
+    const match = await matchFilmToTMDB("Dracula", { year: 2025, director: "Unknown Person" });
+
+    expect(match).not.toBeNull();
+    expect(match!.tmdbId).toBe(100);
+    expect(mocks.getPersonCredits).not.toHaveBeenCalled();
+  });
+
+  it("survives a director-credit API failure and still returns a match", async () => {
+    mocks.searchFilms.mockResolvedValue({ results: draculaTie() });
+    mocks.findDirectorId.mockRejectedValue(new Error("TMDB API error: 500"));
+
+    const match = await matchFilmToTMDB("Dracula", { year: 2025, director: "Radu Jude" });
+
+    expect(match).not.toBeNull();
+    expect(match!.tmdbId).toBe(100);
+  });
+});

--- a/src/lib/tmdb/match.ts
+++ b/src/lib/tmdb/match.ts
@@ -216,7 +216,19 @@ async function applyRuntimeCrossCheck(
     return best;
   }
 
-  const details = await client.getFilmDetails(best.tmdbId);
+  // Best-effort, like the director tie-break: a transient TMDB failure must
+  // skip verification and keep the match — throwing here would convert a
+  // successful match into a TMDB-less film row via the pipeline's fallback.
+  let details: Awaited<ReturnType<typeof client.getFilmDetails>>;
+  try {
+    details = await client.getFilmDetails(best.tmdbId);
+  } catch (err) {
+    console.warn(
+      `[tmdb-match] Runtime cross-check skipped for tmdb=${best.tmdbId}: ` +
+        `getFilmDetails failed (${err instanceof Error ? err.message : String(err)})`
+    );
+    return best;
+  }
   const tmdbRuntime = details.runtime ?? 0;
 
   // Stub/short vs feature: a candidate with no or tiny runtime cannot be the
@@ -370,25 +382,40 @@ async function findBestMatch(
         const directedIds = new Set(
           credits.crew.filter((c) => c.job === "Director").map((c) => c.id)
         );
-        for (const scored of scoredResults) {
-          if (scored.score >= competitorThreshold) {
-            scored.score += directedIds.has(scored.result.id)
-              ? DIRECTOR_MATCH_BONUS
-              : -DIRECTOR_MISMATCH_PENALTY;
+        // Only adjust when the resolved director actually directed at least
+        // one close competitor. A dirty hint (misspelling, namesake picked by
+        // findDirectorId) that discriminates nothing must be a no-op:
+        // penalizing every tied candidate both rejects correct matches and
+        // can promote a weaker, never-examined candidate past the tie set.
+        const discriminates = scoredResults.some(
+          (s) => s.score >= competitorThreshold && directedIds.has(s.result.id)
+        );
+        if (discriminates) {
+          for (const scored of scoredResults) {
+            if (scored.score >= competitorThreshold) {
+              scored.score += directedIds.has(scored.result.id)
+                ? DIRECTOR_MATCH_BONUS
+                : -DIRECTOR_MISMATCH_PENALTY;
+            }
           }
-        }
-        scoredResults.sort((a, b) => b.score - a.score);
-        if (scoredResults[0] !== best) {
-          console.log(
-            `[tmdb-match] Director tie-break for "${searchTitle}": ` +
-              `"${directorHint}" credits pick tmdb=${scoredResults[0].result.id} over tmdb=${best.result.id}`
+          scoredResults.sort((a, b) => b.score - a.score);
+          if (scoredResults[0] !== best) {
+            console.log(
+              `[tmdb-match] Director tie-break for "${searchTitle}": ` +
+                `"${directorHint}" credits pick tmdb=${scoredResults[0].result.id} over tmdb=${best.result.id}`
+            );
+          }
+          best = scoredResults[0];
+          competitorThreshold = best.score * tmdb.competitorThresholdRatio;
+          closeCompetitors = scoredResults.filter(
+            (r) => r.score >= competitorThreshold
+          ).length;
+        } else {
+          console.warn(
+            `[tmdb-match] Director hint "${directorHint}" matches no close ` +
+              `candidate for "${searchTitle}" — ignoring (dirty hint or namesake)`
           );
         }
-        best = scoredResults[0];
-        competitorThreshold = best.score * tmdb.competitorThresholdRatio;
-        closeCompetitors = scoredResults.filter(
-          (r) => r.score >= competitorThreshold
-        ).length;
       }
     } catch (error) {
       // Director resolution is best-effort — never fail the match over it

--- a/src/lib/tmdb/match.ts
+++ b/src/lib/tmdb/match.ts
@@ -31,6 +31,12 @@ const YEAR_MISMATCH_PENALTY = -0.1;
 const CLASSIC_YEAR_THRESHOLD = 2000;
 const CLASSIC_YEAR_MISMATCH_TOLERANCE = 5;
 const CLASSIC_CONFIDENCE_FLOOR = 0.85;
+// Runtime cross-check (plan 005, step 3)
+const MIN_RUNTIME_HINT_MINUTES = 40; // ignore short-programme hints
+const STUB_RUNTIME_MAX_MINUTES = 30; // TMDB runtime below this = stub/short
+const FEATURE_RUNTIME_MIN_MINUTES = 60; // venue runtime at/above this = feature
+const RUNTIME_MISMATCH_TOLERANCE_MINUTES = 30;
+const RUNTIME_MISMATCH_PENALTY = 0.15;
 
 /**
  * Get TMDB matching thresholds from the AutoQuality-tuned config.
@@ -51,6 +57,8 @@ function getTmdbThresholds() {
 interface MatchHints {
   year?: number;
   director?: string;
+  /** Film runtime in minutes from the venue (cross-checked against TMDB) */
+  runtime?: number;
   /** If true, skip ambiguity checks (for re-processing with known good metadata) */
   skipAmbiguityCheck?: boolean;
 }
@@ -164,19 +172,71 @@ export async function matchFilmToTMDB(
   // Search with year hint if provided
   const searchResults = await client.searchFilms(title, hints?.year);
 
+  let best: MatchResult | null;
   if (searchResults.results.length === 0) {
     // Try without year hint
-    if (hints?.year) {
-      const fallbackResults = await client.searchFilms(title);
-      if (fallbackResults.results.length === 0) {
-        return null;
-      }
-      return findBestMatch(title, fallbackResults.results, hints);
+    if (!hints?.year) {
+      return null;
     }
+    const fallbackResults = await client.searchFilms(title);
+    if (fallbackResults.results.length === 0) {
+      return null;
+    }
+    best = findBestMatch(title, fallbackResults.results, hints);
+  } else {
+    best = findBestMatch(title, searchResults.results, hints);
+  }
+
+  return applyRuntimeCrossCheck(best, hints, client);
+}
+
+/**
+ * Cross-check the winning candidate's TMDB runtime against the venue-provided
+ * runtime (plan 005, step 3). Gated on the hint being present and
+ * feature-plausible, so typical matches make zero extra API calls.
+ *
+ * - TMDB runtime missing/tiny vs a feature-length hint → reject (junk stubs
+ *   and shorts have runtime 0/null/<30 on TMDB).
+ * - Runtimes differing by >30 min → −0.15 confidence (e.g. Nosferatu 2024's
+ *   131 min vs the 1922 original's 97 min), re-gated on the floor.
+ */
+async function applyRuntimeCrossCheck(
+  best: MatchResult | null,
+  hints: MatchHints | undefined,
+  client: ReturnType<typeof getTMDBClient>
+): Promise<MatchResult | null> {
+  if (!best || !hints?.runtime || hints.runtime < MIN_RUNTIME_HINT_MINUTES) {
+    return best;
+  }
+
+  const details = await client.getFilmDetails(best.tmdbId);
+  const tmdbRuntime = details.runtime ?? 0;
+
+  // Stub/short vs feature: a candidate with no or tiny runtime cannot be the
+  // feature-length film the venue is showing.
+  if (tmdbRuntime < STUB_RUNTIME_MAX_MINUTES && hints.runtime >= FEATURE_RUNTIME_MIN_MINUTES) {
+    console.log(
+      `[tmdb-match] Rejecting "${best.title}" (tmdb=${best.tmdbId}): ` +
+        `TMDB runtime ${tmdbRuntime}min vs venue runtime ${hints.runtime}min (stub/short vs feature)`
+    );
     return null;
   }
 
-  return findBestMatch(title, searchResults.results, hints);
+  if (tmdbRuntime > 0) {
+    const diff = Math.abs(tmdbRuntime - hints.runtime);
+    if (diff > RUNTIME_MISMATCH_TOLERANCE_MINUTES) {
+      best.confidence = Math.max(0, best.confidence - RUNTIME_MISMATCH_PENALTY);
+    }
+    if (best.confidence < getTmdbThresholds().minMatchConfidence) {
+      console.log(
+        `[tmdb-match] Rejecting "${best.title}" (tmdb=${best.tmdbId}): ` +
+          `runtime mismatch (${tmdbRuntime}min vs ${hints.runtime}min) dropped confidence below floor`
+      );
+      return null;
+    }
+  }
+
+  return best;
 }
 
 /**

--- a/src/lib/tmdb/match.ts
+++ b/src/lib/tmdb/match.ts
@@ -40,6 +40,8 @@ const RUNTIME_MISMATCH_PENALTY = 0.15;
 // Director credit tie-break (plan 005, step 4)
 const DIRECTOR_MATCH_BONUS = 0.15;
 const DIRECTOR_MISMATCH_PENALTY = 0.1;
+// Venue original-language prior (plan 005, step 5)
+const VENUE_LANGUAGE_BONUS = 0.05;
 
 /**
  * Get TMDB matching thresholds from the AutoQuality-tuned config.
@@ -62,6 +64,8 @@ interface MatchHints {
   director?: string;
   /** Film runtime in minutes from the venue (cross-checked against TMDB) */
   runtime?: number;
+  /** ISO 639-1 language priors for the venue (e.g. ["fr"] for Ciné Lumière) */
+  venueLanguages?: string[];
   /** If true, skip ambiguity checks (for re-processing with known good metadata) */
   skipAmbiguityCheck?: boolean;
 }
@@ -322,8 +326,16 @@ async function findBestMatch(
     // A film with popularity 1000 gets only 3% boost, not 10%
     const popularityBonus = Math.min(result.popularity / POPULARITY_DIVISOR, MAX_POPULARITY_BONUS);
 
+    // Venue language prior (plan 005, step 5): venues that program a
+    // specific national cinema (e.g. Ciné Lumière → fr) nudge same-language
+    // candidates past otherwise-tied ones. Zero API cost.
+    const languageBonus = hints?.venueLanguages?.includes(result.original_language)
+      ? VENUE_LANGUAGE_BONUS
+      : 0;
+
     // Calculate total score
-    const score = titleSimilarity * tmdb.titleSimilarityWeight + yearBonus + popularityBonus;
+    const score =
+      titleSimilarity * tmdb.titleSimilarityWeight + yearBonus + popularityBonus + languageBonus;
 
     scoredResults.push({ result, titleSimilarity, score });
   }

--- a/src/lib/tmdb/match.ts
+++ b/src/lib/tmdb/match.ts
@@ -37,6 +37,9 @@ const STUB_RUNTIME_MAX_MINUTES = 30; // TMDB runtime below this = stub/short
 const FEATURE_RUNTIME_MIN_MINUTES = 60; // venue runtime at/above this = feature
 const RUNTIME_MISMATCH_TOLERANCE_MINUTES = 30;
 const RUNTIME_MISMATCH_PENALTY = 0.15;
+// Director credit tie-break (plan 005, step 4)
+const DIRECTOR_MATCH_BONUS = 0.15;
+const DIRECTOR_MISMATCH_PENALTY = 0.1;
 
 /**
  * Get TMDB matching thresholds from the AutoQuality-tuned config.
@@ -182,9 +185,9 @@ export async function matchFilmToTMDB(
     if (fallbackResults.results.length === 0) {
       return null;
     }
-    best = findBestMatch(title, fallbackResults.results, hints);
+    best = await findBestMatch(title, fallbackResults.results, hints);
   } else {
-    best = findBestMatch(title, searchResults.results, hints);
+    best = await findBestMatch(title, searchResults.results, hints);
   }
 
   return applyRuntimeCrossCheck(best, hints, client);
@@ -247,12 +250,17 @@ async function applyRuntimeCrossCheck(
  * - Year match: +0.2 for exact, +0.1 for ±1 year
  * - Popularity: reduced to max 3% to prevent blockbuster bias
  * - Match count penalty: reduces confidence when many films have similar scores
+ * - Director credit tie-break: when >= 2 candidates score within the
+ *   competitor threshold of the best AND a director hint exists, candidates
+ *   the hinted director actually directed get +0.15, others -0.1
+ *   (async only for that tie-only TMDB person lookup — typical matches make
+ *   zero extra API calls)
  */
-function findBestMatch(
+async function findBestMatch(
   searchTitle: string,
   results: TMDBSearchResult[],
   hints?: MatchHints
-): MatchResult | null {
+): Promise<MatchResult | null> {
   // Load AutoQuality-tuned thresholds (cached, near-zero cost)
   const tmdb = getTmdbThresholds();
 
@@ -325,15 +333,59 @@ function findBestMatch(
   // Sort by score descending
   scoredResults.sort((a, b) => b.score - a.score);
 
-  const best = scoredResults[0];
+  let best = scoredResults[0];
 
   // Calculate match count penalty
   // If many films have similar scores, reduce confidence
   // This catches cases like "Ten" where 5 films all score 0.85
-  const competitorThreshold = best.score * tmdb.competitorThresholdRatio;
-  const closeCompetitors = scoredResults.filter(
+  let competitorThreshold = best.score * tmdb.competitorThresholdRatio;
+  let closeCompetitors = scoredResults.filter(
     (r) => r.score >= competitorThreshold
   ).length;
+
+  // Director credit tie-break (plan 005, step 4): only when the title+year
+  // signals genuinely tie (>= 2 close competitors) AND a director hint
+  // exists. Resolves "Dracula" -> Radu Jude's film instead of Besson's
+  // higher-popularity one. The gate keeps the two extra TMDB calls
+  // tie-situations-only.
+  const directorHint = hints?.director?.trim();
+  if (directorHint && closeCompetitors >= 2) {
+    try {
+      const client = getTMDBClient();
+      const directorId = await client.findDirectorId(directorHint);
+      if (directorId) {
+        const credits = await client.getPersonCredits(directorId);
+        const directedIds = new Set(
+          credits.crew.filter((c) => c.job === "Director").map((c) => c.id)
+        );
+        for (const scored of scoredResults) {
+          if (scored.score >= competitorThreshold) {
+            scored.score += directedIds.has(scored.result.id)
+              ? DIRECTOR_MATCH_BONUS
+              : -DIRECTOR_MISMATCH_PENALTY;
+          }
+        }
+        scoredResults.sort((a, b) => b.score - a.score);
+        if (scoredResults[0] !== best) {
+          console.log(
+            `[tmdb-match] Director tie-break for "${searchTitle}": ` +
+              `"${directorHint}" credits pick tmdb=${scoredResults[0].result.id} over tmdb=${best.result.id}`
+          );
+        }
+        best = scoredResults[0];
+        competitorThreshold = best.score * tmdb.competitorThresholdRatio;
+        closeCompetitors = scoredResults.filter(
+          (r) => r.score >= competitorThreshold
+        ).length;
+      }
+    } catch (error) {
+      // Director resolution is best-effort — never fail the match over it
+      console.warn(
+        `[tmdb-match] Director credit check failed for "${directorHint}":`,
+        error
+      );
+    }
+  }
 
   let matchCountPenalty = 0;
   if (closeCompetitors >= 4) {

--- a/src/scrapers/pipeline.ts
+++ b/src/scrapers/pipeline.ts
@@ -14,6 +14,7 @@ import { generateScrapeDiff, printDiffReport, shouldBlockScrape } from "./utils/
 import { linkFilmToMatchingSeasons } from "./seasons/season-linker";
 
 import { runPhase, stampProgress } from "@/lib/scrape-progress";
+import { VENUE_LANGUAGE_PRIORS } from "@/config/cinema-registry";
 
 // Extracted utility modules
 import {
@@ -245,7 +246,9 @@ export async function processScreenings(
               firstScreening.filmTitle,
               firstScreening.year,
               firstScreening.director,
-              firstScreening.posterUrl
+              firstScreening.posterUrl,
+              firstScreening.runtime,
+              VENUE_LANGUAGE_PRIORS[cinemaId]
             ),
             20_000,
             `getOrCreateFilm: ${firstScreening.filmTitle}`,
@@ -399,7 +402,9 @@ async function getOrCreateFilm(
   title: string,
   scraperYear?: number,
   scraperDirector?: string,
-  scraperPosterUrl?: string
+  scraperPosterUrl?: string,
+  scraperRuntime?: number,
+  venueLanguages?: string[]
 ): Promise<string | null> {
   // Use AI to extract the actual film title from event-style names
   // e.g., "Saturday Morning Picture Club: The Muppets Christmas Carol" → "The Muppets Christmas Carol"
@@ -479,7 +484,9 @@ async function getOrCreateFilm(
       matchingTitle,
       scraperYear,
       scraperDirector,
-      scraperPosterUrl
+      scraperPosterUrl,
+      scraperRuntime,
+      venueLanguages
     );
     if (tmdbFilmId) {
       return tmdbFilmId;

--- a/src/scrapers/types.ts
+++ b/src/scrapers/types.ts
@@ -23,6 +23,8 @@ export interface RawScreening {
   year?: number;
   /** Director name (if available from source) */
   director?: string;
+  /** Film runtime in minutes (if available from source) */
+  runtime?: number;
   /** Slug of the festival this screening belongs to (e.g., "bfi-lff-2025") */
   festivalSlug?: string;
   /** Section within the festival (e.g., "Galas", "Competition") */

--- a/src/scrapers/utils/film-matching-tmdb.test.ts
+++ b/src/scrapers/utils/film-matching-tmdb.test.ts
@@ -131,3 +131,46 @@ describe("matchAndCreateFromTMDB — audit trail persistence (step 1)", () => {
     expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 });
+describe("matchAndCreateFromTMDB — year discipline (step 2)", () => {
+  it("strips a current-year hint before calling matchFilmToTMDB", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue(null);
+    const currentYear = new Date().getFullYear();
+
+    await matchAndCreateFromTMDB(makeCache(), "Cronos", currentYear);
+
+    expect(mocks.matchFilmToTMDB).toHaveBeenCalledWith(
+      "Cronos",
+      expect.objectContaining({ year: undefined })
+    );
+  });
+
+  it("passes a historical release year through unchanged", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue(null);
+
+    await matchAndCreateFromTMDB(makeCache(), "Aguirre, the Wrath of God", 1972);
+
+    expect(mocks.matchFilmToTMDB).toHaveBeenCalledWith(
+      "Aguirre, the Wrath of God",
+      expect.objectContaining({ year: 1972 })
+    );
+  });
+
+  it("strips future years and pre-1900 years", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue(null);
+    const futureYear = new Date().getFullYear() + 1;
+
+    await matchAndCreateFromTMDB(makeCache(), "Some Film", futureYear);
+    await matchAndCreateFromTMDB(makeCache(), "Some Film", 1850);
+
+    expect(mocks.matchFilmToTMDB).toHaveBeenNthCalledWith(
+      1,
+      "Some Film",
+      expect.objectContaining({ year: undefined })
+    );
+    expect(mocks.matchFilmToTMDB).toHaveBeenNthCalledWith(
+      2,
+      "Some Film",
+      expect.objectContaining({ year: undefined })
+    );
+  });
+});

--- a/src/scrapers/utils/film-matching-tmdb.test.ts
+++ b/src/scrapers/utils/film-matching-tmdb.test.ts
@@ -115,6 +115,51 @@ describe("matchAndCreateFromTMDB — audit trail persistence (step 1)", () => {
     expect(payload.letterboxdUrl).toBe("https://letterboxd.com/tmdb/555");
   });
 
+  it("records auto-no-hints when the year hint was stripped as current-year contamination", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue({
+      tmdbId: 556,
+      confidence: 0.8,
+      title: "Some New Film",
+      year: new Date().getFullYear(),
+      posterPath: null,
+    });
+    mocks.getFullFilmData.mockResolvedValue(makeFullFilmData());
+
+    // Current-year scraperYear is stripped before matching, so the audit
+    // trail must not claim a year hint was used.
+    const filmId = await matchAndCreateFromTMDB(
+      makeCache(),
+      "Some New Film",
+      new Date().getFullYear()
+    );
+
+    expect(filmId).not.toBeNull();
+    const payload = mocks.insertValues.mock.calls[0][0];
+    expect(payload.matchStrategy).toBe("auto-no-hints");
+  });
+
+  it("records auto-with-director when only a director hint applied", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue({
+      tmdbId: 557,
+      confidence: 0.8,
+      title: "Some New Film",
+      year: new Date().getFullYear(),
+      posterPath: null,
+    });
+    mocks.getFullFilmData.mockResolvedValue(makeFullFilmData());
+
+    const filmId = await matchAndCreateFromTMDB(
+      makeCache(),
+      "Some New Film",
+      undefined,
+      "Saim Sadiq"
+    );
+
+    expect(filmId).not.toBeNull();
+    const payload = mocks.insertValues.mock.calls[0][0];
+    expect(payload.matchStrategy).toBe("auto-with-director");
+  });
+
   it("returns existing film id without inserting when TMDB id already exists in DB", async () => {
     mocks.matchFilmToTMDB.mockResolvedValue({
       tmdbId: 555,

--- a/src/scrapers/utils/film-matching-tmdb.test.ts
+++ b/src/scrapers/utils/film-matching-tmdb.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for matchAndCreateFromTMDB in src/scrapers/utils/film-matching.ts.
+ *
+ * Mocks the DB, TMDB module, poster service, and similarity search so no
+ * network or database access happens. Covers:
+ *  - Step 1 (plan 005): the films INSERT carries the match audit trail
+ *    (matchConfidence / matchStrategy / matchedAt / letterboxdUrl)
+ *  - Step 2 (plan 005): screening-year contamination is stripped before
+ *    the year hint reaches matchFilmToTMDB
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const insertValues = vi.fn().mockResolvedValue(undefined);
+  const insert = vi.fn(() => ({ values: insertValues }));
+  const selectLimit = vi.fn().mockResolvedValue([]);
+  const matchFilmToTMDB = vi.fn();
+  const getFullFilmData = vi.fn();
+  const findPoster = vi.fn().mockResolvedValue({ source: "placeholder", url: null });
+  return { insertValues, insert, selectLimit, matchFilmToTMDB, getFullFilmData, findPoster };
+});
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: mocks.insert,
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: mocks.selectLimit }),
+      }),
+    }),
+  },
+  withDbTimeout: <T>(promise: Promise<T>) => promise,
+}));
+
+vi.mock("@/lib/tmdb", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/tmdb")>();
+  return {
+    ...actual,
+    matchFilmToTMDB: mocks.matchFilmToTMDB,
+    getTMDBClient: () => ({ getFullFilmData: mocks.getFullFilmData }),
+  };
+});
+
+vi.mock("@/lib/posters", () => ({
+  getPosterService: () => ({ findPoster: mocks.findPoster }),
+}));
+
+vi.mock("@/lib/film-similarity", () => ({
+  isSimilarityConfigured: () => false,
+  findMatchingFilm: vi.fn(),
+}));
+
+import { matchAndCreateFromTMDB, type FilmCache } from "./film-matching";
+
+function makeCache(): FilmCache {
+  return {
+    byTitle: new Map(),
+    byTmdbId: new Map(),
+    stats: { hits: 0, misses: 0, dbQueries: 0 },
+    normalizeTitle: (s: string) => s.toLowerCase().trim(),
+  };
+}
+
+function makeFullFilmData(overrides: Record<string, unknown> = {}) {
+  return {
+    details: {
+      imdb_id: "tt0000001",
+      title: "Joyland",
+      original_title: "Joyland",
+      release_date: "2022-11-18",
+      runtime: 126,
+      genres: [{ id: 18, name: "Drama" }],
+      production_countries: [{ iso_3166_1: "PK" }],
+      spoken_languages: [{ iso_639_1: "ur" }],
+      overview: "A synopsis.",
+      tagline: "",
+      poster_path: "/poster.jpg",
+      backdrop_path: null,
+      vote_average: 7.4,
+      popularity: 12.3,
+      ...overrides,
+    },
+    directors: ["Saim Sadiq"],
+    cast: [],
+    certification: "15",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.selectLimit.mockResolvedValue([]);
+  mocks.insertValues.mockResolvedValue(undefined);
+  mocks.findPoster.mockResolvedValue({ source: "placeholder", url: null });
+});
+
+describe("matchAndCreateFromTMDB — audit trail persistence (step 1)", () => {
+  it("persists matchConfidence/matchStrategy/matchedAt/letterboxdUrl on the films insert", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue({
+      tmdbId: 555,
+      confidence: 0.87,
+      title: "Joyland",
+      year: 2022,
+      posterPath: "/poster.jpg",
+    });
+    mocks.getFullFilmData.mockResolvedValue(makeFullFilmData());
+
+    const filmId = await matchAndCreateFromTMDB(makeCache(), "Joyland", 2022);
+
+    expect(filmId).not.toBeNull();
+    expect(mocks.insertValues).toHaveBeenCalledTimes(1);
+    const payload = mocks.insertValues.mock.calls[0][0];
+    expect(payload.matchConfidence).toBe(0.87);
+    expect(payload.matchStrategy).toBe("auto-with-year");
+    expect(payload.matchedAt).toBeInstanceOf(Date);
+    expect(payload.letterboxdUrl).toBe("https://letterboxd.com/tmdb/555");
+  });
+
+  it("returns existing film id without inserting when TMDB id already exists in DB", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue({
+      tmdbId: 555,
+      confidence: 0.9,
+      title: "Joyland",
+      year: 2022,
+      posterPath: null,
+    });
+    mocks.selectLimit.mockResolvedValue([{ id: "existing-film-id" }]);
+
+    const filmId = await matchAndCreateFromTMDB(makeCache(), "Joyland", 2022);
+
+    expect(filmId).toBe("existing-film-id");
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+});

--- a/src/scrapers/utils/film-matching-tmdb.test.ts
+++ b/src/scrapers/utils/film-matching-tmdb.test.ts
@@ -174,3 +174,37 @@ describe("matchAndCreateFromTMDB — year discipline (step 2)", () => {
     );
   });
 });
+
+describe("matchAndCreateFromTMDB — hint threading (step 6)", () => {
+  it("threads runtime and venueLanguages hints into matchFilmToTMDB", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue(null);
+
+    await matchAndCreateFromTMDB(
+      makeCache(),
+      "La Piscine",
+      1969,
+      "Jacques Deray",
+      undefined,
+      120,
+      ["fr"]
+    );
+
+    expect(mocks.matchFilmToTMDB).toHaveBeenCalledWith("La Piscine", {
+      year: 1969,
+      director: "Jacques Deray",
+      runtime: 120,
+      venueLanguages: ["fr"],
+    });
+  });
+
+  it("leaves runtime and venueLanguages undefined when not provided", async () => {
+    mocks.matchFilmToTMDB.mockResolvedValue(null);
+
+    await matchAndCreateFromTMDB(makeCache(), "Joyland", 2022);
+
+    expect(mocks.matchFilmToTMDB).toHaveBeenCalledWith(
+      "Joyland",
+      expect.objectContaining({ runtime: undefined, venueLanguages: undefined })
+    );
+  });
+});

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -161,8 +161,21 @@ export async function matchAndCreateFromTMDB(
   scraperDirector?: string,
   scraperPosterUrl?: string
 ): Promise<string | null> {
+  // Year discipline: many scrapers send the SCREENING year as the film year,
+  // and pipeline.ts also extracts "(YYYY)" from titles — for the current year
+  // those are indistinguishable from screening-year pollution. A wrong
+  // current-year hint gives junk stubs a +0.2/+0.3 exact-year bonus and
+  // SELECTS the wrong film; losing a true hint merely costs a bonus. Same
+  // rule as createFilmWithoutTMDB: only accept years strictly before the
+  // current year (and within sane bounds).
+  const currentYear = new Date().getFullYear();
+  const releaseYearHint =
+    scraperYear && scraperYear >= 1900 && scraperYear < currentYear
+      ? scraperYear
+      : undefined;
+
   const match = await matchFilmToTMDB(matchingTitle, {
-    year: scraperYear,
+    year: releaseYearHint,
     director: scraperDirector,
   });
 

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -240,6 +240,13 @@ export async function matchAndCreateFromTMDB(
     decade: guardedYear ? getDecade(guardedYear) : null,
     tmdbRating: details.details.vote_average,
     tmdbPopularity: details.details.popularity,
+    // Match audit trail — must mirror the addToFilmCache call below. These
+    // were silently dropped before plan 005: only 4.3% of matched films had
+    // any recorded confidence.
+    letterboxdUrl: `https://letterboxd.com/tmdb/${match.tmdbId}`,
+    matchConfidence: match.confidence ?? null,
+    matchStrategy: "auto-with-year",
+    matchedAt: new Date(),
   });
 
   // Add to cache so subsequent lookups in this run find it

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -159,7 +159,9 @@ export async function matchAndCreateFromTMDB(
   matchingTitle: string,
   scraperYear?: number,
   scraperDirector?: string,
-  scraperPosterUrl?: string
+  scraperPosterUrl?: string,
+  scraperRuntime?: number,
+  venueLanguages?: string[]
 ): Promise<string | null> {
   // Year discipline: many scrapers send the SCREENING year as the film year,
   // and pipeline.ts also extracts "(YYYY)" from titles — for the current year
@@ -177,6 +179,8 @@ export async function matchAndCreateFromTMDB(
   const match = await matchFilmToTMDB(matchingTitle, {
     year: releaseYearHint,
     director: scraperDirector,
+    runtime: scraperRuntime,
+    venueLanguages,
   });
 
   if (!match) {

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -183,6 +183,15 @@ export async function matchAndCreateFromTMDB(
     venueLanguages,
   });
 
+  // Audit-trail accuracy: record the strategy that actually applied. After
+  // year-stripping, a current-year film matches with NO year hint — labeling
+  // it "auto-with-year" would be wrong (schema vocabulary: films.ts).
+  const matchStrategy = releaseYearHint
+    ? "auto-with-year"
+    : scraperDirector
+      ? "auto-with-director"
+      : "auto-no-hints";
+
   if (!match) {
     return null;
   }
@@ -262,7 +271,7 @@ export async function matchAndCreateFromTMDB(
     // any recorded confidence.
     letterboxdUrl: `https://letterboxd.com/tmdb/${match.tmdbId}`,
     matchConfidence: match.confidence ?? null,
-    matchStrategy: "auto-with-year",
+    matchStrategy,
     matchedAt: new Date(),
   });
 
@@ -298,7 +307,7 @@ export async function matchAndCreateFromTMDB(
     letterboxdUrl: `https://letterboxd.com/tmdb/${match.tmdbId}`,
     letterboxdRating: null,
     matchConfidence: match.confidence ?? null,
-    matchStrategy: "auto-with-year",
+    matchStrategy,
     matchedAt: new Date(),
     enrichmentStatus: null,
     createdAt: new Date(),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,24 @@
+# Plan 005: TMDB matcher signals (feat/tmdb-matcher-signals)
+
+Drift check: clean (no in-scope file changed 716e543..HEAD; all excerpts verified 2026-06-12)
+findBestMatch callers: only matchFilmToTMDB (2 call sites, both in match.ts) — Step 4 safe.
+Registry check: only `cine-lumiere` verifiable for language priors (no goethe-institut id).
+
+- [x] Step 1: persist match audit trail in films INSERT (test first) — 8e36c99
+- [x] Step 2: year discipline at matcher boundary — 65a60b5
+- [x] Step 3: runtime cross-check (MatchHints.runtime + RawScreening.runtime) — b91d392
+- [x] Step 4: director credit tie-break (findBestMatch async) — ec1b8de
+- [x] Step 5: venue original-language prior — 010875b
+- [x] Step 6: thread hints through pipeline — 2149d8e
+- [x] Step 7: changelogs + plans/README row — 6c9e72b
+
+## Review
+- All 7 steps complete, TDD style, one commit per step.
+- Verification: npm run test:run (113 files / 1721 tests green), npm run lint
+  (exit 0, 60 pre-existing warnings, none in touched files), npx tsc --noEmit clean.
+- No existing test's expected match outcome flipped.
+- Deviation noted: runtime cross-check rejects TMDB runtime 0/null vs feature
+  hint (per the plan's test cases; the plan's code snippet skipped runtime 0 —
+  contradiction resolved in favour of the stated test expectations since junk
+  stubs have runtime 0/null, which is the bug being fixed).
+- PR not opened — orchestrator reviews the diff first.


### PR DESCRIPTION
## Summary
Implements `plans/005-tmdb-matcher-signals.md` — the accuracy core of the 2026-06-11 scrape audit. Production context: confirmed wrong matches (*Joyland* → a Kansas amusement-park doc, *Persepolis* → the archaeological site), and only 4.3% of matched films carried any match-confidence audit trail.

## Changes (7 TDD commits + review hardening)
1. **Audit-trail bug fix**: the films INSERT silently dropped `matchConfidence`/`matchStrategy`/`matchedAt`/`letterboxdUrl` that the cache-add set — now mirrored exactly.
2. **Year discipline**: current/future-year hints (screening-year pollution that handed 2026 junk stubs a +0.3 exact-year bonus over the real classic) are stripped before matching; historical years pass through.
3. **Runtime cross-check**: when a venue runtime hint exists, the winner's TMDB runtime is verified — stubs/shorts rejected vs feature hints, −0.15 for >30 min mismatch, re-gated on the 0.6 floor. Strictly gated: zero extra API calls until scrapers send runtime (plan 006).
4. **Director credit tie-break**: ≥2 close competitors + director hint → resolve via person credits, ±0.15/−0.1. Fixes the Dracula-at-the-ICA class (popularity no longer the only tiebreaker).
5. **Venue language prior**: +0.05 for `original_language` matching `VENUE_LANGUAGE_PRIORS` (Ciné Lumière → fr). Zero API cost.
6. **Hint threading** through pipeline → matcher; `RawScreening.runtime` field added (populated by plan 006).

**Review hardening** (code-reviewer verdict ship-with-nits; nits fixed): director tie-break no-ops when the resolved director directs no close candidate (dirty hint/namesake could previously reject correct matches or promote an unexamined candidate); runtime check survives transient TMDB failures instead of degrading the match to a TMDB-less film row; `matchStrategy` derived from hints that actually applied (`auto-with-year`/`auto-with-director`/`auto-no-hints`).

**Guarantees**: no-hints path bit-identical (reviewer-verified by inspection + full suite unchanged); 0.6 confidence floor untouched.

## Verification
- `npm run test:run`: **113 files / 1725 tests pass** (~34 new, all TMDB calls mocked; production failure classes pinned: Cronos-stub, Dracula-tie, year-contamination, dirty-director-hint)
- `npx tsc --noEmit` clean · `npm run lint` 0 errors
- Reviewer follow-ups deferred to plan 006 (noted there): INSERT/cache year-sanitization divergence (pre-existing), stub-reject → try runner-up, duplicate getFilmDetails on verified matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)