### PR TITLE
feat(data): re-match sweep for unmatched films + preventive blocklist (plan 008)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-06-12: Unmatched re-match sweep + preventive blocklist + decoration suffixes (plan 008)
+**PR**: pending | **Files**: `src/scripts/rematch-unmatched-films.ts`, `src/scrapers/utils/film-title-cleaner.ts`, `src/scrapers/utils/film-matching.ts`, `src/lib/tmdb/blocklist.ts`, `src/scripts/run-scrape-and-enrich.ts`, `package.json`
+- New `npm run rematch:unmatched` (default-dry, `--execute`, `--limit N`): retries TMDB matching for unmatched films with upcoming screenings; UPDATE in place (match_strategy='rematch-sweep' + letterboxd /tmdb/{id}) or MERGE into the row that already owns the tmdb_id (transactional repoint-before-delete); suspected non-films flagged only.
+- Derived-year second-chance pass for hint-less classics (Aliens/Adaptation anchors): dominant exact-title candidate supplies a year hint, real matcher must confirm independently at the unchanged 0.6 floor.
+- `initFilmCache` no longer serves blocklisted (known-wrong) TMDB ids via the tmdb-id index; byTitle still serves the row so no duplicate film rows spawn.
+- Cleaner strips `(Subbed)`/`(Dubbed)`/bare `(4K)`, runs suffix strips to fixpoint (stacked decorations), and returns `extractedYear` instead of discarding stripped `(YYYY)`.
+- Optional pipeline phase (`SCRAPE_REMATCH_SWEEP=1`, default off) runs the sweep `--execute --limit 100` after enrichment.
+
+---
+
 ## 2026-06-12: Pipeline write-resilience — retry queue, validator provenance, progress-file fix (plan 010)
 **PR**: pending | **Files**: `src/scrapers/pipeline.ts`, `src/scrapers/utils/screening-validator.ts`, `src/scrapers/types.ts`, `src/lib/scrape-progress.ts`, `src/scrapers/chains/curzon.ts`, `src/scrapers/chains/everyman.ts`, `src/scrapers/chains/picturehouse.ts`, `src/scrapers/cinemas/castle-calendar.ts`
 - Connection-timeout `insertScreening` failures are now queued and retried once (serial, 1s gap, cap 50/venue) at end of venue instead of being lost until next week's run — the 2026-06-11 runs dropped 19 screenings at electric-white-city alone. Thunks close over resolved filmIds; no re-matching. Non-connection errors (FK violations) are never retried.

--- a/changelogs/2026-06-12-rematch-sweep.md
+++ b/changelogs/2026-06-12-rematch-sweep.md
@@ -53,6 +53,16 @@
   real matcher with that year; the result is accepted only if the matcher
   independently returns the same tmdb id at/above the unchanged floor.
   Derived-year rows are marked "DERIVED year — review" in dry output.
+  Upcoming-conflict guard: when a non-stub exact-title candidate exists in
+  the current/future-year window ("Supergirl" 1984 vs the 2026 DC film,
+  "Masters of the Universe" 1987 vs the 2026 remake — both caught in the
+  production dry run), the pass bails rather than guesses.
+- Code-review hardening: year-hint candidates sanitized individually
+  (polluted row year can't shadow a valid title year); executeUpdate uses
+  429 backoff + the plan-005 write guards; executeMerge pre-deletes dupe
+  screenings that would collide with the primary on the unique
+  (film_id, cinema_id, datetime) index; per-film failure isolation (FAILED
+  bucket) and a 250-UPDATE execute cap matching the plan's STOP threshold.
 
 ### Pipeline wire-up (step 4)
 - `run-scrape-and-enrich.ts` gains an optional post-enrichment phase running

--- a/changelogs/2026-06-12-rematch-sweep.md
+++ b/changelogs/2026-06-12-rematch-sweep.md
@@ -1,0 +1,73 @@
+# Unmatched re-match sweep + preventive blocklist + decoration suffixes (plan 008)
+
+**PR**: pending
+**Date**: 2026-06-12
+
+## Changes
+
+### Title cleaner (step 1, post-#666 remainder)
+- `cleanFilmTitleWithMetadata` now strips `(Subbed)` / `(Dubbed)` and bare
+  `(4K)` decoration suffixes.
+- Suffix stripping runs to fixpoint (max 3 passes) so stacked decorations
+  resolve fully: "AKIRA (2026 Re-release) (Subbed)" → "AKIRA".
+- Stripped trailing `(YYYY)` years and decoration years ("(2026 Re-release)")
+  are no longer discarded: the result carries `extractedYear`, with a plain
+  trailing release year winning over a decoration year on collision. The
+  pipeline keeps consuming `(YYYY)` from the raw title as before (the less
+  invasive option the plan offered); the sweep consumes `extractedYear`.
+
+### Preventive blocklist at cache init (step 2)
+- New `isBlockedTmdbId()` export in `src/lib/tmdb/blocklist.ts`.
+- `initFilmCache` no longer indexes films carrying a blocklisted (known
+  wrong) TMDB id in `byTmdbId` — a recorded-wrong id can never be reused by
+  tmdb-id lookups. The `byTitle` entry is intentionally kept so same-title
+  screenings keep linking to the existing row instead of spawning duplicate
+  film rows (the trap the plan warned about; test written before the code).
+- Logs once per run: `N cached films carry blocklisted TMDB ids — they will
+  be re-matched on next encounter`.
+
+### Re-match sweep (step 3)
+- New `src/scripts/rematch-unmatched-films.ts` (`npm run rematch:unmatched`),
+  default-dry, `--execute` to apply, `--limit N` to cap.
+- Sweeps films with `tmdb_id IS NULL`, `content_type='film'`, and >= 1
+  upcoming screening; cleans titles; flags suspected non-films (audit
+  patterns + live-broadcast keywords + patrol learnings — flag only, never
+  auto-reclassified); matches via the plan-005 matcher (0.6 floor and
+  blocklist filtering built in; ambiguity gate bypassed per the
+  enrich-upcoming-films precedent since dry-run review is the safeguard).
+- UPDATE path: in-place enrichment with full TMDB data, audit trail
+  (`match_strategy='rematch-sweep'`, confidence, matchedAt) and
+  `letterboxd_url=https://letterboxd.com/tmdb/{id}`.
+- MERGE path: when another row already owns the tmdb_id, repoints
+  screenings/season_films/user_film_statuses and deletes the empty row —
+  cleanup-duplicate-films logic in one transaction, with an explicit
+  repoint-before-delete verification.
+- TMDB paced at ~3 req/s with 429 backoff (2s/5s/15s, then abort).
+- Derived-year second-chance pass (anchor fix): hint-less classics like
+  "Aliens"/"Adaptation" (year NULL in prod) fail the primary match because
+  franchise siblings trigger the competition penalty (0.73 − 0.15 = 0.58 <
+  0.6 floor). When the primary match returns nothing AND no year hint
+  existed, the sweep picks a dominant exact-title candidate from raw search
+  results (strict equality, past-year only, popularity ≥ 2, ≥ 5x dominance —
+  ambiguous same-title pairs like "Dracula" stay unresolved) and re-runs the
+  real matcher with that year; the result is accepted only if the matcher
+  independently returns the same tmdb id at/above the unchanged floor.
+  Derived-year rows are marked "DERIVED year — review" in dry output.
+
+### Pipeline wire-up (step 4)
+- `run-scrape-and-enrich.ts` gains an optional post-enrichment phase running
+  the sweep in `--execute --limit 100` mode, gated behind
+  `SCRAPE_REMATCH_SWEEP=1` — default OFF until the operator has watched a
+  few manual runs.
+
+## Impact
+- ~200 currently-unmatched upcoming films become re-matchable; the dry run
+  is the review artifact before any write.
+- Wrong TMDB ids recorded in the blocklist can no longer be served forever
+  from the per-run film cache.
+- Sanity anchors: Aliens → tmdb 679 and Adaptation → tmdb 2757 verified in
+  the production dry run (via the derived-year pass). The third anchor's
+  input row ("CAMP CLASSICS presents Barbarella") no longer exists unmatched
+  in prod — Barbarella (1968, tmdb 8069) is already matched; the cleaner
+  acceptance test proves the prefix strip, and the same title arriving again
+  would MERGE into the existing row.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "agents:verify": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/agents/data-quality/run-verify.ts",
     "agents:fallback-enrich": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/agents/fallback-enrichment/run.ts",
     "enrich:upcoming": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/enrich-upcoming-films.ts",
+    "rematch:unmatched": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/rematch-unmatched-films.ts",
     "cleanup:upcoming": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/cleanup-upcoming-films.ts",
     "audit:films": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/audit-film-data.ts",
     "audit:fix-upcoming": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register scripts/audit-and-fix-upcoming.ts",

--- a/plans/README.md
+++ b/plans/README.md
@@ -25,7 +25,7 @@ Recommended order: 004 → 001 (+002/003) → 005 → 006 ∥ 007 → 008 → 00
 | 005 | TMDB matcher: audit trail, year discipline, runtime/director/language signals | P1 | L | — | DONE (PR #670) |
 | 006 | Scraper metadata capture (runtime at Rio/ICA/Garden/Curzon) | P1 | M | 005 | DONE (pending PR) |
 | 007 | Letterboxd integrity: no-anchor guard, canonical slug, year tolerance | P1 | M | — | DONE (pending PR) |
-| 008 | Unmatched re-match sweep + preventive blocklist + prefix single-sourcing | P1 | M–L | 005 | TODO |
+| 008 | Unmatched re-match sweep + preventive blocklist + prefix single-sourcing | P1 | M–L | 005 | DONE (pending PR/execute) |
 | 009 | sourceId rollout + generalized phantom reconcile | P2 | M–L | 004 | TODO |
 | 010 | Pipeline write-resilience: insert retry queue, validator provenance | P2 | M | 001 | DONE (pending PR) |
 

--- a/src/lib/tmdb/blocklist.ts
+++ b/src/lib/tmdb/blocklist.ts
@@ -95,6 +95,12 @@ export function getBlockedTmdbIds(): Set<number> {
   return ids;
 }
 
+/** TMDB ids recorded as wrong matches; films carrying one need re-matching. */
+export function isBlockedTmdbId(id: number): boolean {
+  loadBlocklist();
+  return wrongIdIndex?.has(id) ?? false;
+}
+
 /**
  * Increment the usage count for a blocklist entry in the learnings JSON.
  * Called when a blocklist entry is actually used to filter a match.

--- a/src/scrapers/utils/film-matching-cache.test.ts
+++ b/src/scrapers/utils/film-matching-cache.test.ts
@@ -6,8 +6,28 @@
  * (initFilmCache, findFilmBySimilarity, matchAndCreateFromTMDB, etc.) need
  * full Drizzle mocks and are out of scope.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  /** Rows returned by the mocked `db.select().from(films)` in initFilmCache. */
+  filmRows: [] as Array<Record<string, unknown>>,
+  /** TMDB ids treated as blocklisted by the mocked blocklist module. */
+  blockedIds: new Set<number>(),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => ({ from: () => Promise.resolve(mocks.filmRows) }),
+  },
+  withDbTimeout: <T>(promise: Promise<T>) => promise,
+}));
+
+vi.mock("@/lib/tmdb/blocklist", () => ({
+  isBlockedTmdbId: (id: number) => mocks.blockedIds.has(id),
+}));
+
 import {
+  initFilmCache,
   lookupFilmInCache,
   logCacheStats,
   type FilmCache,
@@ -119,6 +139,82 @@ describe("logCacheStats", () => {
     const msg = spy.mock.calls[0][0] as string;
     // 1/3 = 33.333...% → "33.3% hit rate"
     expect(msg).toContain("33.3% hit rate");
+    spy.mockRestore();
+  });
+});
+
+describe("initFilmCache — preventive blocklist (plan 008 step 2)", () => {
+  const normalize = (s: string) => s.toLowerCase().trim();
+
+  beforeEach(() => {
+    mocks.filmRows = [];
+    mocks.blockedIds = new Set();
+  });
+
+  it("does not serve a blocklisted tmdbId via byTmdbId", async () => {
+    mocks.filmRows = [
+      { id: "f-wrong", title: "Joyland", tmdbId: 111 },
+      { id: "f-good", title: "Aftersun", tmdbId: 222 },
+    ];
+    mocks.blockedIds = new Set([111]);
+
+    const cache = await initFilmCache(normalize);
+
+    expect(cache.byTmdbId.has(111)).toBe(false);
+    expect(cache.byTmdbId.get(222)?.id).toBe("f-good");
+  });
+
+  it("STILL serves the blocklisted film via byTitle — the duplicate-row trap", async () => {
+    // If the title lookup also skipped the row, every screening for this title
+    // would re-link to a freshly created duplicate film row. The title lookup
+    // must keep returning the existing row; only the tmdb-id index goes blind.
+    mocks.filmRows = [{ id: "f-wrong", title: "Joyland", tmdbId: 111 }];
+    mocks.blockedIds = new Set([111]);
+
+    const cache = await initFilmCache(normalize);
+
+    expect(lookupFilmInCache(cache, "joyland")?.id).toBe("f-wrong");
+  });
+
+  it("leaves non-blocked films fully indexed (both maps)", async () => {
+    mocks.filmRows = [{ id: "f-good", title: "Aftersun", tmdbId: 222 }];
+    mocks.blockedIds = new Set([111]);
+
+    const cache = await initFilmCache(normalize);
+
+    expect(cache.byTmdbId.get(222)?.id).toBe("f-good");
+    expect(lookupFilmInCache(cache, "aftersun")?.id).toBe("f-good");
+  });
+
+  it("logs a once-per-run count of cached films carrying blocklisted ids", async () => {
+    mocks.filmRows = [
+      { id: "f-1", title: "Joyland", tmdbId: 111 },
+      { id: "f-2", title: "Dracula", tmdbId: 333 },
+      { id: "f-3", title: "Aftersun", tmdbId: 222 },
+    ];
+    mocks.blockedIds = new Set([111, 333]);
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await initFilmCache(normalize);
+
+    const blockedLine = spy.mock.calls
+      .map((c) => String(c[0]))
+      .find((m) => m.includes("blocklisted TMDB ids"));
+    expect(blockedLine).toBeDefined();
+    expect(blockedLine).toContain("2 cached films");
+    spy.mockRestore();
+  });
+
+  it("does not log the blocklist line when nothing is blocked", async () => {
+    mocks.filmRows = [{ id: "f-good", title: "Aftersun", tmdbId: 222 }];
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await initFilmCache(normalize);
+
+    const blockedLine = spy.mock.calls
+      .map((c) => String(c[0]))
+      .find((m) => m.includes("blocklisted TMDB ids"));
+    expect(blockedLine).toBeUndefined();
     spy.mockRestore();
   });
 });

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -77,11 +77,14 @@ export async function initFilmCache(
     }
     // Build TMDB ID index — two films with same TMDB ID are always the same film.
     // Preventive blocklist (plan 008): a film carrying a blocklisted (known
-    // wrong) TMDB id must NOT be reachable through the tmdb-id index, or the
-    // wrong id keeps getting reused for every future title that matches to it.
+    // wrong) TMDB id must NOT be reachable through the tmdb-id index, so the
+    // wrong id can't be reused by tmdb-id lookups. Belt-and-braces: the
+    // matcher already filters blocked ids from search results, so this skip
+    // only matters if a blocked id reaches the dedup path some other way.
     // The byTitle entry above is intentionally kept — skipping it too would
     // make the same-title path create a duplicate film row per scrape. Row
-    // repair itself is the rematch sweep's job (rematch-unmatched-films.ts).
+    // REPAIR (re-matching to the correct id) is the rematch sweep's job
+    // (rematch-unmatched-films.ts), not this cache's.
     if (film.tmdbId) {
       if (isBlockedTmdbId(film.tmdbId)) {
         blockedCount++;
@@ -96,7 +99,7 @@ export async function initFilmCache(
   );
   if (blockedCount > 0) {
     console.log(
-      `[Pipeline] ${blockedCount} cached films carry blocklisted TMDB ids — they will be re-matched on next encounter`,
+      `[Pipeline] ${blockedCount} cached films carry blocklisted TMDB ids — invisible to tmdb-id lookups; run the rematch sweep to repair the rows`,
     );
   }
   return cache;

--- a/src/scrapers/utils/film-matching.ts
+++ b/src/scrapers/utils/film-matching.ts
@@ -16,6 +16,7 @@ import {
   isSimilarityConfigured,
 } from "@/lib/film-similarity";
 import { v4 as uuidv4 } from "uuid";
+import { isBlockedTmdbId } from "@/lib/tmdb/blocklist";
 import { sanitizeDirectors, sanitizeYear } from "./film-write-guards";
 
 type FilmRecord = typeof films.$inferSelect;
@@ -66,6 +67,7 @@ export async function initFilmCache(
     "initFilmCache: select films",
   );
 
+  let blockedCount = 0;
   for (const film of allFilms) {
     const normalized = normalizeTitle(film.title);
     // If duplicate normalized titles exist, keep the one with more data (has TMDB ID)
@@ -73,15 +75,30 @@ export async function initFilmCache(
     if (!existing || (film.tmdbId && !existing.tmdbId)) {
       cache.byTitle.set(normalized, film);
     }
-    // Build TMDB ID index — two films with same TMDB ID are always the same film
+    // Build TMDB ID index — two films with same TMDB ID are always the same film.
+    // Preventive blocklist (plan 008): a film carrying a blocklisted (known
+    // wrong) TMDB id must NOT be reachable through the tmdb-id index, or the
+    // wrong id keeps getting reused for every future title that matches to it.
+    // The byTitle entry above is intentionally kept — skipping it too would
+    // make the same-title path create a duplicate film row per scrape. Row
+    // repair itself is the rematch sweep's job (rematch-unmatched-films.ts).
     if (film.tmdbId) {
-      cache.byTmdbId.set(film.tmdbId, film);
+      if (isBlockedTmdbId(film.tmdbId)) {
+        blockedCount++;
+      } else {
+        cache.byTmdbId.set(film.tmdbId, film);
+      }
     }
   }
 
   console.log(
     `[Pipeline] Film cache initialized with ${cache.byTitle.size} unique films, ${cache.byTmdbId.size} TMDB IDs (${allFilms.length} total)`,
   );
+  if (blockedCount > 0) {
+    console.log(
+      `[Pipeline] ${blockedCount} cached films carry blocklisted TMDB ids — they will be re-matched on next encounter`,
+    );
+  }
   return cache;
 }
 

--- a/src/scrapers/utils/film-title-cleaner.test.ts
+++ b/src/scrapers/utils/film-title-cleaner.test.ts
@@ -534,3 +534,63 @@ describe("getKnownNonFilmTypeFromEntries", () => {
     expect(getKnownNonFilmTypeFromEntries("anything", entries)).toBeNull();
   });
 });
+
+describe("decoration suffixes + (YYYY) capture (plan 008)", () => {
+  describe("table-driven acceptance cases", () => {
+    const cases: Array<{ input: string; cleaned: string; year?: number }> = [
+      // Stacked decorations need the fixpoint loop
+      { input: "AKIRA (2026 Re-release) (Subbed)", cleaned: "AKIRA", year: 2026 },
+      { input: "Boogie Nights (4K Restoration)", cleaned: "Boogie Nights" },
+      { input: "Princess Mononoke (Subbed)", cleaned: "Princess Mononoke" },
+      { input: "Princess Mononoke (Dubbed)", cleaned: "Princess Mononoke" },
+      { input: "Seven Samurai (4K)", cleaned: "Seven Samurai" },
+      // Event prefix recoveries from the 2026-06-11 unmatched audit
+      { input: "CAMP CLASSICS presents Barbarella", cleaned: "Barbarella" },
+      // Plain trailing year is captured as a hint, not discarded
+      { input: "Jaws (1975)", cleaned: "Jaws", year: 1975 },
+      // Decoration year + plain year: the plain release year wins
+      { input: "Akira (1988) (2026 Re-release)", cleaned: "Akira", year: 1988 },
+      // Decoration strip can expose a trailing (YYYY) — still captured
+      { input: "Suspiria (1977) (4K Restoration)", cleaned: "Suspiria", year: 1977 },
+    ];
+
+    for (const { input, cleaned, year } of cases) {
+      it(`"${input}" → "${cleaned}"${year ? ` + year ${year}` : ""}`, () => {
+        const result = cleanFilmTitleWithMetadata(input);
+        expect(result.cleanedTitle).toBe(cleaned);
+        if (year) {
+          expect(result.extractedYear).toBe(year);
+        }
+      });
+    }
+  });
+
+  describe("historical prefix-as-title failures must NOT strip", () => {
+    const preserved = [
+      // "The Old Ways" is a film-ish name, not a curatorial prefix — the
+      // after-colon part must not be promoted to the title.
+      "The Old Ways: A Century in Sound",
+      // Franchise / subtitle colons stay intact
+      "Star Wars: The Empire Strikes Back",
+    ];
+
+    for (const title of preserved) {
+      it(`preserves "${title}"`, () => {
+        expect(cleanFilmTitle(title)).toBe(title);
+      });
+    }
+
+    it("does not strip (Subbed)/(Dubbed)-like words mid-title", () => {
+      expect(cleanFilmTitle("Dubbed in Blood")).toBe("Dubbed in Blood");
+    });
+  });
+
+  it("extractedYear is undefined when no year present", () => {
+    expect(cleanFilmTitleWithMetadata("Nosferatu").extractedYear).toBeUndefined();
+  });
+
+  it("remains idempotent on already-clean output", () => {
+    const once = cleanFilmTitle("AKIRA (2026 Re-release) (Subbed)");
+    expect(cleanFilmTitle(once)).toBe(once);
+  });
+});

--- a/src/scrapers/utils/film-title-cleaner.test.ts
+++ b/src/scrapers/utils/film-title-cleaner.test.ts
@@ -594,3 +594,9 @@ describe("decoration suffixes + (YYYY) capture (plan 008)", () => {
     expect(cleanFilmTitle(once)).toBe(once);
   });
 });
+
+describe("fixpoint cap boundary (plan 008)", () => {
+  it("resolves three stacked decorations within the 3-pass cap", () => {
+    expect(cleanFilmTitle("AKIRA (2026 Re-release) (Subbed) (4K)")).toBe("AKIRA");
+  });
+});

--- a/src/scrapers/utils/film-title-cleaner.ts
+++ b/src/scrapers/utils/film-title-cleaner.ts
@@ -492,6 +492,11 @@ export function cleanFilmTitleWithMetadata(title: string): CleanTitleResult {
     // Capture the year inside "(2026 Re-release)"-style decorations as a
     // year hint before the chain below discards it. `??=` so a plain
     // trailing release year (stripTrailingYear above/below) wins on collision.
+    // Known limitation (reviewed, accepted): only decorations trailing at the
+    // START of a pass are seen — "Film (2026 Re-release) (PG)" loses the 2026
+    // because one pass strips "(PG)" and "(2026 Re-release)" in a single
+    // chain. Decoration years are almost always current-year and get
+    // discarded by year discipline anyway.
     const decorationYear = cleaned.match(
       /\((\d{4})\s+(?:re-?release|restoration|reissue|encore)\)\s*$/i,
     );

--- a/src/scrapers/utils/film-title-cleaner.ts
+++ b/src/scrapers/utils/film-title-cleaner.ts
@@ -383,6 +383,14 @@ interface CleanTitleResult {
   cleanedTitle: string;
   strippedPrefix: string | null;
   strippedSuffix: string | null;
+  /**
+   * Year extracted from a stripped trailing "(YYYY)" or from a decoration
+   * suffix like "(2026 Re-release)". A plain trailing release year wins over
+   * a decoration year when both are present. Callers may use it as a TMDB
+   * year hint — subject to the usual year discipline (screening-year
+   * pollution means current/future years must be discarded by the caller).
+   */
+  extractedYear?: number;
 }
 
 /**
@@ -459,13 +467,37 @@ export function cleanFilmTitleWithMetadata(title: string): CleanTitleResult {
     }
   }
 
-  // Strip trailing year like "(1997)" or "(2026)" — year is used as TMDB hint, not title text
-  cleaned = cleaned.replace(/\s*\(\d{4}\)\s*$/, "").trim();
+  // Strip trailing year like "(1997)" or "(2026)" — captured as a TMDB year
+  // hint instead of silently discarded (plan 008). A plain trailing release
+  // year overwrites a decoration year captured below ("Akira (1988) (2026
+  // Re-release)" should hint 1988, not 2026).
+  let extractedYear: number | undefined;
+  const stripTrailingYear = (input: string): string => {
+    const match = input.match(/\s*\((\d{4})\)\s*$/);
+    if (!match) return input;
+    extractedYear = parseInt(match[1], 10);
+    return input.slice(0, match.index).trim();
+  };
+  cleaned = stripTrailingYear(cleaned);
 
   // Capture state before suffix stripping to detect what was removed
   const beforeSuffixStrip = cleaned;
 
-  cleaned = cleaned
+  // Decoration suffixes stack — "AKIRA (2026 Re-release) (Subbed)" needs one
+  // pass to remove "(Subbed)" and a second for "(2026 Re-release)". Apply the
+  // suffix strips iteratively until fixpoint, max 3 passes (plan 008).
+  for (let pass = 0; pass < 3; pass++) {
+    const beforePass = cleaned;
+
+    // Capture the year inside "(2026 Re-release)"-style decorations as a
+    // year hint before the chain below discards it. `??=` so a plain
+    // trailing release year (stripTrailingYear above/below) wins on collision.
+    const decorationYear = cleaned.match(
+      /\((\d{4})\s+(?:re-?release|restoration|reissue|encore)\)\s*$/i,
+    );
+    if (decorationYear) extractedYear ??= parseInt(decorationYear[1], 10);
+
+    cleaned = cleaned
     // Remove BBFC ratings: (U), (PG), (12), (12A), (15), (18), with optional asterisk
     .replace(/\s*\((U|PG|12A?|15|18)\*?\)\s*$/i, "")
     // Remove bracketed notes like [is a Christmas Movie]
@@ -513,21 +545,32 @@ export function cleanFilmTitleWithMetadata(title: string): CleanTitleResult {
     .replace(/\s*\((?:world|uk|london|european?|4k\s+restoration)\s+premiere\)\s*$/i, "")
     // Remove standalone "(Sing-Along)" suffix (prefix version already handled above)
     .replace(/\s*\(sing[\s-]*a[\s-]*long\)\s*$/i, "")
+    // Remove "(Subbed)" / "(Dubbed)" language-presentation decorations
+    .replace(/\s*\((?:subbed|dubbed)\)\s*$/i, "")
+    // Remove bare "(4K)" format decoration ("(4K Restoration)" handled above)
+    .replace(/\s*\(4k\)\s*$/i, "")
     // Remove "- Weird Wednesdays" and similar event series suffixes
     .replace(/\s*-\s*weird\s+wednesdays?\s*$/i, "")
     .trim();
 
-  // Apply patrol-learned suffixes after the hand-curated list, since the
-  // hand-curated patterns are tighter and should win on collision.
-  for (const re of LEARNED_SUFFIX_REGEXES) {
-    cleaned = cleaned.replace(re, "").trim();
+    // Apply patrol-learned suffixes after the hand-curated list, since the
+    // hand-curated patterns are tighter and should win on collision.
+    for (const re of LEARNED_SUFFIX_REGEXES) {
+      cleaned = cleaned.replace(re, "").trim();
+    }
+
+    // A stripped decoration can expose a trailing "(YYYY)" that was hidden
+    // mid-string on entry — capture it too.
+    cleaned = stripTrailingYear(cleaned);
+
+    if (cleaned === beforePass) break;
   }
 
   const strippedSuffix = beforeSuffixStrip !== cleaned
     ? beforeSuffixStrip.slice(cleaned.length).trim()
     : null;
 
-  return { cleanedTitle: cleaned, strippedPrefix, strippedSuffix };
+  return { cleanedTitle: cleaned, strippedPrefix, strippedSuffix, extractedYear };
 }
 
 /**

--- a/src/scripts/rematch-unmatched-films.test.ts
+++ b/src/scripts/rematch-unmatched-films.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the pure helpers in the rematch sweep (plan 008, step 3).
+ * The DB/TMDB orchestration is exercised via the script's default-dry run
+ * against production data; only the pure classification logic is unit-tested.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// The script module imports @/db and @/lib/tmdb at top level — stub them so
+// importing the helpers never touches a database or the network.
+vi.mock("@/db", () => ({ db: {} }));
+vi.mock("@/lib/tmdb", () => ({
+  matchFilmToTMDB: vi.fn(),
+  getTMDBClient: vi.fn(),
+  isRepertoryFilm: vi.fn(),
+  getDecade: vi.fn(),
+}));
+
+import { sanitizeYearHint, isSuspectedNonFilm } from "./rematch-unmatched-films";
+
+describe("sanitizeYearHint", () => {
+  const CURRENT_YEAR = 2026;
+
+  it("accepts a sane past year", () => {
+    expect(sanitizeYearHint(1986, CURRENT_YEAR)).toBe(1986);
+    expect(sanitizeYearHint(2025, CURRENT_YEAR)).toBe(2025);
+  });
+
+  it("rejects the current year (screening-year / re-release pollution)", () => {
+    expect(sanitizeYearHint(2026, CURRENT_YEAR)).toBeUndefined();
+  });
+
+  it("rejects future years", () => {
+    expect(sanitizeYearHint(2030, CURRENT_YEAR)).toBeUndefined();
+  });
+
+  it("rejects pre-1900 and missing years", () => {
+    expect(sanitizeYearHint(1899, CURRENT_YEAR)).toBeUndefined();
+    expect(sanitizeYearHint(0, CURRENT_YEAR)).toBeUndefined();
+    expect(sanitizeYearHint(null, CURRENT_YEAR)).toBeUndefined();
+    expect(sanitizeYearHint(undefined, CURRENT_YEAR)).toBeUndefined();
+  });
+});
+
+describe("isSuspectedNonFilm", () => {
+  it("flags audit non-film patterns (quiz nights etc.)", () => {
+    expect(isSuspectedNonFilm("Picturehouse Quiz Night", "Picturehouse Quiz Night")).toContain(
+      "non-film pattern",
+    );
+  });
+
+  it("flags live-broadcast keywords", () => {
+    expect(isSuspectedNonFilm("NT Live: Hamlet", "Hamlet")).toContain("live-broadcast keyword");
+    expect(isSuspectedNonFilm("Met Opera: Tosca", "Tosca")).toContain("live-broadcast keyword");
+  });
+
+  it("checks the RAW title too, even when the cleaner stripped the signal", () => {
+    // Cleaned title looks like a film, but the raw title carries the signal.
+    expect(isSuspectedNonFilm("Royal Ballet: Giselle", "Giselle")).toContain(
+      "live-broadcast keyword",
+    );
+  });
+
+  it("passes ordinary film titles through", () => {
+    expect(isSuspectedNonFilm("Aliens", "Aliens")).toBeNull();
+    expect(isSuspectedNonFilm("Adaptation", "Adaptation")).toBeNull();
+    expect(isSuspectedNonFilm("CAMP CLASSICS presents Barbarella", "Barbarella")).toBeNull();
+  });
+});

--- a/src/scripts/rematch-unmatched-films.test.ts
+++ b/src/scripts/rematch-unmatched-films.test.ts
@@ -15,7 +15,11 @@ vi.mock("@/lib/tmdb", () => ({
   getDecade: vi.fn(),
 }));
 
-import { sanitizeYearHint, isSuspectedNonFilm } from "./rematch-unmatched-films";
+import {
+  sanitizeYearHint,
+  isSuspectedNonFilm,
+  pickDominantExactTitleMatch,
+} from "./rematch-unmatched-films";
 
 describe("sanitizeYearHint", () => {
   const CURRENT_YEAR = 2026;
@@ -64,5 +68,93 @@ describe("isSuspectedNonFilm", () => {
     expect(isSuspectedNonFilm("Aliens", "Aliens")).toBeNull();
     expect(isSuspectedNonFilm("Adaptation", "Adaptation")).toBeNull();
     expect(isSuspectedNonFilm("CAMP CLASSICS presents Barbarella", "Barbarella")).toBeNull();
+  });
+});
+
+describe("pickDominantExactTitleMatch", () => {
+  const CURRENT_YEAR = 2026;
+
+  function result(overrides: Partial<import("@/lib/tmdb/types").TMDBSearchResult>) {
+    return {
+      id: 0,
+      title: "",
+      original_title: "",
+      overview: "",
+      release_date: "",
+      poster_path: null,
+      backdrop_path: null,
+      vote_average: 0,
+      genre_ids: [],
+      original_language: "en",
+      adult: false,
+      popularity: 0,
+      ...overrides,
+    };
+  }
+
+  it("picks the dominant exact-title classic (the Aliens anchor shape)", () => {
+    const results = [
+      result({ id: 679, title: "Aliens", release_date: "1986-07-18", popularity: 120 }),
+      result({ id: 348, title: "Alien", release_date: "1979-05-25", popularity: 110 }),
+      result({ id: 945961, title: "Alien: Romulus", release_date: "2024-08-13", popularity: 90 }),
+    ];
+    expect(pickDominantExactTitleMatch("Aliens", results, CURRENT_YEAR)).toEqual({
+      tmdbId: 679,
+      year: 1986,
+    });
+  });
+
+  it("requires STRICT title equality — franchise siblings are not exact matches", () => {
+    const results = [
+      result({ id: 348, title: "Alien", release_date: "1979-05-25", popularity: 110 }),
+      result({ id: 945961, title: "Alien: Romulus", release_date: "2024-08-13", popularity: 90 }),
+    ];
+    expect(pickDominantExactTitleMatch("Aliens", results, CURRENT_YEAR)).toBeNull();
+  });
+
+  it("matches on original_title too", () => {
+    const results = [
+      result({
+        id: 426,
+        title: "Queen Margot",
+        original_title: "La Reine Margot",
+        release_date: "1994-05-13",
+        popularity: 15,
+      }),
+    ];
+    expect(pickDominantExactTitleMatch("La Reine Margot", results, CURRENT_YEAR)).toEqual({
+      tmdbId: 426,
+      year: 1994,
+    });
+  });
+
+  it("refuses ambiguous same-title pairs without 5x dominance (the Dracula trap)", () => {
+    const results = [
+      result({ id: 1, title: "Dracula", release_date: "2025-05-30", popularity: 60 }),
+      result({ id: 2, title: "Dracula", release_date: "2024-11-01", popularity: 25 }),
+    ];
+    expect(pickDominantExactTitleMatch("Dracula", results, CURRENT_YEAR)).toBeNull();
+  });
+
+  it("rejects current/future-year candidates (year discipline)", () => {
+    const results = [
+      result({ id: 3, title: "Akira", release_date: "2026-03-01", popularity: 50 }),
+    ];
+    expect(pickDominantExactTitleMatch("Akira", results, CURRENT_YEAR)).toBeNull();
+  });
+
+  it("rejects low-popularity stubs", () => {
+    const results = [
+      result({ id: 4, title: "Light Industry", release_date: "2011-01-01", popularity: 0.4 }),
+    ];
+    expect(pickDominantExactTitleMatch("Light Industry", results, CURRENT_YEAR)).toBeNull();
+  });
+
+  it("ignores adult results and entries without release dates", () => {
+    const results = [
+      result({ id: 5, title: "Aliens", release_date: "1986-07-18", popularity: 80, adult: true }),
+      result({ id: 6, title: "Aliens", release_date: "", popularity: 70 }),
+    ];
+    expect(pickDominantExactTitleMatch("Aliens", results, CURRENT_YEAR)).toBeNull();
   });
 });

--- a/src/scripts/rematch-unmatched-films.test.ts
+++ b/src/scripts/rematch-unmatched-films.test.ts
@@ -158,3 +158,28 @@ describe("pickDominantExactTitleMatch", () => {
     expect(pickDominantExactTitleMatch("Aliens", results, CURRENT_YEAR)).toBeNull();
   });
 });
+
+describe("pickDominantExactTitleMatch — punctuation folding", () => {
+  it('treats TMDB\'s "Adaptation." as an exact match for "Adaptation"', () => {
+    const results = [
+      {
+        id: 2757,
+        title: "Adaptation.",
+        original_title: "Adaptation.",
+        overview: "",
+        release_date: "2002-12-06",
+        poster_path: null,
+        backdrop_path: null,
+        vote_average: 7.5,
+        genre_ids: [],
+        original_language: "en",
+        adult: false,
+        popularity: 30,
+      },
+    ];
+    expect(pickDominantExactTitleMatch("Adaptation", results, 2026)).toEqual({
+      tmdbId: 2757,
+      year: 2002,
+    });
+  });
+});

--- a/src/scripts/rematch-unmatched-films.test.ts
+++ b/src/scripts/rematch-unmatched-films.test.ts
@@ -203,3 +203,41 @@ describe("resolveYearHint", () => {
     expect(resolveYearHint(null, undefined, CURRENT_YEAR)).toBeUndefined();
   });
 });
+
+describe("pickDominantExactTitleMatch — upcoming-conflict guard", () => {
+  function res(id: number, title: string, date: string, popularity: number) {
+    return {
+      id,
+      title,
+      original_title: title,
+      overview: "",
+      release_date: date,
+      poster_path: null,
+      backdrop_path: null,
+      vote_average: 0,
+      genre_ids: [],
+      original_language: "en",
+      adult: false,
+      popularity,
+    };
+  }
+
+  it("bails when a non-stub same-title film exists in the current/future window (Supergirl trap)", () => {
+    const results = [
+      res(9651, "Supergirl", "1984-07-19", 40),
+      res(1234, "Supergirl", "2026-06-26", 95), // the new DC release
+    ];
+    expect(pickDominantExactTitleMatch("Supergirl", results, 2026)).toBeNull();
+  });
+
+  it("ignores upcoming STUBS (below the popularity floor) when guarding", () => {
+    const results = [
+      res(679, "Aliens", "1986-07-18", 120),
+      res(999, "Aliens", "2026-01-01", 0.3), // fan-film stub must not block
+    ];
+    expect(pickDominantExactTitleMatch("Aliens", results, 2026)).toEqual({
+      tmdbId: 679,
+      year: 1986,
+    });
+  });
+});

--- a/src/scripts/rematch-unmatched-films.test.ts
+++ b/src/scripts/rematch-unmatched-films.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/lib/tmdb", () => ({
 
 import {
   sanitizeYearHint,
+  resolveYearHint,
   isSuspectedNonFilm,
   pickDominantExactTitleMatch,
 } from "./rematch-unmatched-films";
@@ -181,5 +182,24 @@ describe("pickDominantExactTitleMatch — punctuation folding", () => {
       tmdbId: 2757,
       year: 2002,
     });
+  });
+});
+
+describe("resolveYearHint", () => {
+  const CURRENT_YEAR = 2026;
+
+  it("prefers a sane film.year over the extracted year", () => {
+    expect(resolveYearHint(1977, 2001, CURRENT_YEAR)).toBe(1977);
+  });
+
+  it("falls through to extractedYear when film.year is polluted (review blocker)", () => {
+    // Screening-year pollution on the row must not shadow a valid title year:
+    // "Suspiria (1977)" with row year 2026 should hint 1977, not nothing.
+    expect(resolveYearHint(2026, 1977, CURRENT_YEAR)).toBe(1977);
+  });
+
+  it("returns undefined when both candidates are unusable", () => {
+    expect(resolveYearHint(2026, 2026, CURRENT_YEAR)).toBeUndefined();
+    expect(resolveYearHint(null, undefined, CURRENT_YEAR)).toBeUndefined();
   });
 });

--- a/src/scripts/rematch-unmatched-films.ts
+++ b/src/scripts/rematch-unmatched-films.ts
@@ -1,0 +1,491 @@
+/**
+ * Re-match sweep for unmatched films (plan 008, step 3).
+ *
+ * 306/993 upcoming films have no tmdb_id and nothing ever retries them — the
+ * pipeline only attempts a match at first sight of a title. This sweep
+ * re-runs TMDB matching for every film that:
+ *   - has tmdb_id IS NULL
+ *   - has content_type = 'film'
+ *   - has at least one upcoming screening
+ *
+ * For each film it cleans the title (fixture-driven cleaner from step 1,
+ * including decoration suffixes and (YYYY) year-hint capture), skips
+ * suspected non-films (flagged for review, never auto-reclassified), and
+ * runs the plan-005 matcher (year discipline, 0.6 confidence floor,
+ * blocklist filtering all built in). Outcomes:
+ *
+ *   UPDATE  — no existing film row has the matched tmdb_id: update the row
+ *             in place with full TMDB data + audit trail
+ *             (match_strategy='rematch-sweep') + letterboxd_url=/tmdb/{id}.
+ *   MERGE   — another film row already owns the tmdb_id: repoint this row's
+ *             screenings/season_films/user_film_statuses to it and delete
+ *             the now-empty row (cleanup-duplicate-films repoint logic, in
+ *             one transaction, with a repoint-before-delete verification).
+ *   SUSPECTED_NON_FILM — title matches the audit non-film patterns; flagged
+ *             only, left untouched.
+ *   NO_MATCH — matcher returned nothing above the confidence floor.
+ *
+ * Usage:
+ *   npm run rematch:unmatched                      # dry run (default)
+ *   npm run rematch:unmatched -- --execute         # apply changes
+ *   npm run rematch:unmatched -- --limit 20        # cap processed films
+ */
+
+import { db } from "@/db";
+import { films, screenings } from "@/db/schema";
+import { and, eq, gte, isNull, sql } from "drizzle-orm";
+import { matchFilmToTMDB, getTMDBClient, isRepertoryFilm, getDecade } from "@/lib/tmdb";
+import { NON_FILM_PATTERNS, LIVE_BROADCAST_KEYWORDS } from "@/lib/title-patterns";
+import {
+  cleanFilmTitleWithMetadata,
+  getKnownNonFilmType,
+} from "@/scrapers/utils/film-title-cleaner";
+
+const DRY_RUN = !process.argv.includes("--execute");
+
+/** TMDB rate limit: ~3 req/s. One film costs 1-3 TMDB calls. */
+const RATE_LIMIT_MS = 350;
+/** Backoff schedule when TMDB answers 429 — do not hammer (plan STOP condition). */
+const RATE_LIMIT_BACKOFF_MS = [2_000, 5_000, 15_000];
+
+function parseLimit(argv: string[]): number | undefined {
+  const idx = argv.indexOf("--limit");
+  if (idx === -1) return undefined;
+  const value = parseInt(argv[idx + 1] ?? "", 10);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`--limit requires a positive integer, got "${argv[idx + 1]}"`);
+  }
+  return value;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Year discipline (plan 005): only accept a year hint that is strictly before
+ * the current year and within sane bounds. Current/future years are
+ * indistinguishable from screening-year pollution (and from re-release years
+ * like "AKIRA (2026 Re-release)") — a wrong current-year hint SELECTS junk
+ * stubs via the exact-year bonus, while a dropped true hint merely costs a
+ * bonus.
+ */
+export function sanitizeYearHint(
+  year: number | null | undefined,
+  currentYear = new Date().getFullYear(),
+): number | undefined {
+  if (year && year >= 1900 && year < currentYear) return year;
+  return undefined;
+}
+
+/**
+ * Suspected non-film check — same signals the audit orchestrator uses
+ * (NON_FILM_PATTERNS + live-broadcast keywords + patrol learnings). Flag
+ * only: the sweep never auto-reclassifies content_type (out of scope per
+ * plan 008).
+ */
+export function isSuspectedNonFilm(rawTitle: string, cleanedTitle: string): string | null {
+  for (const title of [cleanedTitle, rawTitle]) {
+    const pattern = NON_FILM_PATTERNS.find((p) => p.test(title));
+    if (pattern) return `non-film pattern: ${pattern.source}`;
+
+    const lower = title.toLowerCase();
+    const keyword = LIVE_BROADCAST_KEYWORDS.find((k) => lower.includes(k));
+    if (keyword) return `live-broadcast keyword: "${keyword}"`;
+
+    const learnedType = getKnownNonFilmType(title);
+    if (learnedType) return `patrol-learned non-film (${learnedType})`;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// TMDB call with 429 backoff
+// ---------------------------------------------------------------------------
+
+async function matchWithBackoff(
+  title: string,
+  hints: { year?: number; director?: string },
+): Promise<Awaited<ReturnType<typeof matchFilmToTMDB>>> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await matchFilmToTMDB(title, {
+        ...hints,
+        // The titles in this sweep already sit in the DB and have been
+        // through the cleaner; single-word classics like "Aliens" or
+        // "Adaptation" often carry no year/director, and the ambiguity gate
+        // would refuse them outright. Bypassing it follows the
+        // enrich-upcoming-films precedent — the 0.6 confidence floor,
+        // blocklist filtering, and dry-run review are the safeguards here.
+        skipAmbiguityCheck: true,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes("429")) throw error;
+      if (attempt >= RATE_LIMIT_BACKOFF_MS.length) {
+        throw new Error(`TMDB still rate-limiting after ${attempt} backoffs — aborting sweep`);
+      }
+      const wait = RATE_LIMIT_BACKOFF_MS[attempt];
+      console.warn(`  ! TMDB 429 — backing off ${wait / 1000}s`);
+      await sleep(wait);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plan types
+// ---------------------------------------------------------------------------
+
+interface UnmatchedFilm {
+  id: string;
+  title: string;
+  year: number | null;
+  directors: string[];
+}
+
+interface UpdateAction {
+  film: UnmatchedFilm;
+  cleanedTitle: string;
+  tmdbId: number;
+  tmdbTitle: string;
+  tmdbYear: number;
+  confidence: number;
+  yearHint?: number;
+  directorHint?: string;
+}
+
+interface MergeAction {
+  film: UnmatchedFilm;
+  cleanedTitle: string;
+  tmdbId: number;
+  targetFilmId: string;
+  targetTitle: string;
+  screeningCount: number;
+}
+
+interface FlagAction {
+  film: UnmatchedFilm;
+  cleanedTitle: string;
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Execute helpers
+// ---------------------------------------------------------------------------
+
+/** Apply an UPDATE action: enrich the existing row in place with TMDB data. */
+async function executeUpdate(action: UpdateAction): Promise<void> {
+  const client = getTMDBClient();
+  const details = await client.getFullFilmData(action.tmdbId);
+
+  await db
+    .update(films)
+    .set({
+      tmdbId: action.tmdbId,
+      imdbId: details.details.imdb_id || null,
+      title: details.details.title,
+      originalTitle: details.details.original_title,
+      year: action.tmdbYear,
+      runtime: details.details.runtime || null,
+      directors: details.directors.length > 0 ? details.directors : action.film.directors,
+      cast: details.cast,
+      genres: details.details.genres.map((g) => g.name.toLowerCase()),
+      countries: details.details.production_countries.map((c) => c.iso_3166_1),
+      languages: details.details.spoken_languages.map((l) => l.iso_639_1),
+      certification: details.certification || null,
+      synopsis: details.details.overview || null,
+      tagline: details.details.tagline || null,
+      posterUrl: details.details.poster_path
+        ? `https://image.tmdb.org/t/p/w500${details.details.poster_path}`
+        : null,
+      backdropUrl: details.details.backdrop_path
+        ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
+        : null,
+      isRepertory: isRepertoryFilm(details.details.release_date),
+      decade: action.tmdbYear ? getDecade(action.tmdbYear) : null,
+      tmdbRating: details.details.vote_average,
+      tmdbPopularity: details.details.popularity,
+      // Audit trail + Letterboxd anchor, consistent with the pipeline path.
+      letterboxdUrl: `https://letterboxd.com/tmdb/${action.tmdbId}`,
+      matchConfidence: action.confidence,
+      matchStrategy: "rematch-sweep",
+      matchedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(films.id, action.film.id));
+}
+
+/**
+ * Apply a MERGE action: repoint all references from the unmatched row to the
+ * existing row that already owns the tmdb_id, then delete the empty row.
+ * Replicates scripts/cleanup-duplicate-films.ts merge logic, in one
+ * transaction, with a repoint-before-delete verification (plan STOP
+ * condition: never delete a film row that still has screenings).
+ */
+async function executeMerge(action: MergeAction): Promise<void> {
+  const dupeId = action.film.id;
+  const primaryId = action.targetFilmId;
+
+  await db.transaction(async (tx) => {
+    // 1. Repoint screenings
+    await tx
+      .update(screenings)
+      .set({ filmId: primaryId })
+      .where(eq(screenings.filmId, dupeId));
+
+    // 2. Verify the repoint actually happened before any delete
+    const remaining = await tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(screenings)
+      .where(eq(screenings.filmId, dupeId));
+    if ((remaining[0]?.count ?? 0) > 0) {
+      throw new Error(
+        `MERGE aborted: ${remaining[0].count} screenings still point at ${dupeId}`,
+      );
+    }
+
+    // 3. Repoint season_films (conflict-safe: skip rows where the primary is
+    //    already in the season, then delete leftovers)
+    await tx.execute(sql`
+      UPDATE season_films
+      SET film_id = ${primaryId}
+      WHERE film_id = ${dupeId}
+        AND NOT EXISTS (
+          SELECT 1 FROM season_films sf2
+          WHERE sf2.season_id = season_films.season_id
+            AND sf2.film_id = ${primaryId}
+        )
+    `);
+    await tx.execute(sql`DELETE FROM season_films WHERE film_id = ${dupeId}`);
+
+    // 4. Repoint user_film_statuses (conflict-safe on user_id + film_id)
+    await tx.execute(sql`
+      UPDATE user_film_statuses
+      SET film_id = ${primaryId}
+      WHERE film_id = ${dupeId}
+        AND NOT EXISTS (
+          SELECT 1 FROM user_film_statuses ufs2
+          WHERE ufs2.user_id = user_film_statuses.user_id
+            AND ufs2.film_id = ${primaryId}
+        )
+    `);
+    await tx.execute(sql`DELETE FROM user_film_statuses WHERE film_id = ${dupeId}`);
+
+    // 5. Delete the now-empty duplicate row
+    await tx.delete(films).where(eq(films.id, dupeId));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const limit = parseLimit(process.argv);
+
+  console.log(
+    DRY_RUN
+      ? "DRY RUN — no changes will be written (use --execute to apply)\n"
+      : "EXECUTE MODE — unmatched films will be updated/merged\n",
+  );
+
+  const now = new Date();
+
+  // Films with no TMDB match, classified as films, with >= 1 upcoming screening
+  const rows = await db
+    .selectDistinct({
+      id: films.id,
+      title: films.title,
+      year: films.year,
+      directors: films.directors,
+    })
+    .from(films)
+    .innerJoin(screenings, eq(screenings.filmId, films.id))
+    .where(
+      and(
+        isNull(films.tmdbId),
+        eq(films.contentType, "film"),
+        gte(screenings.datetime, now),
+      ),
+    );
+
+  // Deterministic order for reviewable dry-run diffs
+  rows.sort((a, b) => a.title.localeCompare(b.title));
+
+  const candidates = limit ? rows.slice(0, limit) : rows;
+  console.log(
+    `Found ${rows.length} unmatched films with upcoming screenings` +
+      (limit ? ` — processing first ${candidates.length} (--limit ${limit})` : "") +
+      "\n",
+  );
+
+  const updates: UpdateAction[] = [];
+  const merges: MergeAction[] = [];
+  const suspectedNonFilms: FlagAction[] = [];
+  const noMatches: FlagAction[] = [];
+
+  // tmdb_id -> film planned for UPDATE in this run. A second film matching
+  // the same id must MERGE into it (the tmdb_id column is UNIQUE; in dry
+  // mode the DB lookup can't see planned updates, so track them here).
+  const plannedByTmdbId = new Map<number, { id: string; title: string }>();
+
+  for (let i = 0; i < candidates.length; i++) {
+    const film = candidates[i];
+    const meta = cleanFilmTitleWithMetadata(film.title);
+    const cleaned = meta.cleanedTitle;
+    const progress = `[${i + 1}/${candidates.length}]`;
+
+    // Non-film flagging — skip before spending TMDB calls
+    const nonFilmReason = isSuspectedNonFilm(film.title, cleaned);
+    if (nonFilmReason) {
+      suspectedNonFilms.push({ film, cleanedTitle: cleaned, reason: nonFilmReason });
+      console.log(`${progress} FLAG "${film.title}" — ${nonFilmReason}`);
+      continue;
+    }
+
+    const yearHint = sanitizeYearHint(film.year ?? meta.extractedYear);
+    const directorHint = film.directors?.[0] || undefined;
+
+    let match: Awaited<ReturnType<typeof matchFilmToTMDB>>;
+    try {
+      match = await matchWithBackoff(cleaned, { year: yearHint, director: directorHint });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("aborting sweep")) throw error;
+      console.warn(`${progress} ERROR "${film.title}": ${message}`);
+      noMatches.push({ film, cleanedTitle: cleaned, reason: `error: ${message}` });
+      await sleep(RATE_LIMIT_MS);
+      continue;
+    }
+
+    if (!match) {
+      noMatches.push({ film, cleanedTitle: cleaned, reason: "no match above floor" });
+      console.log(`${progress} NO_MATCH "${film.title}" (searched "${cleaned}")`);
+      await sleep(RATE_LIMIT_MS);
+      continue;
+    }
+
+    // Does another row already own this tmdb_id? (DB row, or an UPDATE
+    // planned/applied earlier in this run.)
+    const planned = plannedByTmdbId.get(match.tmdbId);
+    const existing = planned
+      ? [{ id: planned.id, title: planned.title }]
+      : await db
+          .select({ id: films.id, title: films.title })
+          .from(films)
+          .where(eq(films.tmdbId, match.tmdbId))
+          .limit(1);
+
+    if (existing.length > 0) {
+      const screeningCount = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(screenings)
+        .where(eq(screenings.filmId, film.id));
+
+      const action: MergeAction = {
+        film,
+        cleanedTitle: cleaned,
+        tmdbId: match.tmdbId,
+        targetFilmId: existing[0].id,
+        targetTitle: existing[0].title,
+        screeningCount: screeningCount[0]?.count ?? 0,
+      };
+      merges.push(action);
+      console.log(
+        `${progress} MERGE "${film.title}" → existing "${existing[0].title}" ` +
+          `(tmdb ${match.tmdbId}), ${action.screeningCount} screenings to repoint`,
+      );
+      if (!DRY_RUN) {
+        await executeMerge(action);
+      }
+    } else {
+      const action: UpdateAction = {
+        film,
+        cleanedTitle: cleaned,
+        tmdbId: match.tmdbId,
+        tmdbTitle: match.title,
+        tmdbYear: match.year,
+        confidence: match.confidence,
+        yearHint,
+        directorHint,
+      };
+      updates.push(action);
+      plannedByTmdbId.set(match.tmdbId, { id: film.id, title: match.title });
+      console.log(
+        `${progress} UPDATE "${film.title}" → "${match.title}" (${match.year}) ` +
+          `[tmdb ${match.tmdbId}, conf ${match.confidence.toFixed(2)}]`,
+      );
+      if (!DRY_RUN) {
+        await executeUpdate(action);
+      }
+    }
+
+    await sleep(RATE_LIMIT_MS);
+  }
+
+  // -------------------------------------------------------------------------
+  // Plan summary, grouped by action
+  // -------------------------------------------------------------------------
+  const mode = DRY_RUN ? "would be applied with --execute" : "applied";
+
+  console.log(`\n${"=".repeat(70)}`);
+  console.log(`=== UPDATE (${updates.length}) — ${mode} ===`);
+  for (const u of updates) {
+    const hints = [
+      u.yearHint ? `year ${u.yearHint}` : null,
+      u.directorHint ? `director ${u.directorHint}` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    console.log(
+      `  "${u.film.title}" → "${u.tmdbTitle}" (${u.tmdbYear}) ` +
+        `tmdb=${u.tmdbId} conf=${u.confidence.toFixed(2)}${hints ? ` [${hints}]` : ""}`,
+    );
+  }
+
+  console.log(`\n=== MERGE (${merges.length}) — ${mode} ===`);
+  for (const m of merges) {
+    console.log(
+      `  "${m.film.title}" [${m.film.id}] → "${m.targetTitle}" [${m.targetFilmId}] ` +
+        `tmdb=${m.tmdbId}, ${m.screeningCount} screenings`,
+    );
+  }
+
+  console.log(`\n=== SUSPECTED_NON_FILM (${suspectedNonFilms.length}) — flagged only, never auto-reclassified ===`);
+  for (const f of suspectedNonFilms) {
+    console.log(`  "${f.film.title}" — ${f.reason}`);
+  }
+
+  console.log(`\n=== NO_MATCH (${noMatches.length}) ===`);
+  for (const f of noMatches) {
+    console.log(`  "${f.film.title}" (searched "${f.cleanedTitle}") — ${f.reason}`);
+  }
+
+  console.log(`\n${"=".repeat(70)}`);
+  console.log(`Summary: ${candidates.length} processed`);
+  console.log(`  UPDATE:             ${updates.length}`);
+  console.log(`  MERGE:              ${merges.length}`);
+  console.log(`  SUSPECTED_NON_FILM: ${suspectedNonFilms.length}`);
+  console.log(`  NO_MATCH:           ${noMatches.length}`);
+  if (DRY_RUN) {
+    console.log("\n[DRY RUN] No changes were made. Review the UPDATE/MERGE lists, then re-run with --execute.");
+  }
+}
+
+// Only run when called directly (not when imported by tests)
+const isDirectRun =
+  process.argv[1]?.endsWith("rematch-unmatched-films.ts") ||
+  process.argv[1]?.endsWith("rematch-unmatched-films.js");
+
+if (isDirectRun) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error("Error:", err);
+      process.exit(1);
+    });
+}

--- a/src/scripts/rematch-unmatched-films.ts
+++ b/src/scripts/rematch-unmatched-films.ts
@@ -171,7 +171,7 @@ export function pickDominantExactTitleMatch(
   const target = normalizeExact(cleanedTitle);
   if (!target) return null;
 
-  const exact = results
+  const exactAllYears = results
     .filter(
       (r) =>
         !r.adult &&
@@ -179,7 +179,20 @@ export function pickDominantExactTitleMatch(
         (normalizeExact(r.title) === target || normalizeExact(r.original_title) === target),
     )
     .map((r) => ({ r, year: parseInt(r.release_date.split("-")[0], 10) }))
-    .filter(({ year }) => Number.isInteger(year) && year >= 1900 && year < currentYear);
+    .filter(({ year }) => Number.isInteger(year) && year >= 1900);
+
+  // Upcoming-conflict guard: when a NON-stub exact-title film exists in the
+  // current/future-year window, the bare title is ambiguous between the
+  // classic and the new release ("Supergirl" 1984 vs the 2026 DC film,
+  // "Masters of the Universe" 1987 vs the 2026 remake — both real cases from
+  // the first production dry run). A venue listing the bare title during the
+  // remake's release window could mean either — bail out rather than guess.
+  const hasUpcomingConflict = exactAllYears.some(
+    ({ r, year }) => year >= currentYear && r.popularity >= EXACT_TITLE_MIN_POPULARITY,
+  );
+  if (hasUpcomingConflict) return null;
+
+  const exact = exactAllYears.filter(({ year }) => year < currentYear);
 
   if (exact.length === 0) return null;
 

--- a/src/scripts/rematch-unmatched-films.ts
+++ b/src/scripts/rematch-unmatched-films.ts
@@ -110,14 +110,16 @@ const EXACT_TITLE_DOMINANCE_RATIO = 5;
 
 /** Strict normalizer for exact-title equality — deliberately NOT the loose
  *  matcher normalizer (which strips ": subtitles", so "Alien: Romulus" would
- *  "equal" "Alien"). Lowercase, fold diacritics, collapse whitespace. */
+ *  "equal" "Alien"). Lowercase, fold diacritics, fold punctuation to spaces
+ *  (TMDB's official title for the 2002 Jonze film is "Adaptation." with a
+ *  trailing period), collapse whitespace. The words themselves must still
+ *  match exactly — "alien romulus" remains distinct from "aliens". */
 function normalizeExact(title: string): string {
   return title
     .toLowerCase()
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "")
-    .replace(/['‘’]/g, "'")
-    .replace(/[“”]/g, '"')
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/scripts/rematch-unmatched-films.ts
+++ b/src/scripts/rematch-unmatched-films.ts
@@ -41,6 +41,7 @@ import {
   cleanFilmTitleWithMetadata,
   getKnownNonFilmType,
 } from "@/scrapers/utils/film-title-cleaner";
+import { sanitizeDirectors, sanitizeYear } from "@/scrapers/utils/film-write-guards";
 
 const DRY_RUN = !process.argv.includes("--execute");
 
@@ -48,6 +49,8 @@ const DRY_RUN = !process.argv.includes("--execute");
 const RATE_LIMIT_MS = 350;
 /** Backoff schedule when TMDB answers 429 — do not hammer (plan STOP condition). */
 const RATE_LIMIT_BACKOFF_MS = [2_000, 5_000, 15_000];
+/** Plan STOP condition: >250 UPDATEs in one run is suspiciously high. */
+const MAX_EXECUTE_UPDATES = 250;
 
 function parseLimit(argv: string[]): number | undefined {
   const idx = argv.indexOf("--limit");
@@ -81,6 +84,23 @@ export function sanitizeYearHint(
 ): number | undefined {
   if (year && year >= 1900 && year < currentYear) return year;
   return undefined;
+}
+
+/**
+ * Compose the year hint from the film row and the title-extracted year.
+ * Each candidate is sanitized INDIVIDUALLY: a polluted `film.year` (e.g. a
+ * screening year written before the write guards landed) must not shadow a
+ * valid year extracted from the title — "Suspiria (1977)" with row year 2026
+ * should hint 1977, not nothing. (Code-review blocker fix.)
+ */
+export function resolveYearHint(
+  filmYear: number | null | undefined,
+  extractedYear: number | undefined,
+  currentYear = new Date().getFullYear(),
+): number | undefined {
+  return (
+    sanitizeYearHint(filmYear, currentYear) ?? sanitizeYearHint(extractedYear, currentYear)
+  );
 }
 
 /**
@@ -258,7 +278,15 @@ interface FlagAction {
 /** Apply an UPDATE action: enrich the existing row in place with TMDB data. */
 async function executeUpdate(action: UpdateAction): Promise<void> {
   const client = getTMDBClient();
-  const details = await client.getFullFilmData(action.tmdbId);
+  const details = await withTmdbBackoff(() => client.getFullFilmData(action.tmdbId));
+
+  // Same write guards as the pipeline path (film-matching.ts) — every
+  // film-write path enforces the same invariants (code-review major).
+  const guardedYear = sanitizeYear(action.tmdbYear);
+  const guardedDirectors = sanitizeDirectors(
+    details.directors.length > 0 ? details.directors : action.film.directors,
+    `rematch-sweep tmdb=${action.tmdbId} title="${details.details.title}"`,
+  );
 
   await db
     .update(films)
@@ -267,9 +295,9 @@ async function executeUpdate(action: UpdateAction): Promise<void> {
       imdbId: details.details.imdb_id || null,
       title: details.details.title,
       originalTitle: details.details.original_title,
-      year: action.tmdbYear,
+      year: guardedYear,
       runtime: details.details.runtime || null,
-      directors: details.directors.length > 0 ? details.directors : action.film.directors,
+      directors: guardedDirectors,
       cast: details.cast,
       genres: details.details.genres.map((g) => g.name.toLowerCase()),
       countries: details.details.production_countries.map((c) => c.iso_3166_1),
@@ -284,7 +312,7 @@ async function executeUpdate(action: UpdateAction): Promise<void> {
         ? `https://image.tmdb.org/t/p/w1280${details.details.backdrop_path}`
         : null,
       isRepertory: isRepertoryFilm(details.details.release_date),
-      decade: action.tmdbYear ? getDecade(action.tmdbYear) : null,
+      decade: guardedYear ? getDecade(guardedYear) : null,
       tmdbRating: details.details.vote_average,
       tmdbPopularity: details.details.popularity,
       // Audit trail + Letterboxd anchor, consistent with the pipeline path.
@@ -309,6 +337,22 @@ async function executeMerge(action: MergeAction): Promise<void> {
   const primaryId = action.targetFilmId;
 
   await db.transaction(async (tx) => {
+    // 0. Drop dupe screenings that would collide with the primary on the
+    //    unique (film_id, cinema_id, datetime) index after repoint — they are
+    //    true duplicates of rows the primary already has (the sanctioned
+    //    deletion case). Without this, a single collision aborts the merge
+    //    (code-review major; the BFI phantom rows make it a real scenario).
+    await tx.execute(sql`
+      DELETE FROM screenings s
+      WHERE s.film_id = ${dupeId}
+        AND EXISTS (
+          SELECT 1 FROM screenings p
+          WHERE p.film_id = ${primaryId}
+            AND p.cinema_id = s.cinema_id
+            AND p.datetime = s.datetime
+        )
+    `);
+
     // 1. Repoint screenings
     await tx
       .update(screenings)
@@ -405,6 +449,7 @@ async function main(): Promise<void> {
   const merges: MergeAction[] = [];
   const suspectedNonFilms: FlagAction[] = [];
   const noMatches: FlagAction[] = [];
+  const failed: FlagAction[] = [];
 
   // tmdb_id -> film planned for UPDATE in this run. A second film matching
   // the same id must MERGE into it (the tmdb_id column is UNIQUE; in dry
@@ -425,7 +470,7 @@ async function main(): Promise<void> {
       continue;
     }
 
-    const yearHint = sanitizeYearHint(film.year ?? meta.extractedYear);
+    const yearHint = resolveYearHint(film.year, meta.extractedYear);
     const directorHint = film.directors?.[0] || undefined;
 
     let match: Awaited<ReturnType<typeof matchFilmToTMDB>>;
@@ -495,13 +540,24 @@ async function main(): Promise<void> {
         targetTitle: existing[0].title,
         screeningCount: screeningCount[0]?.count ?? 0,
       };
-      merges.push(action);
       console.log(
         `${progress} MERGE "${film.title}" → existing "${existing[0].title}" ` +
           `(tmdb ${match.tmdbId}), ${action.screeningCount} screenings to repoint`,
       );
-      if (!DRY_RUN) {
-        await executeMerge(action);
+      if (DRY_RUN) {
+        merges.push(action);
+      } else {
+        // Per-film failure isolation: one failed write (unique violation
+        // from a concurrent scrape, transient TMDB/DB error) must not abort
+        // the rest of the run. The transaction guarantees per-film atomicity.
+        try {
+          await executeMerge(action);
+          merges.push(action);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.warn(`${progress} MERGE FAILED "${film.title}": ${message}`);
+          failed.push({ film, cleanedTitle: cleaned, reason: `merge failed: ${message}` });
+        }
       }
     } else {
       const action: UpdateAction = {
@@ -515,14 +571,31 @@ async function main(): Promise<void> {
         derivedYear,
         directorHint,
       };
-      updates.push(action);
-      plannedByTmdbId.set(match.tmdbId, { id: film.id, title: match.title });
       console.log(
         `${progress} UPDATE "${film.title}" → "${match.title}" (${match.year}) ` +
           `[tmdb ${match.tmdbId}, conf ${match.confidence.toFixed(2)}]`,
       );
-      if (!DRY_RUN) {
-        await executeUpdate(action);
+      if (DRY_RUN) {
+        updates.push(action);
+        plannedByTmdbId.set(match.tmdbId, { id: film.id, title: match.title });
+      } else if (updates.length >= MAX_EXECUTE_UPDATES) {
+        // Plan STOP condition: >250 proposed UPDATEs is suspiciously high.
+        // In execute mode stop applying instead of ploughing on.
+        console.warn(
+          `${progress} UPDATE cap reached (${MAX_EXECUTE_UPDATES}) — skipping "${film.title}"; ` +
+            "review with the operator before a larger run",
+        );
+        failed.push({ film, cleanedTitle: cleaned, reason: "skipped: execute UPDATE cap reached" });
+      } else {
+        try {
+          await executeUpdate(action);
+          updates.push(action);
+          plannedByTmdbId.set(match.tmdbId, { id: film.id, title: match.title });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.warn(`${progress} UPDATE FAILED "${film.title}": ${message}`);
+          failed.push({ film, cleanedTitle: cleaned, reason: `update failed: ${message}` });
+        }
       }
     }
 
@@ -568,13 +641,29 @@ async function main(): Promise<void> {
     console.log(`  "${f.film.title}" (searched "${f.cleanedTitle}") — ${f.reason}`);
   }
 
+  if (failed.length > 0) {
+    console.log(`\n=== FAILED (${failed.length}) — left untouched, re-run to retry ===`);
+    for (const f of failed) {
+      console.log(`  "${f.film.title}" — ${f.reason}`);
+    }
+  }
+
   console.log(`\n${"=".repeat(70)}`);
   console.log(`Summary: ${candidates.length} processed`);
   console.log(`  UPDATE:             ${updates.length}`);
   console.log(`  MERGE:              ${merges.length}`);
   console.log(`  SUSPECTED_NON_FILM: ${suspectedNonFilms.length}`);
   console.log(`  NO_MATCH:           ${noMatches.length}`);
+  if (failed.length > 0) {
+    console.log(`  FAILED:             ${failed.length}`);
+  }
   if (DRY_RUN) {
+    if (updates.length > MAX_EXECUTE_UPDATES) {
+      console.warn(
+        `\n[WARNING] ${updates.length} proposed UPDATEs exceeds the ${MAX_EXECUTE_UPDATES} ` +
+          "STOP threshold — review with the operator before executing.",
+      );
+    }
     console.log("\n[DRY RUN] No changes were made. Review the UPDATE/MERGE lists, then re-run with --execute.");
   }
 }

--- a/src/scripts/rematch-unmatched-films.ts
+++ b/src/scripts/rematch-unmatched-films.ts
@@ -35,6 +35,7 @@ import { db } from "@/db";
 import { films, screenings } from "@/db/schema";
 import { and, eq, gte, isNull, sql } from "drizzle-orm";
 import { matchFilmToTMDB, getTMDBClient, isRepertoryFilm, getDecade } from "@/lib/tmdb";
+import type { TMDBSearchResult } from "@/lib/tmdb/types";
 import { NON_FILM_PATTERNS, LIVE_BROADCAST_KEYWORDS } from "@/lib/title-patterns";
 import {
   cleanFilmTitleWithMetadata,
@@ -103,26 +104,81 @@ export function isSuspectedNonFilm(rawTitle: string, cleanedTitle: string): stri
   return null;
 }
 
+/** Derived-year fallback guards (see pickDominantExactTitleMatch). */
+const EXACT_TITLE_MIN_POPULARITY = 2;
+const EXACT_TITLE_DOMINANCE_RATIO = 5;
+
+/** Strict normalizer for exact-title equality — deliberately NOT the loose
+ *  matcher normalizer (which strips ": subtitles", so "Alien: Romulus" would
+ *  "equal" "Alien"). Lowercase, fold diacritics, collapse whitespace. */
+function normalizeExact(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/['‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Second-chance pass for hint-less films: plain classic titles like "Aliens"
+ * or "Adaptation" fail the primary match not because the film is unclear but
+ * because franchise siblings trigger the competition penalty (0.73 - 0.15 =
+ * 0.58 < the 0.6 floor) and the DB rows carry no year/director to recover it.
+ *
+ * From the raw search results, pick a candidate ONLY when:
+ *   - its title or original_title is an exact normalized match, AND
+ *   - its release year is a past year (year discipline: current/future-year
+ *     stubs are exactly the junk the matcher reform exists to avoid), AND
+ *   - it is popular enough to be a real film (not a TMDB stub), AND
+ *   - it dominates every other exact-title candidate by >= 5x popularity
+ *     (same-title art-film-vs-blockbuster cases like "Dracula" stay
+ *     unresolved rather than guessed).
+ *
+ * The caller then re-runs the REAL matcher with the candidate's year as a
+ * hint and only accepts the result if the matcher independently lands on the
+ * same tmdb id at/above the unchanged 0.6 floor.
+ */
+export function pickDominantExactTitleMatch(
+  cleanedTitle: string,
+  results: TMDBSearchResult[],
+  currentYear = new Date().getFullYear(),
+): { tmdbId: number; year: number } | null {
+  const target = normalizeExact(cleanedTitle);
+  if (!target) return null;
+
+  const exact = results
+    .filter(
+      (r) =>
+        !r.adult &&
+        r.release_date &&
+        (normalizeExact(r.title) === target || normalizeExact(r.original_title) === target),
+    )
+    .map((r) => ({ r, year: parseInt(r.release_date.split("-")[0], 10) }))
+    .filter(({ year }) => Number.isInteger(year) && year >= 1900 && year < currentYear);
+
+  if (exact.length === 0) return null;
+
+  exact.sort((a, b) => b.r.popularity - a.r.popularity);
+  const top = exact[0];
+  if (top.r.popularity < EXACT_TITLE_MIN_POPULARITY) return null;
+  if (exact.length > 1 && top.r.popularity < exact[1].r.popularity * EXACT_TITLE_DOMINANCE_RATIO) {
+    return null;
+  }
+
+  return { tmdbId: top.r.id, year: top.year };
+}
+
 // ---------------------------------------------------------------------------
 // TMDB call with 429 backoff
 // ---------------------------------------------------------------------------
 
-async function matchWithBackoff(
-  title: string,
-  hints: { year?: number; director?: string },
-): Promise<Awaited<ReturnType<typeof matchFilmToTMDB>>> {
+async function withTmdbBackoff<T>(fn: () => Promise<T>): Promise<T> {
   for (let attempt = 0; ; attempt++) {
     try {
-      return await matchFilmToTMDB(title, {
-        ...hints,
-        // The titles in this sweep already sit in the DB and have been
-        // through the cleaner; single-word classics like "Aliens" or
-        // "Adaptation" often carry no year/director, and the ambiguity gate
-        // would refuse them outright. Bypassing it follows the
-        // enrich-upcoming-films precedent — the 0.6 confidence floor,
-        // blocklist filtering, and dry-run review are the safeguards here.
-        skipAmbiguityCheck: true,
-      });
+      return await fn();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (!message.includes("429")) throw error;
@@ -134,6 +190,24 @@ async function matchWithBackoff(
       await sleep(wait);
     }
   }
+}
+
+function matchWithBackoff(
+  title: string,
+  hints: { year?: number; director?: string },
+): Promise<Awaited<ReturnType<typeof matchFilmToTMDB>>> {
+  return withTmdbBackoff(() =>
+    matchFilmToTMDB(title, {
+      ...hints,
+      // The titles in this sweep already sit in the DB and have been
+      // through the cleaner; single-word classics like "Aliens" or
+      // "Adaptation" often carry no year/director, and the ambiguity gate
+      // would refuse them outright. Bypassing it follows the
+      // enrich-upcoming-films precedent — the 0.6 confidence floor,
+      // blocklist filtering, and dry-run review are the safeguards here.
+      skipAmbiguityCheck: true,
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +229,8 @@ interface UpdateAction {
   tmdbYear: number;
   confidence: number;
   yearHint?: number;
+  /** Year derived via the exact-title second-chance pass (review marker). */
+  derivedYear?: number;
   directorHint?: string;
 }
 
@@ -351,8 +427,31 @@ async function main(): Promise<void> {
     const directorHint = film.directors?.[0] || undefined;
 
     let match: Awaited<ReturnType<typeof matchFilmToTMDB>>;
+    let derivedYear: number | undefined;
     try {
       match = await matchWithBackoff(cleaned, { year: yearHint, director: directorHint });
+
+      // Second-chance pass for hint-less films (see pickDominantExactTitleMatch):
+      // derive a year hint from a dominant exact-title candidate, then make
+      // the real matcher confirm it independently with the year on board.
+      if (!match && !yearHint) {
+        const search = await withTmdbBackoff(() => getTMDBClient().searchFilms(cleaned));
+        const pick = pickDominantExactTitleMatch(cleaned, search.results);
+        if (pick) {
+          await sleep(RATE_LIMIT_MS);
+          const retry = await matchWithBackoff(cleaned, {
+            year: pick.year,
+            director: directorHint,
+          });
+          if (retry && retry.tmdbId === pick.tmdbId) {
+            match = retry;
+            derivedYear = pick.year;
+            console.log(
+              `${progress}   derived-year pass: "${cleaned}" → ${pick.year} (tmdb ${pick.tmdbId})`,
+            );
+          }
+        }
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (message.includes("aborting sweep")) throw error;
@@ -411,6 +510,7 @@ async function main(): Promise<void> {
         tmdbYear: match.year,
         confidence: match.confidence,
         yearHint,
+        derivedYear,
         directorHint,
       };
       updates.push(action);
@@ -437,6 +537,7 @@ async function main(): Promise<void> {
   for (const u of updates) {
     const hints = [
       u.yearHint ? `year ${u.yearHint}` : null,
+      u.derivedYear ? `DERIVED year ${u.derivedYear} — review` : null,
       u.directorHint ? `director ${u.directorHint}` : null,
     ]
       .filter(Boolean)

--- a/src/scripts/run-scrape-and-enrich.ts
+++ b/src/scripts/run-scrape-and-enrich.ts
@@ -170,6 +170,23 @@ async function main(): Promise<void> {
         return { ok };
       }),
     );
+
+    // Optional phase: re-match sweep for unmatched films (plan 008).
+    // Default OFF — opt in with SCRAPE_REMATCH_SWEEP=1 once the operator has
+    // reviewed a few manual `npm run rematch:unmatched` dry runs. Capped at
+    // 100 films per run to bound TMDB usage and blast radius.
+    if (process.env.SCRAPE_REMATCH_SWEEP === "1") {
+      phases.push(
+        await runPhase("Rematch sweep (unmatched films, capped)", async () => {
+          const ok = await runNpmScript("rematch:unmatched", ["--execute", "--limit", "100"]);
+          return { ok };
+        }),
+      );
+    } else {
+      console.log(
+        "[scrape-and-enrich] rematch sweep disabled (set SCRAPE_REMATCH_SWEEP=1 to enable)",
+      );
+    }
   } else {
     console.log("[scrape-and-enrich] --skip-enrich: skipping enrichment phases");
   }


### PR DESCRIPTION
## Summary
Implements `plans/008-unmatched-rematch-sweep.md`. 202 upcoming films currently have no TMDB match and nothing ever retries them. This adds the default-dry `npm run rematch:unmatched` sweep (UPDATE in place / transactional MERGE into existing rows / SUSPECTED_NON_FILM flagging), makes the blocklist preventive at film-cache init, and completes the title-cleaner decoration coverage that PR #666 started.

## Production dry run (read-only)
**202 candidates → 7 UPDATE, 23 MERGE, 4 suspected non-film, 168 NO_MATCH.** Sanity anchors verified: Aliens→679, Adaptation→2757. The derived-year second-chance pass (sweep-only; matcher floor unchanged) is guarded against remake traps — it correctly NO_MATCHes "Supergirl" and "Masters of the Universe" because 2026 same-title releases exist.

**Operator review of flagged merges done pre-execute**: Kokuho→1379266 approved (Lee Sang-il 2025, 174min exact); 4 vetoed — "Tycoon" blocklisted (ICA shows Charlotte Zhang's 2025/89min film, not 8 BUCKS TYCOON — verified on ica.art), and "Previews"/"25th Anniversary"/"Joni Mitchell 'Blue" reclassified as events in prod (Pitchblack Playback album session etc.).

## Changes
- `src/scripts/rematch-unmatched-films.ts`: dry-default / `--execute` / `--limit`; ~3 req/s + 429 backoff; 250-UPDATE execute cap; merge = cleanup-duplicate-films repoint logic + repoint-before-delete verification + unique-index collision pre-delete; per-film failure isolation
- Preventive blocklist: `isBlockedTmdbId()`; `initFilmCache` skips `byTmdbId` for blocked ids while keeping `byTitle` (the duplicate-row trap — trap test written first)
- Cleaner: strips (Subbed)/(Dubbed)/bare (4K), suffix fixpoint (max 3 passes), returns `extractedYear` instead of discarding stripped years
- Pipeline phase gated on `SCRAPE_REMATCH_SWEEP=1` (default off)

## Review
Code-reviewer agent: 1 BLOCKER + 3 MAJORS, all fixed (year-hint composition, execute backoff + plan-005 write guards, merge collision handling + cap, honest logging).

## Verification
`npm run test:run` **1,858 tests pass** (re-run post-rebase) · `npx tsc --noEmit` clean · `npm run lint` 0 errors. Execute will run post-merge with the reviewed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)