### PR TITLE
feat(scrapers): sourceId hardening + generalized phantom-screening reconcile (plan 009)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,13 @@
+## 2026-06-12: Generalized phantom-screening reconcile + sourceId hardening (plan 009)
+**PR**: pending | **Files**: `src/scripts/reconcile-phantom-screenings.ts`, `src/scripts/reconcile-phantom-screenings.test.ts`, `src/scrapers/cinemas/prince-charles.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`, `package.json`
+- New `npm run reconcile:plan -- <cinemaId>` / `reconcile:apply -- <cinemaId>`: generalized, default-dry sweep for upcoming rows the source no longer lists (`scraped_at` < last successful run start). Supersedes the one-off `_bfi_reconcile.ts` staging script.
+- Five hard guards as unit-tested pure functions: single registry-known cinema per invocation; successful scrape completed <2h ago; future-only + stale-only candidates (re-guarded inside the DELETE); 40% deletion cap (`--force-large` override); batched (100) transactional deletes with every doomed row printed first. Plus two non-overridable review-driven guards: empty "success" scrapes are refused outright, and stale rows beyond the run's demonstrated scrape horizon are excluded (printed, never deleted).
+- Prince Charles sourceId can no longer be `undefined` (derived composite fallback when the `booknow/{id}` regex misses; existing bare-digit scheme untouched).
+- SCRAPING_PLAYBOOK.md now documents every scraper's sourceId scheme — the table that makes the next scheme change detectable. Audit finding: contra plan 009's premise, 27/28 registry scrapers already emitted sourceId unconditionally.
+- Rollout (per-venue scrape → reconcile, plan Step 1/3) deliberately NOT run here — code only.
+
+---
+
 ## 2026-06-12: Unmatched re-match sweep + preventive blocklist + decoration suffixes (plan 008)
 **PR**: pending | **Files**: `src/scripts/rematch-unmatched-films.ts`, `src/scrapers/utils/film-title-cleaner.ts`, `src/scrapers/utils/film-matching.ts`, `src/lib/tmdb/blocklist.ts`, `src/scripts/run-scrape-and-enrich.ts`, `package.json`
 - New `npm run rematch:unmatched` (default-dry, `--execute`, `--limit N`): retries TMDB matching for unmatched films with upcoming screenings; UPDATE in place (match_strategy='rematch-sweep' + letterboxd /tmdb/{id}) or MERGE into the row that already owns the tmdb_id (transactional repoint-before-delete); suspected non-films flagged only.

--- a/changelogs/2026-06-12-phantom-reconcile-sourceid.md
+++ b/changelogs/2026-06-12-phantom-reconcile-sourceid.md
@@ -1,0 +1,100 @@
+# Generalized phantom-screening reconcile + sourceId hardening (plan 009)
+
+**PR**: pending
+**Date**: 2026-06-12
+**Plan**: `plans/009-sourceid-phantom-reconcile.md`
+**Branch**: `feat/sourceid-reconcile`
+
+## Background
+
+The scrape pipeline is upsert-only: rows that vanish from a cinema's website
+are never deleted. Stable dedup therefore depends on `screenings.source_id`
+(partial unique index on `(cinema_id, source_id)`), and any sourceId scheme
+change strands every pre-change row as a "phantom" — observed live at BFI
+Southbank (~64 phantom rows + 33 near-dup pairs, cleaned by the one-off
+staging script `src/scripts/_bfi_reconcile.ts`).
+
+## Audit finding (deviation from the plan's premise)
+
+Plan 009 claimed "13 of 26 scrapers don't set sourceId". Verified against
+current code (and against the plan's own authoring commit `716e543`): **27 of
+28 registry scrapers already emit sourceId unconditionally**. The only real
+gaps were:
+
+- **Prince Charles**: `sourceId: bookingUrl.match(/booknow\/(\d+)/)?.[1]`
+  could be `undefined` when the booking URL format drifts.
+- **Phoenix**: the plan's "perfCode at ~line 138" does not exist in current
+  code; Phoenix already uses the plan's recommended derived composite
+  (`phoenix-{titleSlug}-{ISO}`). Left unchanged — switching schemes would
+  strand all existing rows for zero benefit.
+
+## Changes
+
+- **`src/scripts/reconcile-phantom-screenings.ts`** (new): generalized,
+  per-cinema phantom sweep, default-dry. Phantom = upcoming row
+  (`datetime >= now()`) whose `scraped_at` predates the start of the cinema's
+  most recent *successful* scrape (the pipeline bumps `scraped_at` on every
+  insert and update, so live rows are never candidates).
+  Five hard guards, each an exported pure function with unit tests:
+  1. `parseReconcileArgs` / `validateCinemaId` — exactly one cinemaId per
+     invocation, and it must exist in `CINEMA_REGISTRY`.
+  2. `isReconcileSafe` — a successful `scraper_runs` row must have completed
+     within the last 2 hours, else refuse (reconciling against a stale scrape
+     would delete valid rows). `isVacuousRun` additionally refuses — never
+     overridable — when that "success" run upserted 0 screenings (sweeping
+     behind an empty scrape would wipe the venue; code-review major #2).
+  3. `isPhantomRow` — future-only AND untouched-by-the-run only; re-guarded
+     again inside the DELETE (`cinema_id` + `datetime >= now()` +
+     `scraped_at < run start`). `scrapeHorizon` additionally excludes stale
+     rows beyond the latest datetime the run actually refreshed — a
+     temporarily shortened listings window or capped API must not condemn
+     valid far-future rows (code-review major #1); excluded rows are printed
+     separately as `EXCLUDED`, never deleted.
+  4. `exceedsDeletionCap` — refuse plans deleting >40% of the cinema's
+     upcoming rows; `--force-large` overrides with a red warning and still
+     requires `--execute`.
+  5. `batchIds` — every doomed row is printed (title, datetime, source_id,
+     scraped_at) before anything happens; `--execute` deletes in batches of
+     100 inside a single transaction.
+- **`src/scripts/reconcile-phantom-screenings.test.ts`** (new): 36 unit tests
+  covering all guards (boundary conditions, clock skew, the 100% LARGE_DROP
+  case, horizon classification, vacuous runs, batch integrity, pinned
+  constants).
+- Known limitation (documented): canonical registry cinema IDs only — rows
+  under legacy cinema IDs are not swept.
+- **`package.json`**: `reconcile:plan` / `reconcile:apply` entries following
+  the default-dry convention from PR #660.
+- **`src/scrapers/cinemas/prince-charles.ts`**: sourceId is never `undefined`
+  — falls back to `prince-charles-{slugify(title)}-{ISO}` when the
+  `booknow/{id}` regex misses. The bare-digit primary scheme is deliberately
+  untouched (prefixing it would strand every existing PCC row).
+- **`src/scrapers/SCRAPING_PLAYBOOK.md`**: new "sourceId Schemes" section
+  documenting every active scraper's scheme + key source, the
+  scheme-change → reconcile rule, and the reconcile script's guard contract.
+  Notes that the generalized script supersedes `_bfi_reconcile.ts` (that
+  staging one-off is untracked in git, so it could not be deleted from this
+  branch — remove it from the main checkout when encountered).
+
+## Verification
+
+- `npm run test:run` — 123 files / 1886 tests green (incl. 28 new).
+- `npm run lint` — 0 errors (60 pre-existing warnings, none in changed files).
+- `npx tsc --noEmit` — clean.
+- Read-only `npm run reconcile:plan -- phoenix-east-finchley` against prod:
+  correctly **REFUSED (guard 2)** — last successful scrape was the 03:05 UTC
+  nightly, outside the 2h window. A read-only probe of the same selection
+  logic against that run shows 27/83 upcoming rows (32.5%, under the cap)
+  would be planned, including the predicted near-dup phantoms
+  (`rocky-road-to-dublin` vs `rocky-roads-to-dublin` slug drift, stranded
+  "Tuner" rows).
+
+## Impact
+
+- Operators get a safe, guarded path to clean phantom rows for ANY cinema —
+  previously only BFI had (one-off, untracked) tooling.
+- The playbook's scheme table makes the next sourceId scheme change
+  detectable and pairs it with the mandatory reconcile sequence.
+- **No production rows were deleted in this change.** Rollout (per-venue
+  scrape → `reconcile:plan` → review → `reconcile:apply`, worst offenders
+  first: phoenix-east-finchley, then the ≥70% LARGE_DROP chain venues) is
+  performed by the orchestrator post-merge per plan 009 Steps 1 & 3.

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "cleanup:upcoming": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/cleanup-upcoming-films.ts",
     "audit:films": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/audit-film-data.ts",
     "audit:fix-upcoming": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register scripts/audit-and-fix-upcoming.ts",
+    "reconcile:plan": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/reconcile-phantom-screenings.ts",
+    "reconcile:apply": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/reconcile-phantom-screenings.ts --execute",
     "poster:audit": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scripts/poster-audit-and-fix.ts",
     "scrape:snapshot": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scrapers/__tests__/run-snapshot.ts",
     "scrape:genesis-basescraper": "dotenv -e .env.local -- npx tsx -r tsconfig-paths/register src/scrapers/run-genesis-v2-basescraper.ts",

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,7 +26,7 @@ Recommended order: 004 → 001 (+002/003) → 005 → 006 ∥ 007 → 008 → 00
 | 006 | Scraper metadata capture (runtime at Rio/ICA/Garden/Curzon) | P1 | M | 005 | DONE (pending PR) |
 | 007 | Letterboxd integrity: no-anchor guard, canonical slug, year tolerance | P1 | M | — | DONE (pending PR) |
 | 008 | Unmatched re-match sweep + preventive blocklist + prefix single-sourcing | P1 | M–L | 005 | DONE (pending PR/execute) |
-| 009 | sourceId rollout + generalized phantom reconcile | P2 | M–L | 004 | TODO |
+| 009 | sourceId rollout + generalized phantom reconcile | P2 | M–L | 004 | DONE (code; rollout pending) |
 | 010 | Pipeline write-resilience: insert retry queue, validator provenance | P2 | M | 001 | DONE (pending PR) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED (one-line rationale)

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -22,6 +22,82 @@ Update this playbook whenever you:
 - **Time provenance (plan 010, 2026-06-12)**: when a scraper's datetimes come from ISO/API timestamps (not parsed display text), set `RawScreening.timeSource: "iso"`. The validator then treats `suspicious_time_early` (<10:00) as warn-not-reject (ISO times can't have AM/PM errors — Everyman's real 09:00 kids shows were being discarded) and raises the `too_far_future` cap from 90 to 180 days (long-lead event cinema like Met Opera 2026-27 at the chains). Leave text-parsed scrapers unset (treated as `"text"`, full strictness). Currently set by: Curzon (Vista API), Picturehouse (API), Everyman (boxofficeapi), Castle/Castle Sidcup (`data-start-time` attribute via castle-calendar).
 - **Runtime capture (plan 006, 2026-06-12)**: when a source exposes the film's runtime, forward it as `RawScreening.runtime` (minutes) — the TMDB matcher uses it to reject junk stubs and penalize wrong-era matches. Always pass the raw value through `sanitizeRuntime()` (`src/scrapers/utils/metadata-parser.ts`): coerces numeric strings, guards to the 1–600 minute band, returns `undefined` otherwise. Currently emitted by Rio, ICA, Garden Cinema, and Curzon. Caveat: venue runtimes may include event padding (intros/Q&As). Padding within 30 min is tolerated; beyond that the matcher applies a −0.15 confidence penalty, which strong matches (e.g. exact-year classics) usually survive but borderline ones may not. An asymmetric tolerance (venue-above-TMDB is padding, venue-below-TMDB is a wrong-film signal) is a candidate plan-005 scoring follow-up.
 
+## sourceId Schemes (plan 009, 2026-06-12)
+
+`screenings.source_id` is the stable per-row dedup key behind the partial
+unique index `(cinema_id, source_id) WHERE source_id IS NOT NULL`. The
+pipeline is upsert-only — rows that vanish from a source are never deleted —
+so **changing a scraper's sourceId scheme strands every existing row as a
+phantom**. This table is what makes the next scheme change detectable.
+
+Rules:
+- Every scraper must set `sourceId` on **every** emitted `RawScreening` —
+  unconditionally (no regex-miss `undefined` paths).
+- Prefer an upstream booking-system id; otherwise derive a deterministic
+  composite (`{prefix}-{slugify(title)}-{datetime.toISOString()}` using
+  `slugify` from `src/scrapers/utils/url.ts`). Derived ids change when the
+  source retitles or moves a screening — that is expected, and the reconcile
+  sweep cleans the strays.
+- **If you change any scheme below, you MUST update this table and run the
+  reconcile sequence for that cinema in the same session:**
+  scrape venue once → `npm run reconcile:plan -- <cinemaId>` → review →
+  `npm run reconcile:apply -- <cinemaId>`. Otherwise every pre-change row
+  becomes a permanent phantom.
+
+| Scraper (file) | cinema_id(s) | Scheme | Key source |
+|---|---|---|---|
+| Curzon (`chains/curzon.ts`) | `curzon-*` | `curzon-{showtime.id}` | Vista OCAPI showtime id |
+| Picturehouse (`chains/picturehouse.ts`) | `picturehouse-*` | `picturehouse-{venue.id}-{ShowTime.SessionId}` | API SessionId |
+| Everyman (`chains/everyman.ts`) | `everyman-*` | `everyman-{venue.id}-{showtime.id}` | boxofficeapi showtime id |
+| BFI (`cinemas/bfi.ts` → `bfi-pdf/bfi-source-id.ts`) | `bfi-southbank`, `bfi-imax` | `bfi-{cinemaId}-{titleSlug}-{screen}-{ISO}` | derived, path-agnostic across Playwright/PDF (PR #640) |
+| Barbican (`cinemas/barbican.ts`) | `barbican` | `barbican-{YYYY-MM-DD}-{HHMM}-{titleSlug}` | derived |
+| Phoenix (`cinemas/phoenix.ts`) | `phoenix-east-finchley` | `phoenix-{titleSlug}-{ISO}` | derived |
+| Electric (`cinemas/electric-v2.ts`) | `electric-portobello`, `electric-white-city` | `electric-{screeningId}` | site JSON screening key |
+| Lexi (`cinemas/lexi.ts`) | `lexi` | `lexi-{film.ID}-{perf.ID}` | Admit One API ids |
+| Regent Street (`cinemas/regent-street.ts`) | `regent-street` | `regent-street-{showing.id}` | API showing id |
+| Rich Mix (`cinemas/rich-mix-v2.ts`) | `rich-mix` | `richmix-{instanceId\|id}` | Spektrix instance id |
+| JW3 (`cinemas/jw3.ts`) | `jw3` | `jw3-{inst.id}` | API instance id |
+| Castle (`cinemas/castle.ts` → `castle-calendar.ts`) | `castle` | `castle-{perfId}` | Jacro perf id |
+| Castle Sidcup (`cinemas/castle-sidcup.ts` → `castle-calendar.ts`) | `castle-sidcup` | `castle-sidcup-{perfId}` | Jacro perf id |
+| Rio (`cinemas/rio.ts`) | `rio-dalston` | `rio-dalston-{event.ID}-{ISO}` | event id + datetime |
+| Prince Charles (`cinemas/prince-charles.ts`) | `prince-charles` | `{perfId}` (bare digits from `booknow/(\d+)`); fallback `prince-charles-{titleSlug}-{ISO}` | Jacro perf id; derived fallback added 2026-06-12 so sourceId is never undefined. Bare-digit primary kept deliberately — prefixing would strand all existing rows |
+| ICA (`cinemas/ica.ts`) | `ica` | `ica-{titleSlug}-{ISO}` | derived (lowercase, whitespace→dash, punctuation kept) |
+| Genesis (`cinemas/genesis.ts`) | `genesis` | `genesis-{perfCode}` | site perfCode |
+| Peckhamplex (`cinemas/peckhamplex.ts`) | `peckhamplex` | `peckhamplex-{titleSlug}-{ISO}` | derived |
+| Nickel (`cinemas/nickel-v2.ts`) | `the-nickel` | `nickel-{item.id}` | API item id |
+| Garden (`cinemas/garden.ts`) | `garden` | `garden-{slugify(title)}-{ISO}` | derived |
+| Close-Up (`cinemas/close-up.ts`) | `close-up-cinema` | `close-up-{show.id}-{ISO}` (API), `close-up-html-{ISO}-{titleSlug}`, `close-up-search-{ISO}-{titleSlug}` | API id; derived on HTML/search fallback paths |
+| Bertha DocHouse (`cinemas/bertha-dochouse.ts`) | `bertha-dochouse` | `bertha-{ticketId}` | ticket id (`BLO1-XXXXXX`) |
+| Cinema Museum (`cinemas/cinema-museum.ts`) | `cinema-museum` | `cinema-museum-{ev.uid}` | ICS event uid |
+| Ciné Lumière (`cinemas/cine-lumiere.ts`) | `cine-lumiere` | `cine-lumiere-{titleSlug}-{ISO}` | derived (lowercase, whitespace→dash, punctuation kept) |
+| ArtHouse Crouch End (`cinemas/arthouse-crouch-end.ts`) | `arthouse-crouch-end` | `arthouse-{titleSlug}-{ISO}` | derived (lowercase, whitespace→dash, punctuation kept) |
+| Coldharbour Blue (`cinemas/coldharbour-blue.ts`) | `coldharbour-blue` | `coldharbour-{event.id}` | API event id |
+| Olympic (`cinemas/olympic.ts`) | `olympic-studios` | `olympic-{bookingId}-{ISO}` | booking id from URL (`""` when absent; ISO keeps it unique) |
+| David Lean (`cinemas/david-lean.ts`) | `david-lean-cinema` | `david-lean-{titleSlug≤30}-{ISO}` | derived (lowercase, whitespace→dash, punctuation kept) |
+| Riverside (`cinemas/riverside-v2.ts`) | `riverside-studios` | `riverside-{event.id}-{perf.timestamp}` | event id + perf timestamp |
+
+### Phantom reconcile (`src/scripts/reconcile-phantom-screenings.ts`)
+
+Generalized, default-dry sweep for rows the source no longer lists. It
+**supersedes the one-off `src/scripts/_bfi_reconcile.ts`** staging script
+(untracked; delete it when encountered — its logic now lives here,
+parameterized per cinema). Unlike the BFI one-off it does not scrape: run the
+venue's scraper first, then reconcile while the run is < 2h fresh.
+
+- `npm run reconcile:plan -- <cinemaId>` — prints every doomed row; no writes.
+- `npm run reconcile:apply -- <cinemaId>` — deletes the planned rows.
+- Hard guards (all enforced, unit-tested pure functions): single registry-known
+  cinema per invocation; successful `scraper_runs` entry completed < 2h ago
+  AND with a non-zero screening count (an empty "success" scrape is refused,
+  never overridable); candidates limited to `datetime >= now()` AND
+  `scraped_at < run start` AND `datetime <= scrape horizon` (the latest
+  datetime the run actually refreshed — stale rows beyond demonstrated
+  coverage are printed as EXCLUDED, never deleted); re-guarded inside the
+  DELETE; refusal above a 40% deletion cap (`--force-large` overrides with a
+  red warning); batched (100) deletes in a single transaction.
+- Limitation: accepts canonical registry cinema IDs only — rows under legacy
+  cinema IDs are not swept.
+
 ## Health & Flakiness Detection
 The `/scrape` slash command runs three read-only detectors against `scraper_runs`:
 - **`detectSilentBreakers`** (`src/lib/scrape-quarantine.ts`) — Prowlarr-pattern: flags cinemas with ≥N *consecutive* `success+0` runs.

--- a/src/scrapers/cinemas/prince-charles.ts
+++ b/src/scrapers/cinemas/prince-charles.ts
@@ -7,6 +7,7 @@ import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
 import { parseScreeningDate, parseScreeningTime, combineDateAndTime } from "../utils/date-parser";
 import { parseFilmMetadata } from "../utils/metadata-parser";
+import { slugify } from "../utils/url";
 import type { CheerioAPI, CheerioSelection } from "../utils/cheerio-types";
 import { FestivalDetector } from "../festivals/festival-detector";
 
@@ -146,7 +147,13 @@ export class PrinceCharlesScraper extends BaseScraper {
       bookingUrl,
       format,
       eventType,
-      sourceId: bookingUrl.match(/booknow\/(\d+)/)?.[1],
+      // Jacro performance ID from the booking URL — stable across re-scrapes.
+      // Kept un-prefixed to match the scheme of every existing PCC row (a
+      // prefix change would strand them all as phantoms). Falls back to a
+      // deterministic composite so sourceId is never undefined (plan 009).
+      sourceId:
+        bookingUrl.match(/booknow\/(\d+)/)?.[1] ??
+        `prince-charles-${slugify(filmTitle)}-${datetime.toISOString()}`,
       // Pass extracted metadata for better TMDB matching
       year: metadata?.year,
       director: metadata?.director,

--- a/src/scripts/reconcile-phantom-screenings.test.ts
+++ b/src/scripts/reconcile-phantom-screenings.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DELETE_BATCH_SIZE,
+  DELETION_CAP,
+  MAX_SCRAPE_AGE_MS,
+  batchIds,
+  exceedsDeletionCap,
+  isPhantomRow,
+  isReconcileSafe,
+  isVacuousRun,
+  parseReconcileArgs,
+  scrapeHorizon,
+  validateCinemaId,
+} from "./reconcile-phantom-screenings";
+
+const NOW = new Date("2026-06-12T12:00:00.000Z");
+const minutes = (n: number) => n * 60_000;
+
+describe("parseReconcileArgs (guard 1a: single cinema per invocation)", () => {
+  it("parses a bare cinemaId as a dry run", () => {
+    const args = parseReconcileArgs(["phoenix-east-finchley"]);
+    expect(args).toEqual({
+      cinemaId: "phoenix-east-finchley",
+      execute: false,
+      forceLarge: false,
+      errors: [],
+    });
+  });
+
+  it("parses --execute and --force-large in any order", () => {
+    const args = parseReconcileArgs(["--execute", "phoenix-east-finchley", "--force-large"]);
+    expect(args.cinemaId).toBe("phoenix-east-finchley");
+    expect(args.execute).toBe(true);
+    expect(args.forceLarge).toBe(true);
+    expect(args.errors).toEqual([]);
+  });
+
+  it("errors when the cinemaId is missing", () => {
+    const args = parseReconcileArgs(["--execute"]);
+    expect(args.cinemaId).toBeNull();
+    expect(args.errors).toHaveLength(1);
+    expect(args.errors[0]).toMatch(/missing/i);
+  });
+
+  it("errors on a second positional cinemaId", () => {
+    const args = parseReconcileArgs(["rio-dalston", "ica"]);
+    expect(args.errors).toHaveLength(1);
+    expect(args.errors[0]).toMatch(/one cinema per invocation/i);
+  });
+
+  it("errors on unknown flags instead of ignoring them", () => {
+    const args = parseReconcileArgs(["rio-dalston", "--exectue"]);
+    expect(args.errors).toHaveLength(1);
+    expect(args.errors[0]).toMatch(/unknown flag/i);
+  });
+});
+
+describe("validateCinemaId (guard 1b: must exist in registry)", () => {
+  const known = ["phoenix-east-finchley", "rio-dalston", "bfi-southbank"];
+
+  it("accepts a known id", () => {
+    expect(validateCinemaId("rio-dalston", known)).toBe(true);
+  });
+
+  it("rejects an unknown id", () => {
+    expect(validateCinemaId("rio-dalson", known)).toBe(false);
+  });
+
+  it("rejects the empty string", () => {
+    expect(validateCinemaId("", known)).toBe(false);
+  });
+});
+
+describe("isReconcileSafe (guard 2: fresh successful scrape required)", () => {
+  it("accepts a scrape completed just now", () => {
+    expect(isReconcileSafe(NOW, NOW)).toBe(true);
+  });
+
+  it("accepts a scrape completed 1h59m ago", () => {
+    expect(isReconcileSafe(new Date(NOW.getTime() - minutes(119)), NOW)).toBe(true);
+  });
+
+  it("accepts a scrape completed exactly at the 2h boundary", () => {
+    expect(isReconcileSafe(new Date(NOW.getTime() - MAX_SCRAPE_AGE_MS), NOW)).toBe(true);
+  });
+
+  it("rejects a scrape completed 2h01m ago", () => {
+    expect(isReconcileSafe(new Date(NOW.getTime() - minutes(121)), NOW)).toBe(false);
+  });
+
+  it("rejects a missing completion time (run never finished)", () => {
+    expect(isReconcileSafe(null, NOW)).toBe(false);
+    expect(isReconcileSafe(undefined, NOW)).toBe(false);
+  });
+
+  it("rejects a completion time in the future (clock skew / bad data)", () => {
+    expect(isReconcileSafe(new Date(NOW.getTime() + minutes(5)), NOW)).toBe(false);
+  });
+
+  it("pins the documented 2h window", () => {
+    expect(MAX_SCRAPE_AGE_MS).toBe(2 * 60 * 60 * 1000);
+  });
+});
+
+describe("isVacuousRun (guard 2b: empty 'success' scrapes are never swept behind)", () => {
+  it("flags a zero-screening run", () => {
+    expect(isVacuousRun(0)).toBe(true);
+  });
+
+  it("flags a run with no recorded count", () => {
+    expect(isVacuousRun(null)).toBe(true);
+    expect(isVacuousRun(undefined)).toBe(true);
+  });
+
+  it("accepts a run that upserted screenings", () => {
+    expect(isVacuousRun(1)).toBe(false);
+    expect(isVacuousRun(70)).toBe(false);
+  });
+});
+
+describe("isPhantomRow (guard 3: future-only AND untouched by the last run)", () => {
+  const runStartedAt = new Date(NOW.getTime() - minutes(30));
+  const future = new Date(NOW.getTime() + minutes(60));
+  const past = new Date(NOW.getTime() - minutes(60));
+  const staleScrape = new Date(NOW.getTime() - minutes(90)); // before run start
+  const freshScrape = new Date(NOW.getTime() - minutes(10)); // during the run
+
+  it("flags a future row the run did not refresh", () => {
+    expect(isPhantomRow({ datetime: future, scrapedAt: staleScrape }, runStartedAt, NOW)).toBe(true);
+  });
+
+  it("never flags a row the run refreshed", () => {
+    expect(isPhantomRow({ datetime: future, scrapedAt: freshScrape }, runStartedAt, NOW)).toBe(false);
+  });
+
+  it("never flags a past row, even if stale (db:cleanup-screenings territory)", () => {
+    expect(isPhantomRow({ datetime: past, scrapedAt: staleScrape }, runStartedAt, NOW)).toBe(false);
+  });
+
+  it("never flags a row scraped exactly at run start", () => {
+    expect(isPhantomRow({ datetime: future, scrapedAt: runStartedAt }, runStartedAt, NOW)).toBe(false);
+  });
+
+  it("treats a row at exactly now as upcoming (matches the >= now SQL filter)", () => {
+    expect(isPhantomRow({ datetime: NOW, scrapedAt: staleScrape }, runStartedAt, NOW)).toBe(true);
+  });
+});
+
+describe("scrapeHorizon (guard 3b: never condemn rows beyond demonstrated coverage)", () => {
+  const runStartedAt = new Date(NOW.getTime() - minutes(30));
+  const fresh = new Date(NOW.getTime() - minutes(10)); // refreshed by the run
+  const stale = new Date(NOW.getTime() - minutes(90)); // not refreshed
+
+  it("returns the latest datetime among refreshed rows only", () => {
+    const day = (n: number) => new Date(NOW.getTime() + n * 24 * minutes(60));
+    const rows = [
+      { datetime: day(1), scrapedAt: fresh },
+      { datetime: day(7), scrapedAt: fresh },
+      { datetime: day(60), scrapedAt: stale }, // far-future stale row must NOT extend the horizon
+    ];
+    expect(scrapeHorizon(rows, runStartedAt)).toEqual(day(7));
+  });
+
+  it("counts a row scraped exactly at run start as refreshed", () => {
+    const rows = [{ datetime: new Date(NOW.getTime() + minutes(60)), scrapedAt: runStartedAt }];
+    expect(scrapeHorizon(rows, runStartedAt)).toEqual(rows[0].datetime);
+  });
+
+  it("returns null when the run refreshed nothing", () => {
+    const rows = [{ datetime: new Date(NOW.getTime() + minutes(60)), scrapedAt: stale }];
+    expect(scrapeHorizon(rows, runStartedAt)).toBeNull();
+    expect(scrapeHorizon([], runStartedAt)).toBeNull();
+  });
+});
+
+describe("exceedsDeletionCap (guard 4: 40% cap)", () => {
+  it("allows zero deletions", () => {
+    expect(exceedsDeletionCap(0, 100)).toBe(false);
+    expect(exceedsDeletionCap(0, 0)).toBe(false);
+  });
+
+  it("allows deletions at or under the cap", () => {
+    expect(exceedsDeletionCap(40, 100)).toBe(false);
+    expect(exceedsDeletionCap(1, 100)).toBe(false);
+  });
+
+  it("refuses deletions over the cap", () => {
+    expect(exceedsDeletionCap(41, 100)).toBe(true);
+    expect(exceedsDeletionCap(63, 63)).toBe(true); // the 100% LARGE_DROP case
+  });
+
+  it("refuses any deletion when the upcoming total is zero (inconsistent plan)", () => {
+    expect(exceedsDeletionCap(5, 0)).toBe(true);
+  });
+
+  it("uses the documented default cap", () => {
+    expect(DELETION_CAP).toBe(0.4);
+  });
+});
+
+describe("batchIds (guard 5: bounded delete batches)", () => {
+  it("splits ids into batches of the default size", () => {
+    const ids = Array.from({ length: 250 }, (_, i) => `id-${i}`);
+    const batches = batchIds(ids);
+    expect(batches.map((b) => b.length)).toEqual([DELETE_BATCH_SIZE, DELETE_BATCH_SIZE, 50]);
+    expect(batches.flat()).toEqual(ids); // no row lost or duplicated
+  });
+
+  it("returns a single batch when under the size", () => {
+    expect(batchIds(["a", "b"])).toEqual([["a", "b"]]);
+  });
+
+  it("returns no batches for an empty plan", () => {
+    expect(batchIds([])).toEqual([]);
+  });
+
+  it("rejects a non-positive batch size", () => {
+    expect(() => batchIds(["a"], 0)).toThrow(/size must be > 0/);
+  });
+
+  it("pins the documented batch size", () => {
+    expect(DELETE_BATCH_SIZE).toBe(100);
+  });
+});

--- a/src/scripts/reconcile-phantom-screenings.ts
+++ b/src/scripts/reconcile-phantom-screenings.ts
@@ -1,0 +1,379 @@
+/**
+ * Reconcile phantom screenings against the last successful scrape (plan 009).
+ *
+ * The pipeline is upsert-only: rows that vanish from a cinema's website are
+ * never removed, so sourceId scheme changes (or programme changes) strand
+ * "phantom" rows that no longer exist at the source. This script finds and —
+ * only with --execute — deletes them, one cinema at a time.
+ *
+ * A phantom is an UPCOMING row (datetime >= now) that the cinema's most
+ * recent successful scrape did NOT refresh (scraped_at < that run's start).
+ * The pipeline bumps scraped_at on every insert AND update, so anything the
+ * live scrape still lists carries a fresh scraped_at and is never touched.
+ *
+ * Usage (default-dry, PR #660 convention):
+ *   npm run reconcile:plan -- <cinemaId>                   # print plan, no writes
+ *   npm run reconcile:apply -- <cinemaId>                  # delete planned rows
+ *   npm run reconcile:plan -- <cinemaId> --force-large     # bypass the 40% cap (still dry)
+ *
+ * Hard guards (all non-negotiable — see plans/009-sourceid-phantom-reconcile.md):
+ *   1. Exactly one cinemaId per invocation; it must exist in the cinema registry.
+ *   2. A successful scrape of that cinema must have completed within the last
+ *      2 hours (scraper_runs) — reconciling against a stale scrape would
+ *      delete valid rows. A "success" run that upserted 0 screenings is
+ *      refused outright (NOT overridable): it has no information content,
+ *      and sweeping behind it would wipe the venue.
+ *   3. Only rows with datetime >= now AND scraped_at < <last run start> are
+ *      ever candidates (re-guarded again inside the DELETE itself). Rows
+ *      beyond the run's demonstrated scrape horizon (the latest datetime the
+ *      run actually refreshed) are excluded — a temporarily shortened
+ *      listings window must not condemn valid far-future rows.
+ *   4. Refuse if the plan would delete >40% of the cinema's upcoming rows
+ *      (--force-large overrides with a red warning; --execute still required).
+ *   5. Every doomed row is printed (title, datetime, source_id, scraped_at);
+ *      --execute deletes in batches of 100 inside a single transaction.
+ *
+ * Known limitation: only canonical registry cinema IDs are accepted; any
+ * screenings rows still carrying legacy cinema IDs are not swept.
+ *
+ * Supersedes the one-off `src/scripts/_bfi_reconcile.ts` (untracked staging
+ * script): unlike it, this script does NOT scrape — run the venue's scraper
+ * first, then reconcile while the run is fresh.
+ *
+ * Rollout sequence per scraper sourceId change (plan 009 step 1):
+ *   deploy change → scrape venue once → reconcile:plan → review → reconcile:apply
+ */
+
+import { and, desc, eq, gte, inArray, lt } from "drizzle-orm";
+
+import { db } from "@/db";
+import { films, scraperRuns, screenings } from "@/db/schema";
+import { CINEMA_REGISTRY } from "@/config/cinema-registry";
+
+// ============================================================================
+// Pure guard logic (unit-tested in reconcile-phantom-screenings.test.ts)
+// ============================================================================
+
+/** Guard 2: a reconcile is only safe within this window after a successful scrape. */
+export const MAX_SCRAPE_AGE_MS = 2 * 60 * 60 * 1000;
+
+/** Guard 4: refuse plans that would delete more than this share of upcoming rows. */
+export const DELETION_CAP = 0.4;
+
+/** Guard 5: delete batch size inside the transaction. */
+export const DELETE_BATCH_SIZE = 100;
+
+export interface ReconcileArgs {
+  cinemaId: string | null;
+  execute: boolean;
+  forceLarge: boolean;
+  errors: string[];
+}
+
+/**
+ * Guard 1a (pure): parse argv into exactly one cinemaId + known flags.
+ * Any extra positional or unknown flag is an error — a typo must never
+ * silently widen the blast radius of a deletion script.
+ */
+export function parseReconcileArgs(argv: string[]): ReconcileArgs {
+  const args: ReconcileArgs = { cinemaId: null, execute: false, forceLarge: false, errors: [] };
+  for (const arg of argv) {
+    if (arg === "--execute") {
+      args.execute = true;
+    } else if (arg === "--force-large") {
+      args.forceLarge = true;
+    } else if (arg.startsWith("-")) {
+      args.errors.push(`Unknown flag: ${arg}`);
+    } else if (args.cinemaId === null) {
+      args.cinemaId = arg;
+    } else {
+      args.errors.push(`Multiple cinema IDs given ("${args.cinemaId}", "${arg}") — one cinema per invocation.`);
+    }
+  }
+  if (args.cinemaId === null) {
+    args.errors.push("Missing required <cinemaId> argument.");
+  }
+  return args;
+}
+
+/** Guard 1b (pure): the cinemaId must exist in the known registry. */
+export function validateCinemaId(cinemaId: string, knownIds: readonly string[]): boolean {
+  return knownIds.includes(cinemaId);
+}
+
+/**
+ * Guard 2 (pure): true only if the last successful scrape completed recently
+ * enough (within MAX_SCRAPE_AGE_MS, and not in the future).
+ */
+export function isReconcileSafe(
+  lastRunCompletedAt: Date | null | undefined,
+  now: Date,
+  maxAgeMs: number = MAX_SCRAPE_AGE_MS,
+): boolean {
+  if (!lastRunCompletedAt) return false;
+  const age = now.getTime() - lastRunCompletedAt.getTime();
+  return age >= 0 && age <= maxAgeMs;
+}
+
+/**
+ * Guard 2b (pure): a "success" run that upserted zero screenings (or never
+ * recorded a count) is vacuous — reconciling against it would classify every
+ * upcoming row as a phantom. Never overridable, not even by --force-large.
+ */
+export function isVacuousRun(screeningCount: number | null | undefined): boolean {
+  return !(typeof screeningCount === "number" && screeningCount > 0);
+}
+
+/**
+ * Guard 3 (pure): a row is a phantom only if it is upcoming AND the last
+ * successful run did not refresh it (the pipeline bumps scraped_at on every
+ * insert and update, so live rows always carry scraped_at >= run start).
+ */
+export function isPhantomRow(
+  row: { datetime: Date; scrapedAt: Date },
+  runStartedAt: Date,
+  now: Date,
+): boolean {
+  return row.datetime.getTime() >= now.getTime() && row.scrapedAt.getTime() < runStartedAt.getTime();
+}
+
+/**
+ * Guard 3b (pure): the run's demonstrated scrape horizon — the latest
+ * datetime among rows the run actually refreshed (scraped_at >= run start).
+ * Otherwise-phantom rows BEYOND this horizon are excluded from the plan: the
+ * run never demonstrated coverage out there, so their absence proves nothing
+ * (shortened listings windows / capped APIs / partial scraper paths).
+ * Returns null when the run refreshed nothing (vacuous — guard 2b refuses).
+ */
+export function scrapeHorizon(
+  rows: ReadonlyArray<{ datetime: Date; scrapedAt: Date }>,
+  runStartedAt: Date,
+): Date | null {
+  let max: Date | null = null;
+  for (const row of rows) {
+    if (row.scrapedAt.getTime() >= runStartedAt.getTime() && (max === null || row.datetime > max)) {
+      max = row.datetime;
+    }
+  }
+  return max;
+}
+
+/** Guard 4 (pure): does the plan exceed the deletion cap? Empty-total plans with deletions always exceed. */
+export function exceedsDeletionCap(planned: number, total: number, cap: number = DELETION_CAP): boolean {
+  if (planned <= 0) return false;
+  if (total <= 0) return true;
+  return planned / total > cap;
+}
+
+/** Guard 5 (pure): split ids into fixed-size delete batches. */
+export function batchIds<T>(ids: readonly T[], size: number = DELETE_BATCH_SIZE): T[][] {
+  if (size <= 0) throw new Error(`batchIds: size must be > 0, got ${size}`);
+  const batches: T[][] = [];
+  for (let i = 0; i < ids.length; i += size) {
+    batches.push(ids.slice(i, i + size));
+  }
+  return batches;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+const RED = "\x1b[31m";
+const RESET = "\x1b[0m";
+
+async function main(): Promise<void> {
+  const args = parseReconcileArgs(process.argv.slice(2));
+  if (args.errors.length > 0 || !args.cinemaId) {
+    for (const err of args.errors) console.error(`ERROR: ${err}`);
+    console.error(
+      "\nUsage: reconcile-phantom-screenings.ts <cinemaId> [--execute] [--force-large]",
+    );
+    process.exit(1);
+    return;
+  }
+  const cinemaId = args.cinemaId;
+
+  // Guard 1: cinema must exist in the registry.
+  const knownIds = CINEMA_REGISTRY.map((c) => c.id);
+  if (!validateCinemaId(cinemaId, knownIds)) {
+    console.error(`ERROR: Unknown cinema "${cinemaId}" — not in the cinema registry.`);
+    console.error(`Known IDs include: ${knownIds.slice(0, 10).join(", ")}, ...`);
+    process.exit(1);
+    return;
+  }
+
+  const now = new Date();
+
+  // Guard 2: last SUCCESSFUL scrape of this cinema must be fresh (< 2h old).
+  const [lastRun] = await db
+    .select({
+      startedAt: scraperRuns.startedAt,
+      completedAt: scraperRuns.completedAt,
+      screeningCount: scraperRuns.screeningCount,
+    })
+    .from(scraperRuns)
+    .where(and(eq(scraperRuns.cinemaId, cinemaId), eq(scraperRuns.status, "success")))
+    .orderBy(desc(scraperRuns.startedAt))
+    .limit(1);
+
+  if (!lastRun || !isReconcileSafe(lastRun.completedAt, now)) {
+    const lastSeen = lastRun?.completedAt?.toISOString() ?? "never";
+    console.error(
+      `REFUSED (guard 2): no successful scrape of "${cinemaId}" completed in the last ` +
+        `${MAX_SCRAPE_AGE_MS / 3_600_000}h (last success: ${lastSeen}).\n` +
+        `Run the scraper first, then reconcile while the run is fresh — reconciling ` +
+        `against a stale scrape would delete valid rows.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  // Guard 2b: a vacuous "success" run (0 screenings upserted) must never be
+  // swept behind — every upcoming row would be condemned. Not overridable.
+  if (isVacuousRun(lastRun.screeningCount)) {
+    console.error(
+      `REFUSED (guard 2b): the last successful scrape of "${cinemaId}" recorded ` +
+        `${lastRun.screeningCount ?? "no"} screenings — a reconcile against an empty scrape ` +
+        `would delete the venue's entire upcoming programme. This refusal cannot be overridden.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const runStartedAt = lastRun.startedAt;
+  console.log(`[reconcile] cinema:    ${cinemaId}`);
+  console.log(`[reconcile] last run:  started ${runStartedAt.toISOString()}, completed ${lastRun.completedAt!.toISOString()} (${lastRun.screeningCount ?? "?"} screenings)`);
+  console.log(`[reconcile] mode:      ${args.execute ? "EXECUTE" : "plan (dry run — pass --execute to delete)"}\n`);
+
+  // Fetch all upcoming rows for the cinema; classify with the pure guard-3 predicate.
+  const upcoming = await db
+    .select({
+      id: screenings.id,
+      datetime: screenings.datetime,
+      scrapedAt: screenings.scrapedAt,
+      sourceId: screenings.sourceId,
+      title: films.title,
+    })
+    .from(screenings)
+    .innerJoin(films, eq(screenings.filmId, films.id))
+    .where(and(eq(screenings.cinemaId, cinemaId), gte(screenings.datetime, now)));
+
+  // Guard 3b: never condemn rows beyond the run's demonstrated coverage.
+  const horizon = scrapeHorizon(upcoming, runStartedAt);
+  if (horizon === null) {
+    console.error(
+      `REFUSED (guard 3b): the last successful scrape refreshed zero upcoming rows for ` +
+        `"${cinemaId}" — it demonstrated no coverage, so nothing can be safely classified ` +
+        `as a phantom. This refusal cannot be overridden.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const stale = upcoming.filter((row) => isPhantomRow(row, runStartedAt, now));
+  const phantoms = stale
+    .filter((row) => row.datetime.getTime() <= horizon.getTime())
+    .sort((a, b) => a.datetime.getTime() - b.datetime.getTime());
+  const beyondHorizon = stale
+    .filter((row) => row.datetime.getTime() > horizon.getTime())
+    .sort((a, b) => a.datetime.getTime() - b.datetime.getTime());
+
+  console.log(`[reconcile] upcoming rows: ${upcoming.length}`);
+  console.log(`[reconcile] scrape horizon: ${horizon.toISOString()} (latest datetime the run refreshed)`);
+  console.log(`[reconcile] phantom rows:  ${phantoms.length} (scraped_at < run start, now <= datetime <= horizon)\n`);
+
+  if (beyondHorizon.length > 0) {
+    console.log(
+      `[reconcile] BEYOND SCRAPE HORIZON — ${beyondHorizon.length} stale rows excluded ` +
+        `(the run never demonstrated coverage past ${horizon.toISOString()}):`,
+    );
+    for (const p of beyondHorizon) {
+      console.log(
+        `  EXCLUDED      ${p.datetime.toISOString()}  source_id=${p.sourceId ?? "<null>"}  ` +
+          `scraped_at=${p.scrapedAt.toISOString()}  "${p.title}"`,
+      );
+    }
+    console.log("");
+  }
+
+  if (phantoms.length === 0) {
+    console.log("Nothing to reconcile — every upcoming row was refreshed by the last scrape.");
+    process.exit(0);
+    return;
+  }
+
+  // Guard 5 (plan output): print every doomed row.
+  for (const p of phantoms) {
+    console.log(
+      `  WOULD DELETE  ${p.datetime.toISOString()}  source_id=${p.sourceId ?? "<null>"}  ` +
+        `scraped_at=${p.scrapedAt.toISOString()}  "${p.title}"`,
+    );
+  }
+  const pct = upcoming.length > 0 ? ((phantoms.length / upcoming.length) * 100).toFixed(1) : "100";
+  console.log(`\n[reconcile] plan: delete ${phantoms.length}/${upcoming.length} upcoming rows (${pct}%)`);
+
+  // Guard 4: deletion cap.
+  if (exceedsDeletionCap(phantoms.length, upcoming.length)) {
+    if (!args.forceLarge) {
+      console.error(
+        `\nREFUSED (guard 4): plan would delete >${DELETION_CAP * 100}% of "${cinemaId}"'s upcoming rows. ` +
+          `Verify the scrape was complete (not blocked/partial) before overriding with --force-large.`,
+      );
+      process.exit(1);
+      return;
+    }
+    console.warn(
+      `\n${RED}WARNING: --force-large override active — plan exceeds the ${DELETION_CAP * 100}% deletion cap. ` +
+        `Double-check the scrape above was healthy before applying.${RESET}`,
+    );
+  }
+
+  if (!args.execute) {
+    console.log("\nDry run complete. Re-run with --execute to apply this plan.");
+    process.exit(0);
+    return;
+  }
+
+  // Guard 5 (execute): batched deletes inside a single transaction, each batch
+  // re-guarded to this cinema + future-only + still-stale rows.
+  const ids = phantoms.map((p) => p.id);
+  let deleted = 0;
+  await db.transaction(async (tx) => {
+    for (const batch of batchIds(ids)) {
+      const result = await tx
+        .delete(screenings)
+        .where(
+          and(
+            inArray(screenings.id, batch),
+            eq(screenings.cinemaId, cinemaId),
+            gte(screenings.datetime, now),
+            lt(screenings.scrapedAt, runStartedAt),
+          ),
+        )
+        .returning({ id: screenings.id });
+      deleted += result.length;
+    }
+  });
+
+  console.log(`\n[reconcile] deleted ${deleted} phantom rows from "${cinemaId}".`);
+  if (deleted !== ids.length) {
+    console.warn(
+      `[reconcile] note: ${ids.length - deleted} planned rows were skipped by the re-guard ` +
+        `(refreshed or past by execution time) — that is the guard working, not an error.`,
+    );
+  }
+  process.exit(0);
+}
+
+// Run if called directly (not when imported by tests)
+const isDirectRun =
+  process.argv[1]?.endsWith("reconcile-phantom-screenings.ts") ||
+  process.argv[1]?.endsWith("reconcile-phantom-screenings.js");
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
Implements `plans/009-sourceid-phantom-reconcile.md` — code only; per-venue rollout (scrape → plan → review → apply) happens post-merge.

## Premise correction (evidence-based)
The plan claimed 13/26 scrapers lacked sourceId. Verified against live code AND the plan's authoring commit: **27/28 already emitted one**. Real fixes: Prince Charles' sourceId could be `undefined` when the booking-URL regex missed (now falls back to a derived `prince-charles-{slug}-{ISO}` composite; primary bare-digit scheme kept to avoid stranding existing rows); Phoenix already used the recommended derived composite.

## Changes
- `src/scripts/reconcile-phantom-screenings.ts` + `reconcile:plan`/`reconcile:apply`: default-dry, single-cinema, **seven hard guards** as exported pure functions (36 tests) — registry check, fresh-successful-scrape-within-2h, future-only, 40% deletion cap, full plan printing, plus review-added `isVacuousRun` (refuses 0-screening 'success' runs) and `scrapeHorizon` (rows beyond the run's demonstrated coverage are EXCLUDED, never deleted). Transactional batched deletes, re-guarded inside the transaction.
- `SCRAPING_PLAYBOOK.md`: complete 28-scraper sourceId scheme table + the scheme-change → reconcile rule (what makes the next BFI-style incident detectable).

## Prod dry-run evidence (read-only)
Phoenix: guard 2 correctly REFUSED (last successful scrape >2h old). Selection-logic probe vs that run: 27/83 upcoming rows (32.5%, under the 40% cap) — exactly the predicted phantoms (rocky-road[s]-to-dublin slug-drift duplicates, stranded Tuner/Savage House rows).

## Review
Code-reviewer: no blockers; 2 majors fixed (horizon blind spot, vacuous-run wipe path). Reviewer independently verified the scraped_at-bump premise on both insert and update paths.

## Verification
`npm run test:run` 123 files / **1,894 tests pass** · `npx tsc --noEmit` clean · `npm run lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)