### PR TITLE
docs: remove duplicate TMDB-matcher changelog entry

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-06-18: Changelog cleanup — remove duplicate TMDB-matcher entry
+**PR**: TBD | **Files**: `RECENT_CHANGES.md`, `changelogs/2026-06-18-changelog-dedupe.md`
+- Removed an orphaned duplicate "TMDB matcher" header (body-less, separator-less) that landed above the "Untrack tasks" entry during the #668–#677 changelog merges; the complete entry remains intact lower in the file.
+- Docs only — no runtime impact.
+
+---
+
 ## 2026-06-12: Generalized phantom-screening reconcile + sourceId hardening (plan 009)
 **PR**: pending | **Files**: `src/scripts/reconcile-phantom-screenings.ts`, `src/scripts/reconcile-phantom-screenings.test.ts`, `src/scrapers/cinemas/prince-charles.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`, `package.json`
 - New `npm run reconcile:plan -- <cinemaId>` / `reconcile:apply -- <cinemaId>`: generalized, default-dry sweep for upcoming rows the source no longer lists (`scraped_at` < last successful run start). Supersedes the one-off `_bfi_reconcile.ts` staging script.
@@ -46,8 +53,6 @@
 
 ---
 
-## 2026-06-12: TMDB matcher — audit trail persisted, year discipline, runtime/director/language signals
-**PR**: pending | **Files**: `src/lib/tmdb/match.ts`, `src/scrapers/utils/film-matching.ts`, `src/scrapers/pipeline.ts`, `src/scrapers/types.ts`, `src/config/cinema-registry.ts`
 ## 2026-06-12: Untrack tasks/ session scratch
 **PR**: TBD | **Files**: `.gitignore`, `tasks/todo.md` (untracked)
 - tasks/todo.md was accidentally committed in #670 (agent-worktree `git add -A`); removed from tracking and gitignored — it is per-session scratch.

--- a/changelogs/2026-06-18-changelog-dedupe.md
+++ b/changelogs/2026-06-18-changelog-dedupe.md
@@ -1,0 +1,12 @@
+# Changelog Cleanup — Remove Duplicate TMDB-Matcher Entry
+
+**PR**: TBD
+**Date**: 2026-06-18
+
+## Changes
+- Removed an orphaned, duplicate `## 2026-06-12: TMDB matcher …` entry from `RECENT_CHANGES.md`. The stub had only a header and a `**PR**/Files` line — no body bullets and no `---` separator — and sat directly above the "Untrack tasks/ session scratch" entry. It was introduced during the changelog merges across PRs #668–#677.
+- The complete, correctly-formatted "TMDB matcher" entry remains intact lower in the file (with its body and separator).
+
+## Impact
+- Documentation only — no code, schema, or runtime behavior changes.
+- `RECENT_CHANGES.md` is now well-formed (every entry has a body and a trailing separator).


### PR DESCRIPTION
## Summary
Removes a pre-existing malformed entry in `RECENT_CHANGES.md`: an orphaned, duplicate `## 2026-06-12: TMDB matcher …` header (header + `**PR**/Files` line only — **no body, no `---` separator**) that sat directly above the "Untrack tasks" entry. It was introduced during the changelog merges across PRs #668–#677. The complete, correctly-formatted TMDB-matcher entry remains intact lower in the file.

## Changes
- `RECENT_CHANGES.md`: delete the orphaned stub (2 lines); add a top entry recording this cleanup.
- `changelogs/2026-06-18-changelog-dedupe.md`: detailed archive entry (per the project's two-location changelog rule).

## Verification
- **Docs only** — no code, schema, tests, or runtime behavior touched.
- After the fix, `## 2026-06-12: TMDB matcher` appears exactly once; every entry has a body + trailing `---`.
- Authored against authoritative `main` content (transform script with pre/post assertions) — the local working tree was unreliable this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)