### PR TITLE
ci: pin git transport to HTTP/1.1 in workflows that do git ops

### DIFF
--- a/.github/workflows/social-outreach.yml
+++ b/.github/workflows/social-outreach.yml
@@ -27,6 +27,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # Pin HTTP/1.1 for git ops — avoids HTTP/2 fetch stalls.
+      - name: Pin git transport to HTTP/1.1
+        run: git config --global http.version HTTP/1.1
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # git fetch/push can stall on HTTP/2 on some networks; pin HTTP/1.1 so any raw
+      # git op (checkout, any future push) can't hang and burn runner minutes.
+      - name: Pin git transport to HTTP/1.1
+        run: git config --global http.version HTTP/1.1
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -66,6 +71,11 @@ jobs:
             echo "DATABASE_URL_TEST is configured"
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
+
+      # Pin HTTP/1.1 for git ops — avoids HTTP/2 fetch stalls (see unit-tests job).
+      - name: Pin git transport to HTTP/1.1
+        if: steps.check-db.outputs.skip != 'true'
+        run: git config --global http.version HTTP/1.1
 
       - name: Checkout repository
         if: steps.check-db.outputs.skip != 'true'

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,8 @@
+## 2026-06-21: CI — pin git transport to HTTP/1.1 (defensive)
+**PR**: TBD | **Files**: `.github/workflows/test.yml`, `.github/workflows/social-outreach.yml`
+- Added a `git config --global http.version HTTP/1.1` step before checkout in every CI job that does a git op (unit-tests, e2e-tests, social-outreach). `git fetch/push` can hang on HTTP/2 on some networks; pinning HTTP/1.1 stops a raw git op from stalling and burning runner minutes.
+- **Defensive only**: GitHub-hosted runners don't currently exhibit the stall — this is future-proofing per PIC-16, not a fix for an active CI failure. `post-deploy-verify.yml` left untouched (curl-only, no git). (PIC-16)
+
 ## 2026-06-03: Search — instant, typo-tolerant, in-browser film/cinema/people search
 **PR**: TBD | **Files**: `frontend/src/lib/search/catalog-index-core.ts` (new), `frontend/src/lib/search/catalog-index.svelte.ts` (new), `frontend/src/lib/search/catalog-index.test.ts` (new), `frontend/src/lib/stores/palette.svelte.ts`, `frontend/src/lib/search/result-types.ts`, `frontend/src/lib/components/search/ResultsList.svelte`, `frontend/src/lib/components/search/GlobalCmdkBinding.svelte`, `frontend/tests/command-palette.spec.ts`, `frontend/package.json`
 - ⌘K search is now **instant + typo-tolerant**. The catalog (films-with-a-future-screening + cinemas +

--- a/changelogs/2026-06-21-ci-pin-http1.md
+++ b/changelogs/2026-06-21-ci-pin-http1.md
@@ -1,0 +1,16 @@
+# CI — pin git transport to HTTP/1.1
+
+**PR**: TBD
+**Date**: 2026-06-21
+**Issue**: PIC-16
+
+## Changes
+- Added a `Pin git transport to HTTP/1.1` step (`git config --global http.version HTTP/1.1`) before the checkout step in every CI job that performs a git operation:
+  - `.github/workflows/test.yml` → `unit-tests` and `e2e-tests` (the latter mirrors checkout's existing `if: skip != 'true'` guard).
+  - `.github/workflows/social-outreach.yml` → `scrape-and-sync`.
+- `.github/workflows/post-deploy-verify.yml` intentionally left untouched — it only runs `curl`, no git.
+
+## Impact
+- Defensive future-proofing: `git fetch/push` can stall on HTTP/2 on some networks; pinning HTTP/1.1 ensures a raw git op in CI (checkout, or any future push step) can't hang and burn runner minutes.
+- GitHub-hosted runners do not currently exhibit this stall, so there is no active CI failure being fixed — this only hardens against a future regression / new git step.
+- No effect on test outcomes or runtime code.


### PR DESCRIPTION
## What
Adds a `git config --global http.version HTTP/1.1` step before checkout in every CI job that performs a git operation: `test.yml` → `unit-tests` + `e2e-tests`, and `social-outreach.yml` → `scrape-and-sync`. `post-deploy-verify.yml` is left alone (curl-only, no git).

## Why
`git fetch/push` can stall on **HTTP/2** on some networks; the known workaround is pinning HTTP/1.1. Pinning it in CI ensures a raw git op (checkout, or any future push step) can't hang and burn runner minutes.

## Honest caveat
This is **defensive future-proofing**, not a fix for an active CI failure — GitHub-hosted runners don't currently exhibit the HTTP/2 stall (it's been seen on a local network). It matches PIC-16's own rationale ("if CI ever does raw git over HTTP it can hit the same stall"). If you'd rather not carry a no-op step, this PR is safe to close — flagging so you can decide.

## Verification
Config-only; no test or runtime code touched. Documented inline in the workflow comments (PIC-16 criteria allow workflow-file documentation).

Closes PIC-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)