### PR TITLE
perf: remove + gitignore unreferenced InterVariable-Italic.woff2

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,8 @@
+## 2026-06-21: Perf — remove + gitignore unreferenced InterVariable-Italic.woff2 (388 KB)
+**PR**: TBD | **Files**: `frontend/.gitignore` (+ deleted untracked `frontend/static/fonts/InterVariable-Italic.woff2`)
+- The 388 KB italic font is **unreferenced** (no `@font-face`/preload — `app.css` uses the roman `InterVariable.woff2`; `rg InterVariable-Italic frontend/` → 0 hits) yet kept reappearing in the working tree as untracked dead weight. The 2026-05-30 perf campaign deleted it once; it came back.
+- Deleted the local file and **gitignored the exact path** so it can't be accidentally committed/shipped again. Since it was never tracked, the committed change is the gitignore guard. Build unaffected (asset was unreferenced). (PIC-41)
+
 ## 2026-06-03: Search — instant, typo-tolerant, in-browser film/cinema/people search
 **PR**: TBD | **Files**: `frontend/src/lib/search/catalog-index-core.ts` (new), `frontend/src/lib/search/catalog-index.svelte.ts` (new), `frontend/src/lib/search/catalog-index.test.ts` (new), `frontend/src/lib/stores/palette.svelte.ts`, `frontend/src/lib/search/result-types.ts`, `frontend/src/lib/components/search/ResultsList.svelte`, `frontend/src/lib/components/search/GlobalCmdkBinding.svelte`, `frontend/tests/command-palette.spec.ts`, `frontend/package.json`
 - ⌘K search is now **instant + typo-tolerant**. The catalog (films-with-a-future-screening + cinemas +

--- a/changelogs/2026-06-21-remove-intervariable-italic-font.md
+++ b/changelogs/2026-06-21-remove-intervariable-italic-font.md
@@ -1,0 +1,19 @@
+# Remove + gitignore unreferenced InterVariable-Italic.woff2
+
+**PR**: TBD
+**Date**: 2026-06-21
+**Issue**: PIC-41
+
+## Changes
+- Deleted the untracked `frontend/static/fonts/InterVariable-Italic.woff2` (387,976 bytes) from the working tree.
+- Added `/static/fonts/InterVariable-Italic.woff2` to `frontend/.gitignore` so the file can't be accidentally committed/shipped if it reappears.
+
+## Context
+- The file is **unreferenced**: no `@font-face` or preload points at it. `frontend/src/app.css` declares the roman `InterVariable.woff2` plus `Fraunces`, `Cormorant-Italic`, and `IBMPlexMono`; `rg InterVariable-Italic frontend/` returns zero hits.
+- It was **never tracked** in git (`git ls-files frontend/static/fonts/` lists the five real fonts, not this one), so it was not actually shipped — but it kept reappearing locally as dead weight, and a stray `git add .` would have committed 388 KB.
+- The 2026-05-30 perf campaign reported deleting it; it returned. The gitignore guard makes the removal durable.
+
+## Impact
+- No runtime/build impact — the asset was unreferenced, so removal cannot break a font face.
+- Prevents 388 KB of dead weight from being accidentally committed in future.
+- Verified by inspection (CI runners currently not executing; this is a static-asset/gitignore-only change with no code path).

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,8 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .env*.local
+
+# Fonts — unreferenced variant that keeps reappearing in the working tree.
+# Not used by any @font-face/preload (app.css uses InterVariable.woff2, the roman).
+# Ignored so the 388 KB file can't be accidentally committed/shipped (PIC-41).
+/static/fonts/InterVariable-Italic.woff2


### PR DESCRIPTION
## What
Deletes the untracked 388 KB `frontend/static/fonts/InterVariable-Italic.woff2` and gitignores its path.

## Why
The italic font is **unreferenced** — no `@font-face`/preload points at it (`app.css` uses the roman `InterVariable.woff2`; `rg InterVariable-Italic frontend/` → 0 hits). It was never tracked in git (so not actually shipped), but kept reappearing in the working tree as dead weight; a stray `git add .` would commit 388 KB. The 2026-05-30 perf campaign deleted it once and it returned — gitignoring the path makes the removal durable.

## Note on the diff
Because the file was untracked, the committed change is the **`.gitignore` guard** (+ changelog); the file deletion isn't in the diff.

## Verification
Inspection-only: the asset is unreferenced, so removal can't break a font face or the build. (CI runners aren't currently executing — see the CI-down note on the campaign; this change has no code path regardless.)

Closes PIC-41

🤖 Generated with [Claude Code](https://claude.com/claude-code)