### PR TITLE
test(curzon): cover healthCheck 401-is-healthy contract

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-06-21: Test — Curzon healthCheck 401-is-healthy contract
-**PR**: #718 | **Files**: `src/scrapers/chains/curzon.test.ts`
+**PR**: #720 (supersedes #718) | **Files**: `src/scrapers/chains/curzon.test.ts`
 - The Curzon `healthCheck()` already implements the 401-is-healthy contract (Cloudflare blocks HEAD, so it probes the Vista API; `401` = up-but-needs-auth = healthy; `5xx`/network = down). This adds the missing unit test: 401 → healthy, 2xx → healthy, 5xx → unhealthy, network error → unhealthy. Implementation was already on `main`; this closes the test gap. (PIC-29)
 
 ---

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,9 @@
+## 2026-06-21: Test — Curzon healthCheck 401-is-healthy contract
+**PR**: #718 | **Files**: `src/scrapers/chains/curzon.test.ts`
+- The Curzon `healthCheck()` already implements the 401-is-healthy contract (Cloudflare blocks HEAD, so it probes the Vista API; `401` = up-but-needs-auth = healthy; `5xx`/network = down). This adds the missing unit test: 401 → healthy, 2xx → healthy, 5xx → unhealthy, network error → unhealthy. Implementation was already on `main`; this closes the test gap. (PIC-29)
+
+---
+
 ## 2026-06-21: Test — rate-limiter fail-open path (Upstash throws → in-memory)
 **PR**: #719 (supersedes #714) | **Files**: `src/lib/rate-limit.test.ts`
 - Regression coverage for the 2026-05-30 incident path (fixed in PR #584): when the Upstash backend throws (over-quota / unreachable), `checkRateLimit` must **fail OPEN** via the in-memory limiter rather than propagate a 500 to every DB-backed route.

--- a/changelogs/2026-06-21-curzon-healthcheck-test.md
+++ b/changelogs/2026-06-21-curzon-healthcheck-test.md
@@ -1,0 +1,17 @@
+# Curzon healthCheck unit test (401-is-healthy)
+
+**PR**: #718
+**Date**: 2026-06-21
+**Issue**: PIC-29
+
+## Changes
+- Added a `Curzon healthCheck (401-is-healthy contract)` describe block to `src/scrapers/chains/curzon.test.ts`.
+- Stubs global `fetch` and asserts the four cases: `401` → healthy, `2xx` → healthy, `5xx` → unhealthy, network error/timeout → unhealthy.
+
+## Context
+- The implementation already exists and is correct on `main` (`src/scrapers/chains/curzon.ts` `healthCheck()` returns `response.status === 401 || response.ok`, with a `catch` → `false`). Cloudflare blocks HEAD on `www.curzon.com`, so the scraper probes the Vista API endpoint; a `401` proves Cloudflare let the request through and the API is up.
+- PIC-29's "done-when" required this behaviour to be **covered by a unit test**; that test was missing. This closes the gap — no production code changed.
+
+## Impact
+- Locks in the 401-is-healthy contract so a future refactor can't silently turn Curzon's health check into a false-negative (which would wrongly mark the scraper down).
+- Verified via CI (local vitest workers time out under disk pressure in this environment).

--- a/changelogs/2026-06-21-curzon-healthcheck-test.md
+++ b/changelogs/2026-06-21-curzon-healthcheck-test.md
@@ -1,6 +1,6 @@
 # Curzon healthCheck unit test (401-is-healthy)
 
-**PR**: #718
+**PR**: #720 (supersedes #718)
 **Date**: 2026-06-21
 **Issue**: PIC-29
 

--- a/src/scrapers/chains/curzon.test.ts
+++ b/src/scrapers/chains/curzon.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { CURZON_CONFIG, CURZON_VENUES, createCurzonScraper } from "./curzon";
 
 /**
@@ -113,5 +113,45 @@ describe("CurzonScraper.convertToRawScreenings — runtime capture", () => {
     expect(screenings[0].filmTitle).toBe("The Drama");
     expect(screenings[0].year).toBe(2025);
     expect(screenings[0].sourceId).toBe("curzon-ST-001");
+  });
+});
+
+/**
+ * Curzon healthCheck contract: Cloudflare blocks HEAD on www.curzon.com, so the
+ * scraper probes the Vista API instead. A 401 means Cloudflare let the request
+ * through and the API is up (just needs a JWT) → healthy. Only 5xx / network
+ * failures mean the service is actually down. (PIC-29)
+ */
+describe("Curzon healthCheck (401-is-healthy contract)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const fakeResponse = (status: number, ok: boolean) =>
+    vi.fn(async () => ({ status, ok }) as unknown as Response);
+
+  it("treats 401 (Cloudflare passed, auth required) as healthy", async () => {
+    vi.stubGlobal("fetch", fakeResponse(401, false));
+    expect(await createCurzonScraper().healthCheck()).toBe(true);
+  });
+
+  it("treats a 2xx response as healthy", async () => {
+    vi.stubGlobal("fetch", fakeResponse(200, true));
+    expect(await createCurzonScraper().healthCheck()).toBe(true);
+  });
+
+  it("treats 5xx as unhealthy", async () => {
+    vi.stubGlobal("fetch", fakeResponse(503, false));
+    expect(await createCurzonScraper().healthCheck()).toBe(false);
+  });
+
+  it("treats a network error / timeout as unhealthy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNRESET");
+      })
+    );
+    expect(await createCurzonScraper().healthCheck()).toBe(false);
   });
 });


### PR DESCRIPTION
## What
Relands #718 rebased onto current main (the original PR branch could not be updated from this session, so this supersedes it). Adds the unit test for Curzon's `healthCheck()` 401-is-healthy contract — the implementation already exists on main (`src/scrapers/chains/curzon.ts`): Cloudflare blocks HEAD, so it probes the Vista API where a 401 proves the API is up.

## Test cases
- 401 → healthy (the core contract)
- 2xx → healthy
- 5xx → unhealthy
- network error / timeout → unhealthy

## Conflict resolution vs #718
`src/scrapers/chains/curzon.test.ts` had also gained runtime-capture tests on main (plan 006) — both suites kept, imports combined. Changelog entries merged.

## Verification
Verified locally on this merge result: `npx vitest run src/scrapers/chains/curzon.test.ts src/lib/rate-limit.test.ts` → 33/33 passed (12 curzon incl. both suites). Note: the Tests workflow is not currently running on PRs, so local verification is the gate.

Closes PIC-29. Supersedes #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBzmMaczXW8hGw9QbJVAPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBzmMaczXW8hGw9QbJVAPn)_