### PR TITLE
perf: remove + gitignore unreferenced InterVariable-Italic.woff2

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-06-21: Perf — remove + gitignore unreferenced InterVariable-Italic.woff2 (388 KB)
-**PR**: TBD | **Files**: `frontend/.gitignore` (+ deleted untracked `frontend/static/fonts/InterVariable-Italic.woff2`)
+**PR**: #721 (supersedes #716) | **Files**: `frontend/.gitignore` (+ deleted untracked `frontend/static/fonts/InterVariable-Italic.woff2`)
 - The 388 KB italic font is **unreferenced** (no `@font-face`/preload — `app.css` uses the roman `InterVariable.woff2`; `rg InterVariable-Italic frontend/` → 0 hits) yet kept reappearing in the working tree as untracked dead weight. The 2026-05-30 perf campaign deleted it once; it came back.
 - Deleted the local file and **gitignored the exact path** so it can't be accidentally committed/shipped again. Since it was never tracked, the committed change is the gitignore guard. Build unaffected (asset was unreferenced). (PIC-41)
 

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-06-21: Perf — remove + gitignore unreferenced InterVariable-Italic.woff2 (388 KB)
+**PR**: TBD | **Files**: `frontend/.gitignore` (+ deleted untracked `frontend/static/fonts/InterVariable-Italic.woff2`)
+- The 388 KB italic font is **unreferenced** (no `@font-face`/preload — `app.css` uses the roman `InterVariable.woff2`; `rg InterVariable-Italic frontend/` → 0 hits) yet kept reappearing in the working tree as untracked dead weight. The 2026-05-30 perf campaign deleted it once; it came back.
+- Deleted the local file and **gitignored the exact path** so it can't be accidentally committed/shipped again. Since it was never tracked, the committed change is the gitignore guard. Build unaffected (asset was unreferenced). (PIC-41)
+
+---
+
 ## 2026-06-21: Test — Curzon healthCheck 401-is-healthy contract
 **PR**: #720 (supersedes #718) | **Files**: `src/scrapers/chains/curzon.test.ts`
 - The Curzon `healthCheck()` already implements the 401-is-healthy contract (Cloudflare blocks HEAD, so it probes the Vista API; `401` = up-but-needs-auth = healthy; `5xx`/network = down). This adds the missing unit test: 401 → healthy, 2xx → healthy, 5xx → unhealthy, network error → unhealthy. Implementation was already on `main`; this closes the test gap. (PIC-29)

--- a/changelogs/2026-06-21-remove-intervariable-italic-font.md
+++ b/changelogs/2026-06-21-remove-intervariable-italic-font.md
@@ -1,0 +1,19 @@
+# Remove + gitignore unreferenced InterVariable-Italic.woff2
+
+**PR**: TBD
+**Date**: 2026-06-21
+**Issue**: PIC-41
+
+## Changes
+- Deleted the untracked `frontend/static/fonts/InterVariable-Italic.woff2` (387,976 bytes) from the working tree.
+- Added `/static/fonts/InterVariable-Italic.woff2` to `frontend/.gitignore` so the file can't be accidentally committed/shipped if it reappears.
+
+## Context
+- The file is **unreferenced**: no `@font-face` or preload points at it. `frontend/src/app.css` declares the roman `InterVariable.woff2` plus `Fraunces`, `Cormorant-Italic`, and `IBMPlexMono`; `rg InterVariable-Italic frontend/` returns zero hits.
+- It was **never tracked** in git (`git ls-files frontend/static/fonts/` lists the five real fonts, not this one), so it was not actually shipped — but it kept reappearing locally as dead weight, and a stray `git add .` would have committed 388 KB.
+- The 2026-05-30 perf campaign reported deleting it; it returned. The gitignore guard makes the removal durable.
+
+## Impact
+- No runtime/build impact — the asset was unreferenced, so removal cannot break a font face.
+- Prevents 388 KB of dead weight from being accidentally committed in future.
+- Verified by inspection (CI runners currently not executing; this is a static-asset/gitignore-only change with no code path).

--- a/changelogs/2026-06-21-remove-intervariable-italic-font.md
+++ b/changelogs/2026-06-21-remove-intervariable-italic-font.md
@@ -1,6 +1,6 @@
 # Remove + gitignore unreferenced InterVariable-Italic.woff2
 
-**PR**: TBD
+**PR**: #721 (supersedes #716)
 **Date**: 2026-06-21
 **Issue**: PIC-41
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,8 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .env*.local
+
+# Fonts — unreferenced variant that keeps reappearing in the working tree.
+# Not used by any @font-face/preload (app.css uses InterVariable.woff2, the roman).
+# Ignored so the 388 KB file can't be accidentally committed/shipped (PIC-41).
+/static/fonts/InterVariable-Italic.woff2


### PR DESCRIPTION
## What
Relands #716 rebased onto current main (the original PR branch could not be updated from this session, so this supersedes it). Gitignores `frontend/static/fonts/InterVariable-Italic.woff2` — the 388 KB italic font is unreferenced (no `@font-face`/preload; `app.css` uses the roman `InterVariable.woff2`) but kept reappearing untracked in working trees after the 2026-05-30 perf campaign deleted it. The ignore rule makes the removal durable; since the file was never tracked, the committed change is the `.gitignore` guard + changelog.

## Verification
Inspection-only: the asset is unreferenced, so this cannot affect a font face or the build. Verified the file is absent from a fresh clone (it was never tracked) and that no reference exists (`rg InterVariable-Italic` → 0 hits).

Closes PIC-41. Supersedes #716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBzmMaczXW8hGw9QbJVAPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBzmMaczXW8hGw9QbJVAPn)_