### PR TITLE
docs: recreate tasks/semantic-search-plan.md (lost design record)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,10 @@
+## 2026-06-21: Docs — recreate tasks/semantic-search-plan.md (lost design record)
+**PR**: TBD | **Files**: `tasks/semantic-search-plan.md` (new)
+- Restores the validated semantic-search design that memory referenced but was missing from the repo: `bge-small-en-v1.5` q8 / 384d, `onnxruntime-node` backend (native x64 prebuilt — the web build needs a browser), added as a **third RRF arm (k=60)** alongside the existing tsvector + trigram fusion in `/api/films/search`.
+- Documents the one open gate (PIC-33: validate `onnxruntime-node` bundle size + cold-start on a Vercel preview deploy) and the implementation sequence (PIC-32 → PIC-33 → PIC-34). Reconstructed from the design record; no runtime code. (PIC-32)
+
+---
+
 ## 2026-06-21: Perf — remove + gitignore unreferenced InterVariable-Italic.woff2 (388 KB)
 **PR**: #721 (supersedes #716) | **Files**: `frontend/.gitignore` (+ deleted untracked `frontend/static/fonts/InterVariable-Italic.woff2`)
 - The 388 KB italic font is **unreferenced** (no `@font-face`/preload — `app.css` uses the roman `InterVariable.woff2`; `rg InterVariable-Italic frontend/` → 0 hits) yet kept reappearing in the working tree as untracked dead weight. The 2026-05-30 perf campaign deleted it once; it came back.

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-06-21: Docs — recreate tasks/semantic-search-plan.md (lost design record)
-**PR**: TBD | **Files**: `tasks/semantic-search-plan.md` (new)
+**PR**: #722 (supersedes #717) | **Files**: `tasks/semantic-search-plan.md` (new)
 - Restores the validated semantic-search design that memory referenced but was missing from the repo: `bge-small-en-v1.5` q8 / 384d, `onnxruntime-node` backend (native x64 prebuilt — the web build needs a browser), added as a **third RRF arm (k=60)** alongside the existing tsvector + trigram fusion in `/api/films/search`.
 - Documents the one open gate (PIC-33: validate `onnxruntime-node` bundle size + cold-start on a Vercel preview deploy) and the implementation sequence (PIC-32 → PIC-33 → PIC-34). Reconstructed from the design record; no runtime code. (PIC-32)
 

--- a/changelogs/2026-06-21-recreate-semantic-search-plan.md
+++ b/changelogs/2026-06-21-recreate-semantic-search-plan.md
@@ -1,6 +1,6 @@
 # Recreate tasks/semantic-search-plan.md
 
-**PR**: TBD
+**PR**: #722 (supersedes #717)
 **Date**: 2026-06-21
 **Issue**: PIC-32
 

--- a/changelogs/2026-06-21-recreate-semantic-search-plan.md
+++ b/changelogs/2026-06-21-recreate-semantic-search-plan.md
@@ -1,0 +1,18 @@
+# Recreate tasks/semantic-search-plan.md
+
+**PR**: TBD
+**Date**: 2026-06-21
+**Issue**: PIC-32
+
+## Changes
+- Recreated `tasks/semantic-search-plan.md`, which memory referenced but was missing from the repo.
+
+## Content restored (from the design record + spike findings)
+- **Model**: `bge-small-en-v1.5`, q8 quantization, 384 dimensions (spike confirmed output L2 norm ≈ 1.0).
+- **Backend**: `onnxruntime-node` (native) — corrected from the original forced-WASM assumption, because the web build needs a browser environment and `onnxruntime-node` ships a prebuilt `linux/x64` binary matching Vercel's runtime.
+- **Architecture**: semantic embeddings added as a **third RRF arm (k=60)** alongside the existing `tsvector` (full-text) + `pg_trgm` (trigram) arms in `/api/films/search`; pgvector still needs enabling (part of the PIC-34 migration — 0012/0013 only add pg_trgm/unaccent/btree_gin).
+- **Open gate (PIC-33)**: validate `onnxruntime-node` bundle size + cold-start + execution inside a Vercel serverless function on a preview deploy before wiring the arm live.
+- **Sequence**: PIC-32 (plan) → PIC-33 (Vercel validation) → PIC-34 (migration + backfill + RRF wiring, degrading to the 2-arm hybrid on error).
+
+## Impact
+- Documentation only; no runtime code. Restores the prerequisite artefact for the Semantic Search Productionization project so the validated decisions aren't lost.

--- a/tasks/semantic-search-plan.md
+++ b/tasks/semantic-search-plan.md
@@ -1,0 +1,74 @@
+# Semantic Film Search — Productionization Plan
+
+> **Status:** design validated by spike; productionization gated on a Vercel serverless check.
+> **Reconstructed 2026-06-21** (the original `tasks/semantic-search-plan.md` was lost from the repo; this restores the validated decisions from the design record / spike findings — PIC-32). Tracks: PIC-32 (this doc), PIC-33 (Vercel validation), PIC-34 (wire the RRF arm).
+
+## Goal
+
+Add a **semantic** retrieval arm to `/api/films/search` so conceptual queries — "films about grief", "neon-noir", "slow-burn revenge" — rank well alongside the existing lexical and fuzzy matching. Semantic search complements, never replaces, the current hybrid.
+
+## Where search is today
+
+`/api/films/search` is already a **hybrid** ranker fusing two arms via Reciprocal Rank Fusion (RRF, k=60):
+
+1. **Full-text** — Postgres `tsvector` (`search_tsv` generated column).
+2. **Trigram** — `pg_trgm` similarity over `search_text` (typo / partial tolerance).
+
+Extensions enabled: `pg_trgm`, `unaccent`, `btree_gin` (migration 0012). **pgvector is NOT yet enabled** — `src/db/schema/films.ts` notes the embedding column is commented out until it is. Enabling the extension is part of the PIC-34 migration below.
+
+## The plan: semantic as a third RRF arm
+
+Add embeddings as a **third arm** fused into the same RRF (k=60):
+
+```
+final_rank = RRF(fulltext_rank, trigram_rank, semantic_rank)   # k = 60
+```
+
+RRF is the right fusion choice because it needs no score calibration across arms (each arm only contributes ranks), so the semantic arm can be added without retuning the existing two.
+
+### Model decision (validated by spike)
+
+- **Model:** `bge-small-en-v1.5`
+- **Quantization:** **q8** (int8) — small footprint, negligible quality loss for this use.
+- **Dimensions:** **384**
+- Spike validation: embedding output **L2 norm ≈ 1.0** (correctly normalized), so cosine similarity = dot product and pgvector `<=>` / `<#>` behave as expected.
+
+### Backend decision (CORRECTED during spike)
+
+- **Use `onnxruntime-node` (native), NOT a forced-WASM/web build.**
+- Rationale:
+  - The **web build** of the embedding runtime expects a **browser environment** (DOM/Worker APIs) and does not run cleanly in a Node serverless function.
+  - **`onnxruntime-node` ships a prebuilt `linux/x64` binary**, which matches the Vercel serverless runtime — no native compile step at deploy time.
+- Embeddings are computed **server-side at query time** for the user's query string; film embeddings are precomputed and stored in a pgvector column.
+
+## Open gate (the one blocker) — PIC-33
+
+**Validate `onnxruntime-node` inside a Vercel serverless function on a preview deploy**, specifically:
+
+- **Bundle size** — the native `.node` binary + model weights must fit within the serverless function size limit (and not blow cold-start).
+- **Cold-start latency** — first-invocation model load must be acceptable; consider lazy-loading the session and/or keeping the model file small (q8 helps).
+- **Execution** — confirm the prebuilt binary actually loads and runs in the deployed runtime (not just locally).
+
+This must be proven on a **preview deployment** before wiring the arm into the live endpoint — local success is necessary but not sufficient (the spike's original WASM assumption is exactly what local-only testing would have missed).
+
+## Implementation sequence
+
+1. **PIC-32 — this plan** (recreate + commit the design record). ✅ this PR.
+2. **PIC-33 — Vercel validation.** Stand up a throwaway route on a preview deploy that loads `onnxruntime-node` + the q8 model and embeds a string; measure bundle size + cold start; confirm it executes. Gate everything below on this passing.
+3. **PIC-34 — wire the third RRF arm.**
+   - Migration: enable the `pgvector` extension, then add a `vector(384)` column to the films table; backfill embeddings for all films (batch job).
+   - Query path: embed the query server-side, run a pgvector nearest-neighbour query, feed its ranking into the existing RRF(k=60) alongside fulltext + trigram.
+   - Keep the arm **additive and guarded**: if the embedding step errors or is slow, the endpoint must degrade to the current 2-arm hybrid (never 500, never block lexical results).
+
+## Risks / watch-items
+
+- **Serverless cold start** — model load on a cold function could spike p99 latency; mitigate with lazy session init and the small q8 model. Re-evaluate if PIC-33 shows it's heavy.
+- **Bundle limit** — if the binary + weights exceed the function limit, fall back to a separate embedding service or precompute-only (no query-time embedding).
+- **Backfill cost** — embedding the full film catalogue is a one-off batch; throttle to avoid DB/CPU pressure.
+- **No new paid APIs** — this is deliberately a local/in-process model (no Voyage/OpenAI embedding API), consistent with the project's "no new paid/AI APIs for features" rule.
+
+## References
+
+- Hybrid search migrations: 0012 / 0013 (`pg_trgm`, `unaccent`, `btree_gin`; pgvector still to be enabled in PIC-34).
+- Existing fusion: RRF k=60 over `search_tsv` (tsvector) + `search_text` (trigram).
+- Design record: memory `project_semantic_search_2026_06_01`.


### PR DESCRIPTION
## What
Relands #717 rebased onto current main (the original PR branch could not be updated from this session, so this supersedes it). Recreates `tasks/semantic-search-plan.md` — the prerequisite design record for the Semantic Search Productionization project (PIC-32 → PIC-33 → PIC-34).

## Correction vs #717
The original PR asked for a sanity check of its claims — one was wrong: it stated pgvector was already enabled by migrations 0012/0013. Those migrations only add `pg_trgm`, `unaccent`, `btree_gin`, and `src/db/schema/films.ts:95` explicitly notes the embedding column is commented out *until* pgvector is enabled. The doc now says pgvector still needs enabling as part of the PIC-34 migration.

## Restored decisions (unchanged from #717)
- Model: `bge-small-en-v1.5`, q8, 384d (spike confirmed L2 norm ≈ 1.0)
- Backend: `onnxruntime-node` (native linux/x64 prebuilt matches Vercel; the web/WASM build needs a browser)
- Architecture: semantic as a third RRF arm (k=60) alongside tsvector + trigram in `/api/films/search`
- Open gate (PIC-33): validate bundle size / cold start / execution on a Vercel preview before wiring live

## Verification
Docs only; no runtime code. pgvector claim checked against `src/db/migrations/0012_search_layer.sql` and `src/db/schema/films.ts`.

Closes PIC-32. Supersedes #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBzmMaczXW8hGw9QbJVAPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBzmMaczXW8hGw9QbJVAPn)_