### PR TITLE
fix(scrapers): Rich Mix Spektrix v3 rewrite + Close-Up WAF hardening + dedup merge fixes

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-07-13: Rich Mix Spektrix rewrite + Close-Up WAF hardening
+**PR**: TBD | **Files**: `src/scrapers/cinemas/rich-mix-v2.ts`, `src/scrapers/cinemas/close-up.ts`, `scripts/cleanup-duplicate-films.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
+- Rich Mix scraper rewritten against the public Spektrix v3 API (old WP JSON endpoint removed in site restructure) — 81 screenings restored, times site-verified
+- Close-Up: per-page retries + far-future pages soft-fail + browser-header healthCheck (WAF burst-403s)
+- Dedup merge unique-index fix committed (was missing from #724)
+
+---
+
 ## 2026-07-13: L-CUT ingestion, 4 new venues, full scrape + data-quality pass
 **PR**: TBD | **Files**: `scripts/lcut-gapfill.ts`, `src/config/cinema-registry.ts`, `src/db/seed-cli.ts`, `scripts/cleanup-duplicate-films.ts`, `src/scrapers/utils/film-title-cleaner.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
 - New L-CUT gap-fill source: diffs lcutlondon.com's public API against our DB, inserts only missing screenings attributed to real venues (`sourceId lcut-{id}`); 222 inserted, 99.3% L-CUT parity

--- a/changelogs/2026-07-13-richmix-closeup-scraper-fixes.md
+++ b/changelogs/2026-07-13-richmix-closeup-scraper-fixes.md
@@ -1,0 +1,26 @@
+# Rich Mix Spektrix rewrite + Close-Up WAF hardening + dedup merge fix
+
+**PR**: TBD
+**Date**: 2026-07-13
+
+## Changes
+- **Rich Mix rewritten against the public Spektrix v3 API** (`src/scrapers/cinemas/rich-mix-v2.ts`):
+  the old WordPress JSON endpoint was removed in a site restructure (301 → `/cinema/`).
+  Now reads `system.spektrix.com/richmix/api/v3/events` + `/instances?startFrom=`,
+  filters film events via `attribute_COGEventProgramme === "FILM"`, uses `startUtc`
+  (`timeSource: "iso"`), captures runtime + screen, links to `/cinema/{slug}/` pages.
+  New sourceId scheme `richmix-{inst.id}` (no reconcile needed — 0 upcoming rows existed).
+  **81 screenings restored**; times verified against richmix.org.uk.
+- **Close-Up WAF hardening** (`src/scrapers/cinemas/close-up.ts`): per-page retries with
+  backoff (burst-403s are transient); only weeks 1–4 of the date-search pages are
+  load-bearing — far-future failures shorten the horizon instead of failing the run;
+  `healthCheck()` overridden to use full browser headers (UA-only GET gets 403'd).
+  Verified: 10/10 pages fetched, 29 screenings, run success.
+- **Dedup merge fix** (`scripts/cleanup-duplicate-films.ts`): unique-index-safe screening
+  move + per-cluster error isolation — was described in PR #724's changelog but the code
+  was accidentally left uncommitted.
+
+## Impact
+- Rich Mix (dark since the site restructure, not covered by L-CUT) is back on
+  pictures.london with a full programme.
+- Close-Up no longer flaps on WAF bursts; its silent-breaker/flaky signals should clear.

--- a/scripts/cleanup-duplicate-films.ts
+++ b/scripts/cleanup-duplicate-films.ts
@@ -284,59 +284,64 @@ async function mergeDuplicates(
     // whole pass (seen 2026-07-13: idx_screenings_unique violation).
     try {
     await db.transaction(async (tx) => {
-      const dupeIdsSql = sql.join(dupeIds.map(id => sql`${id}`), sql`, `);
+      // Migrate duplicates ONE AT A TIME so each pass's NOT EXISTS sees the
+      // rows the previous duplicate already moved to the primary. A single
+      // multi-id UPDATE can move two duplicates' rows into the same
+      // (primary, cinema, datetime) / (season, primary) / (user, primary)
+      // slot in one statement — the guard only checks rows that belong to
+      // the primary BEFORE the statement, so dup-vs-dup collisions in 3+-way
+      // clusters would still violate the unique index (code-review finding).
+      for (const dupeId of dupeIds) {
+        // 1. Move screenings — guard idx_screenings_unique (film_id,
+        // cinema_id, datetime): when the primary already holds the slot, the
+        // dup's row IS the same screening (scraped under both spellings with
+        // different sourceIds), so delete it instead of moving.
+        const moved = await tx.execute(sql`
+          UPDATE screenings
+          SET film_id = ${primary.id}
+          WHERE film_id = ${dupeId}
+            AND NOT EXISTS (
+              SELECT 1 FROM screenings s2
+              WHERE s2.film_id = ${primary.id}
+                AND s2.cinema_id = screenings.cinema_id
+                AND s2.datetime = screenings.datetime
+            )
+        `);
+        mergedScreenings += (moved as unknown as { count?: number }).count ?? 0;
+        await tx.execute(sql`
+          DELETE FROM screenings WHERE film_id = ${dupeId}
+        `);
 
-      // 1. Move screenings — guard idx_screenings_unique (film_id, cinema_id,
-      // datetime): when the primary already holds the same slot, the dup's
-      // row IS the same screening (scraped under both spellings with
-      // different sourceIds), so delete it instead of moving.
-      const moved = await tx.execute(sql`
-        UPDATE screenings
-        SET film_id = ${primary.id}
-        WHERE film_id IN (${dupeIdsSql})
-          AND NOT EXISTS (
-            SELECT 1 FROM screenings s2
-            WHERE s2.film_id = ${primary.id}
-              AND s2.cinema_id = screenings.cinema_id
-              AND s2.datetime = screenings.datetime
-          )
-      `);
-      mergedScreenings += (moved as unknown as { count?: number }).count ?? 0;
-      await tx.execute(sql`
-        DELETE FROM screenings WHERE film_id IN (${dupeIdsSql})
-      `);
+        // 2. Move season_films (unique on season_id + film_id)
+        await tx.execute(sql`
+          UPDATE season_films
+          SET film_id = ${primary.id}
+          WHERE film_id = ${dupeId}
+            AND NOT EXISTS (
+              SELECT 1 FROM season_films sf2
+              WHERE sf2.season_id = season_films.season_id
+                AND sf2.film_id = ${primary.id}
+            )
+        `);
+        await tx.execute(sql`
+          DELETE FROM season_films WHERE film_id = ${dupeId}
+        `);
 
-      // 2. Move season_films (handle potential unique constraint conflicts)
-      await tx.execute(sql`
-        UPDATE season_films
-        SET film_id = ${primary.id}
-        WHERE film_id IN (${dupeIdsSql})
-          AND NOT EXISTS (
-            SELECT 1 FROM season_films sf2
-            WHERE sf2.season_id = season_films.season_id
-              AND sf2.film_id = ${primary.id}
-          )
-      `);
-      // Delete any remaining season_films that would conflict
-      await tx.execute(sql`
-        DELETE FROM season_films WHERE film_id IN (${dupeIdsSql})
-      `);
-
-      // 3. Move user_film_statuses (handle unique constraint on user_id + film_id)
-      await tx.execute(sql`
-        UPDATE user_film_statuses
-        SET film_id = ${primary.id}
-        WHERE film_id IN (${dupeIdsSql})
-          AND NOT EXISTS (
-            SELECT 1 FROM user_film_statuses ufs2
-            WHERE ufs2.user_id = user_film_statuses.user_id
-              AND ufs2.film_id = ${primary.id}
-          )
-      `);
-      // Delete any remaining that would conflict (user already has a status for primary film)
-      await tx.execute(sql`
-        DELETE FROM user_film_statuses WHERE film_id IN (${dupeIdsSql})
-      `);
+        // 3. Move user_film_statuses (unique on user_id + film_id)
+        await tx.execute(sql`
+          UPDATE user_film_statuses
+          SET film_id = ${primary.id}
+          WHERE film_id = ${dupeId}
+            AND NOT EXISTS (
+              SELECT 1 FROM user_film_statuses ufs2
+              WHERE ufs2.user_id = user_film_statuses.user_id
+                AND ufs2.film_id = ${primary.id}
+            )
+        `);
+        await tx.execute(sql`
+          DELETE FROM user_film_statuses WHERE film_id = ${dupeId}
+        `);
+      }
 
       // 4. Delete duplicate film records
       await tx.delete(films).where(inArray(films.id, dupeIds));

--- a/scripts/cleanup-duplicate-films.ts
+++ b/scripts/cleanup-duplicate-films.ts
@@ -280,17 +280,33 @@ async function mergeDuplicates(
       continue;
     }
 
-    // Execute in a transaction
+    // Execute in a transaction. Wrapped so one bad cluster doesn't abort the
+    // whole pass (seen 2026-07-13: idx_screenings_unique violation).
+    try {
     await db.transaction(async (tx) => {
-      // 1. Move screenings
-      const movedScreenings = await tx
-        .update(screenings)
-        .set({ filmId: primary.id })
-        .where(inArray(screenings.filmId, dupeIds));
-      mergedScreenings += (movedScreenings as unknown as { rowCount?: number }).rowCount ?? 0;
+      const dupeIdsSql = sql.join(dupeIds.map(id => sql`${id}`), sql`, `);
+
+      // 1. Move screenings — guard idx_screenings_unique (film_id, cinema_id,
+      // datetime): when the primary already holds the same slot, the dup's
+      // row IS the same screening (scraped under both spellings with
+      // different sourceIds), so delete it instead of moving.
+      const moved = await tx.execute(sql`
+        UPDATE screenings
+        SET film_id = ${primary.id}
+        WHERE film_id IN (${dupeIdsSql})
+          AND NOT EXISTS (
+            SELECT 1 FROM screenings s2
+            WHERE s2.film_id = ${primary.id}
+              AND s2.cinema_id = screenings.cinema_id
+              AND s2.datetime = screenings.datetime
+          )
+      `);
+      mergedScreenings += (moved as unknown as { count?: number }).count ?? 0;
+      await tx.execute(sql`
+        DELETE FROM screenings WHERE film_id IN (${dupeIdsSql})
+      `);
 
       // 2. Move season_films (handle potential unique constraint conflicts)
-      const dupeIdsSql = sql.join(dupeIds.map(id => sql`${id}`), sql`, `);
       await tx.execute(sql`
         UPDATE season_films
         SET film_id = ${primary.id}
@@ -328,6 +344,9 @@ async function mergeDuplicates(
 
       console.log(`  → Merged and deleted ${dupeIds.length} duplicate(s)`);
     });
+    } catch (error) {
+      console.error(`  ✗ Cluster merge failed for "${primary.title}" — skipping:`, error);
+    }
   }
 
   return { mergedScreenings, deletedFilms };

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -55,7 +55,7 @@ Rules:
 | Electric (`cinemas/electric-v2.ts`) | `electric-portobello`, `electric-white-city` | `electric-{screeningId}` | site JSON screening key |
 | Lexi (`cinemas/lexi.ts`) | `lexi` | `lexi-{film.ID}-{perf.ID}` | Admit One API ids |
 | Regent Street (`cinemas/regent-street.ts`) | `regent-street` | `regent-street-{showing.id}` | API showing id |
-| Rich Mix (`cinemas/rich-mix-v2.ts`) | `rich-mix` | `richmix-{instanceId\|id}` | Spektrix instance id |
+| Rich Mix (`cinemas/rich-mix-v2.ts`) | `rich-mix` | `richmix-{inst.id}` | Spektrix v3 API instance id (scheme changed 2026-07-13 with the API rewrite; no reconcile needed — 0 upcoming rows existed, old WP endpoint dead since site restructure) |
 | JW3 (`cinemas/jw3.ts`) | `jw3` | `jw3-{inst.id}` | API instance id |
 | Castle (`cinemas/castle.ts` → `castle-calendar.ts`) | `castle` | `castle-{perfId}` | Jacro perf id |
 | Castle Sidcup (`cinemas/castle-sidcup.ts` → `castle-calendar.ts`) | `castle-sidcup` | `castle-sidcup-{perfId}` | Jacro perf id |
@@ -359,3 +359,22 @@ Use this format when recording cinema-specific quirks:
 - **Pitfalls**: venue names carry emoji/diacritics ("The Arzner 🏳️‍🌈", "Ciné Lumière") —
   normalized before mapping; unmapped venue names are warned loudly, never guessed.
 - **Not scheduled** in the nightly pipeline yet — manual runs while dedup accuracy bakes in.
+
+### Rich Mix — Spektrix v3 API (rewritten 2026-07-13)
+- Old WP JSON endpoint (`/whats-on/cinema/?ajax=1&json=1`) removed in a site restructure
+  (301 → `/cinema/`, params dropped). Scraper now reads the public Spektrix API:
+  `https://system.spektrix.com/richmix/api/v3/events` + `/instances?startFrom=YYYY-MM-DD`.
+- Film events: `attribute_COGEventProgramme === "FILM"` (venue also hosts music/theatre).
+- `startUtc` omits the trailing `Z` — append before `new Date()`. `timeSource: "iso"`.
+- Booking URL: `/cinema/{slugified event name incl. rating}/` (e.g. `toy-story-5-pg/`);
+  trailing slash avoids a 301. `attribute_VENUE` = screen. `duration` = runtime.
+- healthCheck hits the Spektrix events endpoint (the real dependency), not the WP site.
+
+### Close-Up — WAF burst-403s (hardened 2026-07-13)
+- The WAF intermittently 403s bursts of `/search_film_programmes/?date=` requests, then
+  serves the same URLs fine minutes later. Scraper now retries each page (3 attempts,
+  linear backoff) and only weeks 1–4 are load-bearing: far-future page failures shorten
+  the horizon with a warning instead of failing the run (homepage embedded `var shows`
+  JSON covers the current programme regardless).
+- `healthCheck()` overridden to reuse `fetchUrl`'s full browser headers — the BaseScraper
+  UA-only GET gets 403'd even when the real scrape works (known false-negative class).

--- a/src/scrapers/cinemas/bst-regression.test.ts
+++ b/src/scrapers/cinemas/bst-regression.test.ts
@@ -15,6 +15,15 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// Rich Mix v2's parsePages preloads the festival cache (DB hit) — mock it so
+// the Spektrix parsing test below runs without a database.
+vi.mock("../festivals/festival-detector", () => ({
+  FestivalDetector: {
+    preload: vi.fn().mockResolvedValue(undefined),
+    detect: vi.fn().mockReturnValue({}),
+  },
+}));
+
 import { RichMixScraper } from "./rich-mix";
 import { RichMixScraperV2 } from "./rich-mix-v2";
 import { BFIScraper } from "./bfi";
@@ -57,17 +66,37 @@ describe("BST regression: Rich Mix parseDateTime", () => {
   });
 });
 
-describe("BST regression: Rich Mix v2 parseDateTime", () => {
-  const scraper = new RichMixScraperV2() as unknown as PrivDate;
+describe("BST regression: Rich Mix v2 (Spektrix startUtc)", () => {
+  // The 2026-07-13 Spektrix rewrite removed local-time parsing entirely —
+  // instances carry startUtc, so no BST conversion happens in the scraper.
+  // Pin the Z-append behaviour instead (Spektrix omits the trailing Z):
+  // a BST-season UTC timestamp must be stored verbatim, not shifted.
+  const scraper = new RichMixScraperV2() as unknown as {
+    parsePages(pages: string[]): Promise<Array<{ datetime: Date; filmTitle: string }>>;
+  };
 
-  it("BST: 2026-05-26 18:10:00 UK local → 17:10 UTC", () => {
-    expect(scraper.parseDateTime("2026-05-26 18:10:00")?.toISOString())
-      .toBe("2026-05-26T17:10:00.000Z");
-  });
-
-  it("GMT: 2026-01-15 18:10:00 UK local → 18:10 UTC (no offset)", () => {
-    expect(scraper.parseDateTime("2026-01-15 18:10:00")?.toISOString())
-      .toBe("2026-01-15T18:10:00.000Z");
+  it("parses Spektrix startUtc (no trailing Z) as UTC, not local time", async () => {
+    const events = JSON.stringify([
+      {
+        id: "ev1",
+        name: "Test Film (15)",
+        duration: 100,
+        isOnSale: true,
+        attribute_COGEventProgramme: "FILM",
+      },
+    ]);
+    const instances = JSON.stringify([
+      {
+        id: "in1",
+        startUtc: "2027-05-26T17:10:00", // BST-season date; must stay 17:10 UTC
+        cancelled: false,
+        event: { id: "ev1" },
+      },
+    ]);
+    const screenings = await scraper.parsePages([events, instances]);
+    expect(screenings).toHaveLength(1);
+    expect(screenings[0].datetime.toISOString()).toBe("2027-05-26T17:10:00.000Z");
+    expect(screenings[0].filmTitle).toBe("Test Film");
   });
 });
 

--- a/src/scrapers/cinemas/close-up.ts
+++ b/src/scrapers/cinemas/close-up.ts
@@ -54,14 +54,41 @@ export class CloseUpCinemaScraper extends BaseScraper {
     delayBetweenRequests: 1000,
   };
 
+  /**
+   * The site's WAF intermittently 403s bursts of requests (2026-07-13: 2/10
+   * search pages failed mid-run, then returned 200 minutes later with the
+   * same headers). Each page gets retries with backoff; only near-term weeks
+   * are load-bearing — far-future failures degrade coverage, not correctness,
+   * and the homepage's embedded shows JSON already covers the current
+   * programme. See SCRAPING_PLAYBOOK.md.
+   */
+  private static readonly REQUIRED_WEEKS = 4;
+
+  private async fetchWithRetry(url: string, attempts = 3, backoffMs = 5_000): Promise<string> {
+    let lastError: unknown;
+    for (let i = 1; i <= attempts; i++) {
+      try {
+        return await this.fetchUrl(url);
+      } catch (error) {
+        lastError = error;
+        if (i < attempts) {
+          console.warn(`[${this.config.cinemaId}] Attempt ${i}/${attempts} failed for ${url} — backing off ${backoffMs * i}ms`);
+          await this.delay(backoffMs * i);
+        }
+      }
+    }
+    throw lastError;
+  }
+
   protected async fetchPages(): Promise<string[]> {
     const pages: string[] = [];
-    const failures: string[] = [];
+    const requiredFailures: string[] = [];
+    const optionalFailures: string[] = [];
 
     // Fetch the homepage first (has JSON data + immediate screenings)
     const homepageUrl = this.config.baseUrl;
     console.log(`[${this.config.cinemaId}] Fetching homepage: ${homepageUrl}`);
-    const homepage = await this.fetchUrl(homepageUrl);
+    const homepage = await this.fetchWithRetry(homepageUrl);
     pages.push(homepage);
 
     // Fetch future weeks using the date search endpoint
@@ -81,21 +108,48 @@ export class CloseUpCinemaScraper extends BaseScraper {
       console.log(`[${this.config.cinemaId}] Fetching week ${week}: ${dateUrl}`);
 
       try {
-        const html = await this.fetchUrl(dateUrl);
+        const html = await this.fetchWithRetry(dateUrl);
         pages.push(html);
-        // Respect rate limiting
         await this.delay(this.config.delayBetweenRequests);
       } catch (error) {
         console.warn(`[${this.config.cinemaId}] Failed to fetch ${dateUrl}:`, error);
-        failures.push(dateUrl);
+        if (week <= CloseUpCinemaScraper.REQUIRED_WEEKS) {
+          requiredFailures.push(dateUrl);
+        } else {
+          optionalFailures.push(dateUrl);
+        }
       }
     }
 
-    if (failures.length > 0) {
-      throw new Error(`Failed to fetch ${failures.length}/${weeksToFetch} Close-Up search pages`);
+    // Near-term pages are required — partial near-term coverage must not be
+    // persisted as a successful run (playbook rule). Far-future pages only
+    // shorten the horizon; the weekly cadence catches those dates next run.
+    if (requiredFailures.length > 0) {
+      throw new Error(
+        `Failed to fetch ${requiredFailures.length} near-term Close-Up search pages (weeks 1-${CloseUpCinemaScraper.REQUIRED_WEEKS})`,
+      );
+    }
+    if (optionalFailures.length > 0) {
+      console.warn(
+        `[${this.config.cinemaId}] ${optionalFailures.length} far-future search pages failed after retries — horizon shortened this run`,
+      );
     }
 
     return pages;
+  }
+
+  /**
+   * BaseScraper.healthCheck sends a UA-only GET, which this WAF 403s even
+   * when the real scrape succeeds (known false-negative pattern — same class
+   * as the 2026-05-27 incident). Reuse fetchUrl's full browser headers.
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.fetchWithRetry(this.config.baseUrl, 3, 4_000);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   protected async parsePages(htmlPages: string[]): Promise<RawScreening[]> {

--- a/src/scrapers/cinemas/rich-mix-v2.ts
+++ b/src/scrapers/cinemas/rich-mix-v2.ts
@@ -1,51 +1,45 @@
 /**
- * Rich Mix Cinema Scraper (v2 - extends BaseScraper)
+ * Rich Mix Cinema Scraper (v3 - Spektrix public API)
  *
  * Cinema: Rich Mix (Shoreditch)
  * Address: 35-47 Bethnal Green Rd, London E1 6LA
  * Website: https://richmix.org.uk
- *
- * Uses WordPress JSON API at ?ajax=1&json=1
- * Ticketing: Spektrix (tickets.richmix.org.uk)
  * 3 screens: Screen 1 (181 seats), Screen 2 (132 seats), Screen 3 (59 seats)
+ *
+ * 2026-07-13 rewrite: the old WordPress JSON endpoint
+ * (/whats-on/cinema/?ajax=1&json=1) was removed in a site restructure —
+ * /whats-on/cinema/ now 301s to /cinema/ and returns HTML. We now read the
+ * venue's public Spektrix v3 API directly:
+ *   https://system.spektrix.com/richmix/api/v3/events      (film metadata)
+ *   https://system.spektrix.com/richmix/api/v3/instances?startFrom=YYYY-MM-DD
+ * Film events are identified by attribute_COGEventProgramme === "FILM".
+ * Instance `startUtc` is authoritative (timeSource: "iso").
  */
 
 import { BaseScraper } from "../base";
 import type { RawScreening, ScraperConfig } from "../types";
 import { FestivalDetector } from "../festivals/festival-detector";
-import { ukLocalToUTC } from "../utils/date-parser";
 
-// API response types
+interface SpektrixEvent {
+  id: string;
+  name: string;
+  duration?: number;
+  isOnSale: boolean;
+  imageUrl?: string;
+  attribute_COGEventProgramme?: string;
+  attribute_VENUE?: string;
+}
+
 interface SpektrixInstance {
   id: string;
-  start: string; // "2025-12-30 14:30:00" (local time)
-  startUtc: string;
-  eventId: string;
-  instanceId: string;
-  onSale: string;
-  status?: {
-    name?: string;
-    available?: number;
-    capacity?: number;
-  };
-  time?: string;
-  date?: string;
-  cancelled?: string;
+  startUtc: string; // ISO UTC, e.g. "2026-07-14T09:00:00" (Z implied)
+  cancelled?: boolean;
+  isOnSale?: boolean;
+  event: { id: string };
+  attribute_MembersOnlyScreening?: boolean;
 }
 
-interface SpektrixInstances {
-  [dateKey: string]: SpektrixInstance[];
-}
-
-interface RichMixFilm {
-  id: number;
-  post_title: string;
-  slug: string;
-  _spectrix_id?: string;
-  spektrix_data?: {
-    instances?: SpektrixInstances;
-  };
-}
+const SPEKTRIX_BASE = "https://system.spektrix.com/richmix/api/v3";
 
 export class RichMixScraperV2 extends BaseScraper {
   config: ScraperConfig = {
@@ -55,95 +49,102 @@ export class RichMixScraperV2 extends BaseScraper {
     delayBetweenRequests: 500,
   };
 
-  private apiUrl = "https://richmix.org.uk/whats-on/cinema/?ajax=1&json=1";
-
   protected async fetchPages(): Promise<string[]> {
-    console.log("[rich-mix] Fetching JSON API...");
-    const json = await this.fetchUrl(this.apiUrl);
-    return [json];
+    console.log("[rich-mix] Fetching Spektrix events + instances...");
+    const events = await this.fetchUrl(`${SPEKTRIX_BASE}/events`);
+    await this.delay(this.config.delayBetweenRequests);
+    const startFrom = new Date().toISOString().slice(0, 10);
+    const instances = await this.fetchUrl(
+      `${SPEKTRIX_BASE}/instances?startFrom=${startFrom}`,
+    );
+    return [events, instances];
   }
 
   protected async parsePages(jsonPages: string[]): Promise<RawScreening[]> {
     await FestivalDetector.preload();
-    const films: RichMixFilm[] = JSON.parse(jsonPages[0]);
-    console.log(`[rich-mix] Found ${films.length} films`);
+    const events: SpektrixEvent[] = JSON.parse(jsonPages[0]);
+    const instances: SpektrixInstance[] = JSON.parse(jsonPages[1]);
 
+    const filmEvents = new Map<string, SpektrixEvent>();
+    for (const e of events) {
+      if (e.attribute_COGEventProgramme === "FILM") filmEvents.set(e.id, e);
+    }
+    console.log(
+      `[rich-mix] ${events.length} events (${filmEvents.size} film), ${instances.length} future instances`,
+    );
+
+    const now = new Date();
     const screenings: RawScreening[] = [];
     const seenIds = new Set<string>();
 
-    for (const film of films) {
-      const instances = film.spektrix_data?.instances;
-      if (!instances) continue;
+    for (const inst of instances) {
+      if (inst.cancelled) continue;
+      const event = filmEvents.get(inst.event?.id);
+      if (!event) continue; // music/theatre/comedy instance
 
-      // Process all date keys
-      for (const dateKey of Object.keys(instances)) {
-        const dateInstances = instances[dateKey];
-        if (!Array.isArray(dateInstances)) continue;
+      // Spektrix omits the Z on startUtc — append if missing
+      const iso = inst.startUtc.endsWith("Z") ? inst.startUtc : `${inst.startUtc}Z`;
+      const datetime = new Date(iso);
+      if (isNaN(datetime.getTime()) || datetime < now) continue;
 
-        for (const instance of dateInstances) {
-          // Skip cancelled screenings
-          if (instance.cancelled === "1") continue;
+      const sourceId = `richmix-${inst.id}`;
+      if (seenIds.has(sourceId)) continue;
+      seenIds.add(sourceId);
 
-          // Skip if not on sale
-          if (instance.onSale !== "1") continue;
+      const title = this.cleanEventName(event.name);
+      const bookingUrl = `${this.config.baseUrl}/cinema/${this.slugifyEventName(event.name)}/`;
 
-          // Create unique ID
-          const sourceId = `richmix-${instance.instanceId || instance.id}`;
-          if (seenIds.has(sourceId)) continue;
-          seenIds.add(sourceId);
-
-          // Parse datetime - format is "2025-12-30 14:30:00" (local time)
-          const datetime = this.parseDateTime(instance.start);
-          if (!datetime) {
-            console.warn(`[rich-mix] Failed to parse datetime: ${instance.start}`);
-            continue;
-          }
-
-          // Build booking URL
-          const bookingUrl = `${this.config.baseUrl}/whats-on/cinema/${film.slug}/`;
-
-          screenings.push({
-            filmTitle: film.post_title,
-            datetime,
-            bookingUrl,
-            sourceId,
-            ...FestivalDetector.detect("rich-mix", film.post_title, datetime, bookingUrl),
-          });
-        }
-      }
+      screenings.push({
+        filmTitle: title,
+        datetime,
+        bookingUrl,
+        sourceId,
+        runtime: event.duration && event.duration > 0 ? event.duration : undefined,
+        screen: event.attribute_VENUE || undefined,
+        timeSource: "iso",
+        ...FestivalDetector.detect("rich-mix", title, datetime, bookingUrl),
+      });
     }
 
+    console.log(`[rich-mix] ${screenings.length} film screenings`);
     return screenings;
   }
 
-  /**
-   * Parse datetime string in format "2025-12-30 14:30:00" (UK local time).
-   *
-   * Goes through `ukLocalToUTC` so BST is applied explicitly — the previous
-   * `new Date(y,m,d,h,mi)` constructor depended on the runtime's local TZ,
-   * which silently stored BST clock-face times as UTC on the UTC server
-   * (rendering 1h ahead of reality to users).
-   */
-  private parseDateTime(dateStr: string): Date | null {
-    if (!dateStr) return null;
-
-    const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/);
-    if (!match) return null;
-
-    const [, year, month, day, hour, minute] = match;
-
-    return ukLocalToUTC(
-      parseInt(year, 10),
-      parseInt(month, 10) - 1,
-      parseInt(day, 10),
-      parseInt(hour, 10),
-      parseInt(minute, 10),
-    );
+  /** "The Odyssey (12A)" → "The Odyssey" — strip trailing BBFC rating. */
+  private cleanEventName(name: string): string {
+    return name
+      .trim()
+      .replace(/\s*\((U|PG|12A?|15|18|R18|TBC|CTBA)\*?\)\s*$/i, "")
+      .trim();
   }
 
+  /**
+   * "The Odyssey (12A)" → "the-odyssey-12a" — the site's /cinema/{slug} pages
+   * slugify the full event name INCLUDING the rating (verified 2026-07-13:
+   * richmix.org.uk/cinema/toy-story-5-pg, /cinema/the-invite-18).
+   */
+  private slugifyEventName(name: string): string {
+    return name
+      .trim()
+      .toLowerCase()
+      .normalize("NFKD")
+      .replace(/[̀-ͯ]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+
+  /** The Spektrix API is the real dependency — health-check it, not the WP site. */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const body = await this.fetchUrl(`${SPEKTRIX_BASE}/events`);
+      return Array.isArray(JSON.parse(body));
+    } catch {
+      return false;
+    }
+  }
 }
 
-/** Creates a Rich Mix Cinema scraper (Cheerio-based, extends BaseScraper). */
+/** Creates a Rich Mix Cinema scraper (Spektrix API, extends BaseScraper). */
 export function createRichMixScraperV2(): RichMixScraperV2 {
   return new RichMixScraperV2();
 }


### PR DESCRIPTION
## Summary
Fixes the 2 scraper failures from today's full scrape (#724 follow-up), plus completes the dedup merge fix.

- **Rich Mix** (`rich-mix-v2.ts`): the old WordPress JSON endpoint was removed in a site restructure (301 → `/cinema/`). Rewritten against the public Spektrix v3 API (`events` + `instances?startFrom=`), filtering film events via `attribute_COGEventProgramme === \"FILM\"`; `startUtc` with `timeSource: \"iso\"`; runtime + screen captured; booking links to the site's `/cinema/{slug}/` pages (trailing slash, verified 200). New sourceId scheme `richmix-{inst.id}` — no reconcile needed (0 upcoming rows existed). **Verified live: 81 screenings, times match richmix.org.uk.**
- **Close-Up** (`close-up.ts`): WAF burst-403s are transient (same URLs 200 minutes later). Per-page retries with backoff; weeks 1–4 of the date-search pages remain load-bearing (throw), far-future pages soft-fail with a warning (horizon shortens, weekly cadence catches up); `healthCheck()` uses full browser headers (UA-only GET is 403'd even when the scrape works). **Verified live: 10/10 pages, 29 screenings, run success.**
- **Dedup merge** (`cleanup-duplicate-films.ts`): unique-index-safe move + per-cluster error isolation (was described in #724's changelog but accidentally left uncommitted), hardened per second code review to migrate duplicates one at a time — dup-vs-dup collisions in 3+-way clusters no longer abort the cluster.

## Review
Code-reviewer agent run twice; its critical finding (multi-way cluster dup-vs-dup collisions) is fixed in the final commit. Dry-run verified post-fix.

## Test plan
- Live scrape runs for both venues (results above)
- `cleanup-duplicate-films.ts` dry run clean
- Local vitest/tsc wedge on this machine — CI is the gate (eslint: 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)