### PR TITLE
fix(regent-street): direct INDY GraphQL fetch via shared platform adapter (Phase 2a, PR 1)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-07-14: INDY GraphQL adapter — Regent Street direct-fetch migration (Coverage Phase 2a, PR 1)
+**PR**: TBD | **Files**: `src/scrapers/platforms/indy.ts` (new), `src/scrapers/platforms/indy.test.ts` (new), `src/scrapers/cinemas/regent-street.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
+- New shared **INDY Systems GraphQL client** (`platforms/indy.ts`): direct `fetch()` POST to `{venue}/graphql` with `circuit-id`/`site-id` headers — no browser, no auth token. Loops dates today…+35, filters `published && !past && !private && !isPreview`, dedupes by id, throws on HTTP/GraphQL error (never empty-success).
+- **Regent Street migrated** off Playwright response-interception (fragile 20s/3s timers — the P0) to the direct client. sourceId **preserved** (`regent-street-{id}` → no reconcile); booking URL upgraded to `/checkout/showing/{id}`; `timeSource:"iso"`; runtime + year now captured.
+- Live-verified: 25 screenings / 14-day horizon, 0 sub-09:00 times, healthCheck green. Fixture test covers mapping + all filters + throw-on-error.
+- Corrects the record: **Phoenix is NOT on INDY** (it's an ASP.NET `.dll` system) — out of the INDY adapter's scope. Sets up Chiswick (PR 2, same platform, ids 56/170).
+
+---
+
 ## 2026-07-14: Schedule L-CUT gap-fill + scraper-regression parity monitor (Coverage Phase 1)
 **PR**: #726 | **Files**: `scripts/lcut-gapfill.ts`, `scripts/lcut-gapfill.test.ts`, `src/scrapers/registry.ts`, `src/scripts/run-scrape-and-enrich.ts`, `package.json`, `src/scrapers/SCRAPING_PLAYBOOK.md`, `.claude/commands/scrape.md`
 - L-CUT gap-fill is now a phase ("1b") of the weekly `/scrape` orchestrator — runs after the scrape wave (parity vs fresh data) and before cleanup (inserted rows get enriched). There is no cron in this repo by policy; `/scrape` IS the weekly cadence.

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-07-14: INDY GraphQL adapter — Regent Street direct-fetch migration (Coverage Phase 2a, PR 1)
-**PR**: TBD | **Files**: `src/scrapers/platforms/indy.ts` (new), `src/scrapers/platforms/indy.test.ts` (new), `src/scrapers/cinemas/regent-street.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
+**PR**: #727 | **Files**: `src/scrapers/platforms/indy.ts` (new), `src/scrapers/platforms/indy.test.ts` (new), `src/scrapers/cinemas/regent-street.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
 - New shared **INDY Systems GraphQL client** (`platforms/indy.ts`): direct `fetch()` POST to `{venue}/graphql` with `circuit-id`/`site-id` headers — no browser, no auth token. Loops dates today…+35, filters `published && !past && !private && !isPreview`, dedupes by id, throws on HTTP/GraphQL error (never empty-success).
 - **Regent Street migrated** off Playwright response-interception (fragile 20s/3s timers — the P0) to the direct client. sourceId **preserved** (`regent-street-{id}` → no reconcile); booking URL upgraded to `/checkout/showing/{id}`; `timeSource:"iso"`; runtime + year now captured.
 - Live-verified: 25 screenings / 14-day horizon, 0 sub-09:00 times, healthCheck green. Fixture test covers mapping + all filters + throw-on-error.

--- a/changelogs/2026-07-14-indy-adapter-regent-street.md
+++ b/changelogs/2026-07-14-indy-adapter-regent-street.md
@@ -1,6 +1,6 @@
 # INDY GraphQL adapter — Regent Street direct-fetch migration (Coverage Phase 2a, PR 1)
 
-**PR**: TBD
+**PR**: #727
 **Date**: 2026-07-14
 **Plan**: `docs/plans/2026-07-13-coverage-implementation-plan.md` (Phase 2a)
 

--- a/changelogs/2026-07-14-indy-adapter-regent-street.md
+++ b/changelogs/2026-07-14-indy-adapter-regent-street.md
@@ -1,0 +1,72 @@
+# INDY GraphQL adapter — Regent Street direct-fetch migration (Coverage Phase 2a, PR 1)
+
+**PR**: TBD
+**Date**: 2026-07-14
+**Plan**: `docs/plans/2026-07-13-coverage-implementation-plan.md` (Phase 2a)
+
+## Summary
+
+Extract a shared INDY Systems GraphQL client and migrate Regent Street Cinema onto it,
+replacing fragile Playwright response-interception with a deterministic direct `fetch()`.
+This is the first of two Phase 2a PRs (PR 2 adds The Chiswick Cinema on the same adapter).
+
+## Research finding that reshaped Phase 2a
+
+The handoff plan grouped Regent Street **and Phoenix** under the INDY adapter (following a
+stale comment in `regent-street.ts`: "Same platform as Phoenix Cinema"). Live investigation
+disproved this:
+
+- **INDY `/graphql` is open and directly callable** — a plain POST with `circuit-id` /
+  `site-id` headers returns showings; no auth token, cookie, or CSRF. Proven end-to-end with
+  curl for Regent Street (19/85) and Chiswick (56/170). So Playwright is removed entirely,
+  not worked around.
+- **Phoenix is NOT on INDY** — `phoenixcinema.co.uk/graphql` 302s; it's an ASP.NET `.dll`
+  system (`PhoenixCinemaLondon.dll`). Phoenix is therefore **out of the INDY adapter's
+  scope**; its DOM-heuristic P0 is a separate assessment (alongside the `.dll`/Savoy work).
+
+So Phase 2a narrows to: Regent Street migration (this PR) → Chiswick (next PR).
+
+## Changes
+
+### `src/scrapers/platforms/indy.ts` (new)
+- `fetchIndyShowings(venue, opts)`: loops dates today…+N (35-day default), POSTs
+  `showingsForDate(date, siteIds)`, dedupes by showing id, keeps only
+  `published && !past && !private && !isPreview` future showings, maps to `RawScreening`.
+- `checkIndyHealth(venue)`: a today `showingsForDate` POST against the real dependency.
+- `postShowingsForDate` retries (3×) then **throws** on HTTP / GraphQL / INDY error — never
+  swallowed as empty success (playbook failure semantics).
+- Injectable `fetchImpl` / `now` / `days` / `attempts` seams → fully unit-testable, no
+  browser or network.
+
+### `src/scrapers/cinemas/regent-street.ts`
+- Deleted the Playwright launch + `page.on("response")` interception + 20s/3s timer promise.
+- Now a thin `CinemaScraper` delegating to `fetchIndyShowings(REGENT_STREET_VENUE)` and
+  `checkIndyHealth`. Removed the stale "same platform as Phoenix" comment.
+- **sourceId unchanged** (`regent-street-{showing.id}`) — no reconcile needed. Booking URL
+  upgraded from `/movie/{slug}` to the `/checkout/showing/{id}` deep-link;
+  `timeSource:"iso"`; runtime + year now populated from the payload.
+
+### `src/scrapers/platforms/indy.test.ts` (new)
+- Fixture test off the real captured payload: mapping (sourceId / booking / iso / runtime /
+  year), dedup, and every filter (past / unpublished / private / preview / before-now); plus
+  throw-on-INDY-error and throw-on-non-ok-HTTP.
+
+### `SCRAPING_PLAYBOOK.md`
+- New "INDY Systems platform" section (endpoint, headers, query, mapping, failure semantics,
+  known venue ids, the Phoenix-is-not-INDY correction).
+
+## Verification
+
+- Fixture smoke (tsx, DB-free): 7/7.
+- **Live**: `fetchIndyShowings` against the real Regent Street endpoint — healthCheck green,
+  25 screenings / 14-day horizon, 6 distinct films, 0 sub-09:00-London times, sensible date
+  range, sourceIds/booking URLs correct.
+- eslint clean; `tsc --noEmit` clean; CI is the authoritative gate for the unit tests
+  (local vitest worker pool wedges on this machine).
+
+## Impact
+
+- Regent Street coverage is now deterministic and browser-free — no more 20s/3s timing races
+  that could silently under-capture. Faster, more complete (explicit 35-day date loop).
+- No sourceId change → existing rows update in place (booking URL improves; no duplicates).
+- Reusable `platforms/indy.ts` unblocks Chiswick (PR 2) and any future INDY venue.

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -389,3 +389,26 @@ Use this format when recording cinema-specific quirks:
   JSON covers the current programme regardless).
 - `healthCheck()` overridden to reuse `fetchUrl`'s full browser headers — the BaseScraper
   UA-only GET gets 403'd even when the real scrape works (known false-negative class).
+
+### INDY Systems platform (`src/scrapers/platforms/indy.ts`, 2026-07-14)
+- **What**: INDY Cinema Group booking platform ("powered by Fandango"). Shared GraphQL
+  client used by multiple London venues. Each venue proxies `/graphql` on its OWN domain.
+- **Direct fetch, no browser**: the endpoint is OPEN — a plain `POST /graphql` with two
+  identifying headers returns showings. No auth token / cookie / CSRF. This replaced the old
+  Regent Street Playwright response-interception (which waited on fragile 20s/3s timers).
+- **Required headers**: `circuit-id`, `site-id` (both mandatory — either alone → `{"error":
+  {"message":"Site not found. (Code: 104)"}}`), plus `client-type: consumer` and
+  `accept: application/graphql-response+json,application/json;q=0.9`.
+- **Query**: `showingsForDate(date: "YYYY-MM-DD", siteIds: [<siteId>])` → `data[]` of
+  `{ id, time (ISO UTC "…Z"), published, past, private, isPreview, screenId, movie{ id, name,
+  urlSlug, duration, rating, releaseDate } }`. Loop dates today…+N (35-day default).
+- **Map**: filmTitle=`movie.name`; datetime=`new Date(time)` (`timeSource:"iso"` — true UTC,
+  no BST mislabel); runtime=`movie.duration`; year=`movie.releaseDate` year;
+  bookingUrl=`{baseUrl}/checkout/showing/{id}`; **sourceId=`{cinemaId}-{showing.id}`**.
+  Keep only `published && !past && !private && !isPreview` future showings; dedupe by id.
+- **Failure semantics**: `postShowingsForDate` retries (3×) then THROWS on HTTP/GraphQL/INDY
+  error — never swallowed as empty success.
+- **Known venues** (`circuit-id`/`site-id`): Regent Street 19/85, Chiswick 56/170. Discover a
+  new venue's ids from the `circuit-id`/`site-id` headers on any `/graphql` request it makes.
+- **NOT INDY**: Phoenix Cinema (East Finchley) is an ASP.NET `.dll` system
+  (`PhoenixCinemaLondon.dll`), despite an old comment claiming otherwise — see cinemas/phoenix.ts.

--- a/src/scrapers/cinemas/regent-street.ts
+++ b/src/scrapers/cinemas/regent-street.ts
@@ -5,162 +5,55 @@
  * Address: 307 Regent Street, London W1B 2HW
  * Website: https://www.regentstreetcinema.com
  *
- * "Birthplace of British cinema" - first cinema screening in 1896
- * Only UK cinema with 16mm/35mm/Super8/4K projection
+ * "Birthplace of British cinema" - first cinema screening in 1896.
+ * Only UK cinema with 16mm/35mm/Super8/4K projection.
  *
- * Uses INDY Systems GraphQL API at /graphql
- * Same platform as Phoenix Cinema
- * Captures data by intercepting GraphQL responses from the page
+ * On the INDY Systems platform — scraped via a DIRECT GraphQL fetch through the
+ * shared client in ../platforms/indy.ts (no browser). This replaced the old
+ * Playwright response-interception that waited on fragile 20s/3s timers.
+ * sourceId scheme unchanged: `regent-street-{showing.id}`.
  */
 
-import { chromium } from "rebrowser-playwright";
-
-import { BOT_USER_AGENT } from "../constants";
-import { checkHealth } from "../utils/health-check";
+import {
+  fetchIndyShowings,
+  checkIndyHealth,
+  type IndyVenue,
+} from "../platforms/indy";
 import type { RawScreening, ScraperConfig, CinemaScraper } from "../types";
 
-const REGENT_STREET_CONFIG: ScraperConfig & { programmeUrl: string } = {
+const REGENT_STREET_VENUE: IndyVenue = {
   cinemaId: "regent-street",
   baseUrl: "https://www.regentstreetcinema.com",
-  programmeUrl: "https://www.regentstreetcinema.com/programme/",
-  requestsPerMinute: 10,
-  delayBetweenRequests: 1500,
+  circuitId: "19",
+  siteId: "85",
 };
 
-// GraphQL response types
-interface RegentStreetMovie {
-  id: string;
-  name: string;
-  abbreviation: string;
-  showingStatus: string;
-  urlSlug?: string;
-}
-
-interface RegentStreetShowing {
-  id: string;
-  time: string; // ISO UTC datetime "2025-12-30T18:30:00Z"
-  published: boolean;
-  past: boolean;
-  screenId: string;
-  movie: RegentStreetMovie;
-}
+const REGENT_STREET_CONFIG: ScraperConfig = {
+  cinemaId: REGENT_STREET_VENUE.cinemaId,
+  baseUrl: REGENT_STREET_VENUE.baseUrl,
+  // Decorative for INDY: the per-date request pacing lives inside
+  // fetchIndyShowings (DEFAULT_REQUEST_DELAY_MS); these are not consumed by the
+  // single-call scrape() path, kept only to satisfy ScraperConfig.
+  requestsPerMinute: 20,
+  delayBetweenRequests: 250,
+};
 
 export class RegentStreetScraper implements CinemaScraper {
   config = REGENT_STREET_CONFIG;
 
   async scrape(): Promise<RawScreening[]> {
-    console.log(`[${this.config.cinemaId}] Starting Regent Street Cinema scrape...`);
-
-    const browser = await chromium.launch({ headless: true });
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    const allShowings: RegentStreetShowing[] = [];
-
-    // Track when showings are captured
-    let showingsPromiseResolve: () => void;
-    let showingsCaptured = false;
-    const showingsPromise = new Promise<void>((resolve) => {
-      showingsPromiseResolve = resolve;
-      // Timeout after 20 seconds
-      setTimeout(() => {
-        if (!showingsCaptured) {
-          console.log(`[${this.config.cinemaId}] Showings timeout - proceeding with ${allShowings.length} showings`);
-          resolve();
-        }
-      }, 20000);
-    });
-
-    // Intercept GraphQL responses
-    page.on("response", async (response) => {
-      if (response.url().includes("/graphql")) {
-        try {
-          const text = await response.text();
-          const json = JSON.parse(text);
-
-          // Capture showingsForDate
-          if (json?.data?.showingsForDate?.data) {
-            const showings = json.data.showingsForDate.data as RegentStreetShowing[];
-            allShowings.push(...showings);
-            console.log(`[${this.config.cinemaId}] Captured ${showings.length} showings (total: ${allShowings.length})`);
-
-            // Mark as captured after we have some showings
-            if (!showingsCaptured && allShowings.length > 0) {
-              // Wait a bit more for additional date batches
-              setTimeout(() => {
-                if (!showingsCaptured) {
-                  showingsCaptured = true;
-                  showingsPromiseResolve();
-                }
-              }, 3000);
-            }
-          }
-        } catch {
-          // Not JSON or parse error - ignore
-        }
-      }
-    });
-
-    try {
-      // Visit the programme page
-      console.log(`[${this.config.cinemaId}] Loading programme page...`);
-      await page.goto(this.config.programmeUrl, { waitUntil: "networkidle", timeout: 60000 });
-
-      // Wait for showings to be captured
-      console.log(`[${this.config.cinemaId}] Waiting for showings data...`);
-      await showingsPromise;
-      console.log(`[${this.config.cinemaId}] Showings captured: ${allShowings.length}`);
-
-      const screenings = this.convertShowings(allShowings);
-      console.log(`[${this.config.cinemaId}] Found ${screenings.length} screenings total`);
-      return screenings;
-    } finally {
-      await browser.close();
-    }
-  }
-
-  /**
-   * Convert captured GraphQL showings into RawScreening format.
-   * Deduplicates by ID and filters out unpublished/past showings.
-   */
-  private convertShowings(allShowings: RegentStreetShowing[]): RawScreening[] {
-    const screenings: RawScreening[] = [];
-    const now = new Date();
-    const seenIds = new Set<string>();
-
-    for (const showing of allShowings) {
-      if (seenIds.has(showing.id)) continue;
-      seenIds.add(showing.id);
-
-      if (!showing.published) continue;
-      if (showing.past) continue;
-
-      const datetime = new Date(showing.time);
-      if (isNaN(datetime.getTime())) continue;
-      if (datetime < now) continue;
-
-      const movieSlug = showing.movie.urlSlug || showing.movie.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-      const bookingUrl = `${this.config.baseUrl}/movie/${movieSlug}`;
-
-      screenings.push({
-        filmTitle: showing.movie.name,
-        datetime,
-        bookingUrl,
-        sourceId: `regent-street-${showing.id}`,
-      });
-    }
-
+    console.log(`[${this.config.cinemaId}] Scraping via INDY GraphQL (direct fetch)...`);
+    const screenings = await fetchIndyShowings(REGENT_STREET_VENUE);
+    console.log(`[${this.config.cinemaId}] Found ${screenings.length} screenings`);
     return screenings;
   }
 
   async healthCheck(): Promise<boolean> {
-    return checkHealth(this.config.baseUrl, {
-      headers: { "User-Agent": BOT_USER_AGENT },
-    });
+    return checkIndyHealth(REGENT_STREET_VENUE);
   }
 }
 
-/** Creates a Regent Street Cinema scraper (Playwright-based, implements CinemaScraper). */
+/** Creates a Regent Street Cinema scraper (INDY direct-fetch, implements CinemaScraper). */
 export function createRegentStreetScraper(): RegentStreetScraper {
   return new RegentStreetScraper();
 }

--- a/src/scrapers/platforms/indy.test.ts
+++ b/src/scrapers/platforms/indy.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { fetchIndyShowings, checkIndyHealth, type IndyVenue, type IndyFetch } from "./indy";
+
+const VENUE: IndyVenue = {
+  cinemaId: "regent-street",
+  baseUrl: "https://www.regentstreetcinema.com",
+  circuitId: "19",
+  siteId: "85",
+};
+
+// Reference "now": 09:00 UTC on the fixture date, so 11:15/15:00/18:45 are
+// future and 08:00 is past.
+const NOW = new Date("2026-07-18T09:00:00Z");
+
+const movie = {
+  id: "33278",
+  name: "The Odyssey",
+  urlSlug: "the-odyssey",
+  duration: 173,
+  rating: "15",
+  releaseDate: "2026-07-17",
+};
+
+// Real captured payload (regentstreetcinema.com/graphql, siteIds:[85]) plus
+// synthetic edge rows for the filters.
+const SHOWINGS = [
+  { id: "449131", time: "2026-07-18T11:15:00Z", published: true, past: false, private: false, isPreview: false, screenId: "117", movie },
+  { id: "449130", time: "2026-07-18T15:00:00Z", published: true, past: false, private: false, isPreview: false, screenId: "117", movie },
+  { id: "449129", time: "2026-07-18T18:45:00Z", published: true, past: false, private: false, isPreview: false, screenId: "117", movie },
+  { id: "449131", time: "2026-07-18T11:15:00Z", published: true, past: false, private: false, isPreview: false, screenId: "117", movie }, // duplicate id
+  { id: "449128", time: "2026-07-18T08:00:00Z", published: true, past: false, private: false, isPreview: false, screenId: "117", movie }, // before NOW
+  { id: "449127", time: "2026-07-18T20:00:00Z", published: false, past: false, private: false, isPreview: false, screenId: "117", movie }, // unpublished
+  { id: "449126", time: "2026-07-18T20:30:00Z", published: true, past: true, private: false, isPreview: false, screenId: "117", movie }, // past
+  { id: "449125", time: "2026-07-18T21:00:00Z", published: true, past: false, private: true, isPreview: false, screenId: "117", movie }, // private
+  { id: "449124", time: "2026-07-18T21:30:00Z", published: true, past: false, private: false, isPreview: true, screenId: "117", movie }, // preview
+];
+
+function fakeFetch(payloadForDate: (date: string) => unknown): IndyFetch {
+  return (async (_url: string, init?: { body?: string }) => {
+    const body = JSON.parse(init?.body ?? "{}");
+    const date = body.variables?.date as string;
+    return {
+      ok: true,
+      json: async () => payloadForDate(date),
+    } as unknown as Response;
+  }) as IndyFetch;
+}
+
+describe("fetchIndyShowings", () => {
+  it("maps published future showings, dedupes by id, and filters the rest", async () => {
+    const fetchImpl = fakeFetch((date) =>
+      date === "2026-07-18"
+        ? { data: { showingsForDate: { data: SHOWINGS, count: SHOWINGS.length } } }
+        : { data: { showingsForDate: { data: [] } } },
+    );
+
+    const screenings = await fetchIndyShowings(VENUE, { days: 1, now: NOW, fetchImpl, delayMs: 0 });
+
+    // Only the 3 valid, distinct, future, published showings survive.
+    expect(screenings.map((s) => s.sourceId)).toEqual([
+      "regent-street-449131",
+      "regent-street-449130",
+      "regent-street-449129",
+    ]);
+    const first = screenings[0];
+    expect(first.filmTitle).toBe("The Odyssey");
+    expect(first.bookingUrl).toBe("https://www.regentstreetcinema.com/checkout/showing/449131");
+    expect(first.datetime.toISOString()).toBe("2026-07-18T11:15:00.000Z");
+    expect(first.timeSource).toBe("iso");
+    expect(first.runtime).toBe(173);
+    expect(first.year).toBe(2026); // from releaseDate 2026-07-17
+  });
+
+  it("returns empty when the venue has no showings in the horizon", async () => {
+    const fetchImpl = fakeFetch(() => ({ data: { showingsForDate: { data: [] } } }));
+    const screenings = await fetchIndyShowings(VENUE, { days: 1, now: NOW, fetchImpl, delayMs: 0 });
+    expect(screenings).toEqual([]);
+  });
+
+  it("throws on an INDY error instead of returning empty success", async () => {
+    // Bad/missing site headers => {"error":{"message":"Site not found..."}}.
+    const fetchImpl = fakeFetch(() => ({ error: { message: "Site not found. (Code: 104)" } }));
+    await expect(
+      fetchIndyShowings(VENUE, {
+        days: 1,
+        now: NOW,
+        fetchImpl,
+        delayMs: 0,
+        attempts: 1,
+        retryDelayMs: 0,
+      }),
+    ).rejects.toThrow(/Site not found/);
+  });
+
+  it("queries consecutive London days across a BST spring-forward (no skip/dup)", async () => {
+    const requested: string[] = [];
+    const fetchImpl = (async (_url: string, init?: { body?: string }) => {
+      requested.push(JSON.parse(init?.body ?? "{}").variables.date);
+      return { ok: true, json: async () => ({ data: { showingsForDate: { data: [] } } }) } as unknown as Response;
+    }) as IndyFetch;
+    // Sat 23:30 UTC, night before GMT→BST (2026-03-29 01:00). A naive +24h step
+    // from here would skip the 23-hour Sunday; the noon-anchored loop must not.
+    await fetchIndyShowings(VENUE, {
+      now: new Date("2026-03-28T23:30:00Z"),
+      days: 4,
+      fetchImpl,
+      delayMs: 0,
+    });
+    expect(requested).toEqual(["2026-03-28", "2026-03-29", "2026-03-30", "2026-03-31"]);
+  });
+
+  it("throws on a non-ok HTTP response", async () => {
+    const fetchImpl = (async () =>
+      ({ ok: false, status: 503, json: async () => ({}) }) as unknown as Response) as IndyFetch;
+    await expect(
+      fetchIndyShowings(VENUE, {
+        days: 1,
+        now: NOW,
+        fetchImpl,
+        delayMs: 0,
+        attempts: 1,
+        retryDelayMs: 0,
+      }),
+    ).rejects.toThrow(/HTTP 503/);
+  });
+
+  it("throws on a GraphQL errors[] response", async () => {
+    const fetchImpl = fakeFetch(() => ({ errors: [{ message: "Cannot query field foo" }] }));
+    await expect(
+      fetchIndyShowings(VENUE, {
+        days: 1,
+        now: NOW,
+        fetchImpl,
+        delayMs: 0,
+        attempts: 1,
+        retryDelayMs: 0,
+      }),
+    ).rejects.toThrow(/Cannot query field foo/);
+  });
+
+  it("dedupes a showing id returned under multiple date responses", async () => {
+    const s = { id: "500", time: "2026-07-18T20:00:00Z", published: true, past: false, private: false, isPreview: false, screenId: "1", movie };
+    // Same showing echoed for every date in the horizon.
+    const fetchImpl = fakeFetch(() => ({ data: { showingsForDate: { data: [s] } } }));
+    const screenings = await fetchIndyShowings(VENUE, { days: 3, now: NOW, fetchImpl, delayMs: 0 });
+    expect(screenings.map((x) => x.sourceId)).toEqual(["regent-street-500"]);
+  });
+});
+
+describe("checkIndyHealth", () => {
+  it("returns true when the endpoint returns data without error", async () => {
+    const fetchImpl = fakeFetch(() => ({ data: { showingsForDate: { data: [] } } }));
+    expect(await checkIndyHealth(VENUE, fetchImpl)).toBe(true);
+  });
+
+  it("returns false when the endpoint errors (the one place empty is ok)", async () => {
+    const fetchImpl = fakeFetch(() => ({ error: { message: "Site not found. (Code: 104)" } }));
+    expect(await checkIndyHealth(VENUE, fetchImpl)).toBe(false);
+  });
+});

--- a/src/scrapers/platforms/indy.ts
+++ b/src/scrapers/platforms/indy.ts
@@ -1,0 +1,242 @@
+/**
+ * INDY Systems platform client (INDY Cinema Group, "powered by Fandango").
+ *
+ * Shared GraphQL client for London cinemas on the INDY booking platform. Each
+ * venue proxies `/graphql` on its own domain; the endpoint is OPEN — a plain
+ * POST with two identifying headers (`circuit-id`, `site-id`) returns showings,
+ * no auth token / cookie / CSRF required. This replaces the old per-scraper
+ * Playwright response-interception (which waited on fragile 20s/3s timers) with
+ * a deterministic direct `fetch()`.
+ *
+ * Known INDY venues (circuit-id / site-id):
+ *   - Regent Street Cinema — 19 / 85 (regentstreetcinema.com)
+ *   - The Chiswick Cinema  — 56 / 170 (chiswickcinema.co.uk)
+ * Discover a new venue's ids by reading the `circuit-id` / `site-id` headers on
+ * any `/graphql` request the site makes (constant per venue).
+ *
+ * NOTE: Phoenix Cinema (East Finchley) is NOT on INDY — it's an ASP.NET `.dll`
+ * system (`PhoenixCinemaLondon.dll`); see cinemas/phoenix.ts.
+ */
+
+import { sanitizeRuntime } from "../utils/metadata-parser";
+import type { RawScreening } from "../types";
+
+export interface IndyVenue {
+  /** Our cinema id, e.g. "regent-street" — also the sourceId prefix. */
+  cinemaId: string;
+  /** Venue site origin, e.g. "https://www.regentstreetcinema.com". */
+  baseUrl: string;
+  /** INDY `circuit-id` header value, e.g. "19". */
+  circuitId: string;
+  /** INDY `site-id` header + `siteIds` variable value, e.g. "85". */
+  siteId: string;
+}
+
+interface IndyMovie {
+  id: string;
+  name: string;
+  urlSlug?: string | null;
+  duration?: number | null;
+  rating?: string | null;
+  releaseDate?: string | null;
+}
+
+interface IndyShowing {
+  id: string;
+  time: string; // ISO UTC, e.g. "2026-07-18T11:15:00Z"
+  published: boolean;
+  past: boolean;
+  private?: boolean;
+  isPreview?: boolean;
+  screenId?: string | null;
+  movie: IndyMovie;
+}
+
+interface IndyResponse {
+  data?: { showingsForDate?: { data?: IndyShowing[] | null; count?: number } | null } | null;
+  errors?: Array<{ message: string }>;
+  // INDY returns a top-level `error` object for bad/missing site headers
+  // (e.g. {"error":{"message":"Site not found. (Code: 104)"}}).
+  error?: { message: string };
+}
+
+const SHOWINGS_QUERY =
+  "query ($date: String, $siteIds: [ID]) { showingsForDate(date: $date, siteIds: $siteIds) " +
+  "{ data { id time published past private isPreview screenId " +
+  "movie { id name urlSlug duration rating releaseDate } } count } }";
+
+export type IndyFetch = typeof fetch;
+
+const DEFAULT_HORIZON_DAYS = 35;
+const DEFAULT_REQUEST_DELAY_MS = 250;
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 500;
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * YYYY-MM-DD in Europe/London, `offset` calendar days after `from`'s London
+ * date. Anchors arithmetic at NOON UTC (12:00/13:00 London — always inside the
+ * same calendar day) so stepping never skips or duplicates a day across a
+ * BST↔GMT transition, the way raw `+ offset*86_400_000` from a near-midnight
+ * `now` would (spring-forward's 23h day gets jumped clean over).
+ */
+function londonDateKey(from: Date, offset: number): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(from);
+  const num = (t: string) => Number(parts.find((p) => p.type === t)!.value);
+  // Date.UTC normalizes day-of-month overflow (e.g. day 32 → next month).
+  const anchored = new Date(Date.UTC(num("year"), num("month") - 1, num("day") + offset, 12));
+  const yyyy = anchored.getUTCFullYear();
+  const mm = String(anchored.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(anchored.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Deterministic failure (bad site headers, GraphQL error, HTTP 4xx) that won't
+ * fix itself on retry — surfaced immediately instead of burning all attempts.
+ */
+class DeterministicIndyError extends Error {}
+
+/**
+ * POST showingsForDate for one date. Retries TRANSIENT failures (network / 5xx
+ * / parse) and THROWS if all attempts fail; deterministic API errors fail fast.
+ * Never swallowed as an empty success (SCRAPING_PLAYBOOK.md failure semantics).
+ */
+async function postShowingsForDate(
+  venue: IndyVenue,
+  date: string,
+  fetchFn: IndyFetch,
+  attempts: number,
+  retryDelayMs: number,
+): Promise<IndyShowing[]> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetchFn(`${venue.baseUrl}/graphql`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/graphql-response+json,application/json;q=0.9",
+          "circuit-id": venue.circuitId,
+          "site-id": venue.siteId,
+          "client-type": "consumer",
+        },
+        body: JSON.stringify({
+          query: SHOWINGS_QUERY,
+          variables: { date, siteIds: [venue.siteId] },
+        }),
+      });
+      if (!res.ok) {
+        const msg = `HTTP ${res.status} for ${venue.cinemaId} ${date}`;
+        // 4xx won't fix on retry; 5xx might be transient.
+        throw res.status < 500 ? new DeterministicIndyError(msg) : new Error(msg);
+      }
+      const json = (await res.json()) as IndyResponse;
+      if (json.error) {
+        throw new DeterministicIndyError(
+          `INDY error for ${venue.cinemaId} ${date}: ${json.error.message}`,
+        );
+      }
+      if (json.errors?.length) {
+        throw new DeterministicIndyError(
+          `GraphQL error for ${venue.cinemaId} ${date}: ${json.errors
+            .map((e) => e.message)
+            .join("; ")}`,
+        );
+      }
+      return json.data?.showingsForDate?.data ?? [];
+    } catch (err) {
+      if (err instanceof DeterministicIndyError) throw err;
+      lastError = err; // transient — retry
+      if (i < attempts - 1 && retryDelayMs > 0) await delay(retryDelayMs * (i + 1));
+    }
+  }
+  throw lastError ?? new Error(`INDY request failed for ${venue.cinemaId} ${date}`);
+}
+
+export interface FetchIndyOptions {
+  /** Horizon in days from `now` (default 35). */
+  days?: number;
+  /** Injectable fetch (tests). Defaults to global fetch. */
+  fetchImpl?: IndyFetch;
+  /** Reference "now" (tests). Defaults to new Date(). */
+  now?: Date;
+  /** Delay between per-date requests (default 250ms). */
+  delayMs?: number;
+  /** Retry attempts per date request (default 3). */
+  attempts?: number;
+  /** Base retry backoff (default 500ms). */
+  retryDelayMs?: number;
+}
+
+/**
+ * Fetch an INDY venue's upcoming showings via direct GraphQL, mapped to
+ * RawScreening. Loops each day today…+days, dedupes by showing id, and keeps
+ * only published, non-past, non-private, non-preview future showings.
+ */
+export async function fetchIndyShowings(
+  venue: IndyVenue,
+  opts: FetchIndyOptions = {},
+): Promise<RawScreening[]> {
+  const days = opts.days ?? DEFAULT_HORIZON_DAYS;
+  const fetchFn = opts.fetchImpl ?? fetch;
+  const now = opts.now ?? new Date();
+  const delayMs = opts.delayMs ?? DEFAULT_REQUEST_DELAY_MS;
+  const attempts = opts.attempts ?? DEFAULT_ATTEMPTS;
+  const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+  const seen = new Set<string>();
+  const screenings: RawScreening[] = [];
+
+  for (let offset = 0; offset < days; offset++) {
+    const date = londonDateKey(now, offset);
+    const showings = await postShowingsForDate(venue, date, fetchFn, attempts, retryDelayMs);
+    for (const s of showings) {
+      if (seen.has(s.id)) continue;
+      seen.add(s.id);
+      if (!s.published || s.past || s.private || s.isPreview) continue;
+      const datetime = new Date(s.time);
+      if (isNaN(datetime.getTime()) || datetime < now) continue;
+      screenings.push(mapShowing(venue, s, datetime));
+    }
+    if (offset < days - 1 && delayMs > 0) await delay(delayMs);
+  }
+
+  return screenings;
+}
+
+/** Map an INDY showing to a RawScreening (ISO-sourced; sourceId preserved). */
+function mapShowing(venue: IndyVenue, s: IndyShowing, datetime: Date): RawScreening {
+  const releaseYear = s.movie.releaseDate
+    ? new Date(s.movie.releaseDate).getFullYear()
+    : undefined;
+  return {
+    filmTitle: s.movie.name.trim(),
+    datetime,
+    bookingUrl: `${venue.baseUrl}/checkout/showing/${s.id}`,
+    sourceId: `${venue.cinemaId}-${s.id}`,
+    runtime: sanitizeRuntime(s.movie.duration ?? null),
+    year: releaseYear && !Number.isNaN(releaseYear) ? releaseYear : undefined,
+    timeSource: "iso",
+  };
+}
+
+/**
+ * Health check against the REAL dependency: a today `showingsForDate` POST that
+ * returns without an INDY/GraphQL error means the endpoint + venue headers work.
+ */
+export async function checkIndyHealth(venue: IndyVenue, fetchImpl?: IndyFetch): Promise<boolean> {
+  try {
+    const today = londonDateKey(new Date(), 0);
+    await postShowingsForDate(venue, today, fetchImpl ?? fetch, 1, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What

Coverage plan **Phase 2a, PR 1 of 2**: extract a shared **INDY Systems GraphQL client** and migrate **Regent Street Cinema** onto it, replacing fragile Playwright response-interception with a deterministic direct `fetch()`. PR 2 will add The Chiswick Cinema on the same adapter.

## Research finding that reshaped the scope

The handoff plan grouped Regent Street **and Phoenix** under the INDY adapter (following a stale `regent-street.ts` comment, *"Same platform as Phoenix"*). Live investigation disproved it:
- **INDY `/graphql` is open** — a plain POST with `circuit-id`/`site-id` headers returns showings; no auth token/cookie/CSRF. Proven with curl for Regent Street (19/85) and Chiswick (56/170). So Playwright is **removed entirely**.
- **Phoenix is NOT on INDY** — `phoenixcinema.co.uk/graphql` 302s; it's an ASP.NET `.dll` system. Phoenix is **out of scope** here; its DOM-heuristic P0 belongs with the `.dll`/Savoy work.

## Changes

- **`src/scrapers/platforms/indy.ts`** (new): `fetchIndyShowings(venue, opts)` loops dates today…+35 (**noon-UTC anchored** so a BST↔GMT transition can't skip/duplicate a day), keeps only `published && !past && !private && !isPreview`, dedupes by showing id, maps to `RawScreening`. `checkIndyHealth` hits the real dependency. `postShowingsForDate` retries transient failures but **fails fast on deterministic errors** (bad headers / GraphQL / 4xx) and never returns empty-as-success.
- **`src/scrapers/cinemas/regent-street.ts`**: deleted the Playwright launch + response interception + 20s/3s timer promise; now a thin `CinemaScraper` delegating to the adapter. **sourceId unchanged** (`regent-street-{showing.id}` → no reconcile); booking URL upgraded to the `/checkout/showing/{id}` deep-link; `timeSource:"iso"`; runtime + year captured.
- **`src/scrapers/platforms/indy.test.ts`** (new): mapping, all five filters, dedupe, the BST spring-forward date loop, `checkIndyHealth` (both branches), and every throw path.
- Playbook + changelogs.

## Verification

- Fixture smokes (tsx, DB-free): 7/7 + 6/6 (incl. deterministic-error-fails-fast in 0ms).
- **Live**: Regent Street endpoint — healthCheck green, 25 screenings / 14-day, 0 sub-09:00-London times, `/checkout/showing/{id}` resolves **200**.
- Bug caught in review + fixed: raw `+24h` date stepping skipped the spring-forward Sunday (verified `03-28 → 03-30`); fixed via noon-UTC anchor + regression test.
- eslint clean; `tsc --noEmit` clean. CI is the authoritative gate for the unit suite (local vitest worker pool wedges on this machine).
- code-reviewer agent: no blockers; all findings + nits addressed.

Part of the coverage-expansion plan (Phase 2a). Sets up Chiswick (PR 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
