### PR TITLE
fix(seed): source cinemas from the registry (fixes Garden map pin + zombie cinemas)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-07-14: seed-cli sources cinemas from the registry (fixes Garden map pin, kills zombie cinemas)
-**PR**: TBD | **Files**: `src/db/seed-cli.ts`
+**PR**: #730 | **Files**: `src/db/seed-cli.ts`
 - `seedCinemas()` now seeds from `getCinemasSeedData()` (the cinema registry — single source of truth, 71 cinemas) instead of a stale hand-maintained 16-entry `LONDON_CINEMAS` array that had drifted to **deprecated ids** (`garden-cinema`, `genesis-mile-end`) with a wrong (Golders Green) address. That drift meant `db:seed:cinemas` created empty **zombie cinemas** and left canonical `garden` (200 screenings) with **NULL coordinates → no map pin**.
 - Coordinate/screens/programmingFocus/description upserts now **COALESCE** against the existing row, so the registry's 18 null-coordinate entries can't blank the 11 live-pinned venues (lexi, Picturehouse/Everyman branches) that currently lack registry coords.
 - **Prod remediation (data-only):** re-seeded 71 cinemas (Garden pin restored; verified no pins blanked); deleted 4 orphaned zombie cinema records (`garden-cinema`, `genesis-mile-end`, `nickel`, `olympic`) + 132 stale `nickel` screenings (inactive → already hidden from the site).

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-07-14: seed-cli sources cinemas from the registry (fixes Garden map pin, kills zombie cinemas)
+**PR**: TBD | **Files**: `src/db/seed-cli.ts`
+- `seedCinemas()` now seeds from `getCinemasSeedData()` (the cinema registry — single source of truth, 71 cinemas) instead of a stale hand-maintained 16-entry `LONDON_CINEMAS` array that had drifted to **deprecated ids** (`garden-cinema`, `genesis-mile-end`) with a wrong (Golders Green) address. That drift meant `db:seed:cinemas` created empty **zombie cinemas** and left canonical `garden` (200 screenings) with **NULL coordinates → no map pin**.
+- Coordinate/screens/programmingFocus/description upserts now **COALESCE** against the existing row, so the registry's 18 null-coordinate entries can't blank the 11 live-pinned venues (lexi, Picturehouse/Everyman branches) that currently lack registry coords.
+- **Prod remediation (data-only):** re-seeded 71 cinemas (Garden pin restored; verified no pins blanked); deleted 4 orphaned zombie cinema records (`garden-cinema`, `genesis-mile-end`, `nickel`, `olympic`) + 132 stale `nickel` screenings (inactive → already hidden from the site).
+- Surfaced during a coverage audit; the `LONDON_CINEMAS`↔registry drift is the exact "seed-cli doesn't read the registry" hazard, now eliminated.
+
+---
+
 ## 2026-07-14: Savoy JSON adapter — Rio migration + empty-success P0 fix (Coverage Phase 2b, PR 1)
 **PR**: #729 | **Files**: `src/scrapers/platforms/savoy.ts` (new), `src/scrapers/platforms/savoy.test.ts` (new), `src/scrapers/cinemas/rio.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
 - New shared **Savoy Systems modern-JSON client** (`platforms/savoy.ts`): brace-matched `var Events` extraction + performance mapping (UK-local HHMM via `combineDateAndTime`, festival detection, optional `TypeDescription==="Film"` filter), per-venue sourceId/booking builders. **Throws on a missing/malformed `var Events` blob — fixes Rio's empty-success P0** (previously returned `[]` silently, masking a broken scrape).

--- a/changelogs/2026-07-14-seed-cli-registry-source.md
+++ b/changelogs/2026-07-14-seed-cli-registry-source.md
@@ -1,0 +1,63 @@
+# seed-cli sources cinemas from the registry (fixes Garden map pin, kills zombie cinemas)
+
+**PR**: TBD
+**Date**: 2026-07-14
+
+## Problem (found during a coverage audit)
+
+`db:seed:cinemas` seeded from a hand-maintained 16-entry `LONDON_CINEMAS` array in
+`src/db/seed-cli.ts`, which had drifted from the cinema registry:
+
+- It used **deprecated ids** `garden-cinema` and `genesis-mile-end` (canonical: `garden`,
+  `genesis`), so seeding created empty **zombie cinemas** (active, 0 screenings) that render
+  as empty venues on the site.
+- The `garden-cinema` entry even had the **wrong address** (Golders Green NW11) — The Garden
+  Cinema is in Covent Garden (WC2B).
+- Because coordinates were written to the zombie id, canonical **`garden`** (200 screenings)
+  was left with **NULL coordinates → missing from the map entirely**. (The scraper path's
+  `ensureCinemaExists` writes address/name but not coordinates, so nothing else filled them.)
+
+The registry already exposed `getCinemasSeedData()` (all 71 cinemas, correct coords) and its
+own header comment said seed-cli *should* use it — a stale local array was just left in place.
+
+## Change
+
+- `seedCinemas()` now iterates `getCinemasSeedData()` (registry — single source of truth).
+  The stale 261-line `LONDON_CINEMAS` array is deleted. Kills the drift permanently.
+- The upsert **COALESCEs** the NULLABLE columns (`coordinates`/`screens`/`description`) against
+  the existing DB row: the registry has null coordinates for 18 of 71 cinemas, and 11 of those
+  are currently live-pinned (lexi, several Picturehouse/Everyman branches). COALESCE means the
+  registry value wins when present and the existing DB value is preserved when the registry is
+  null — so the fix can't blank a live pin. (`programmingFocus`/`features` are NOT NULL, so they
+  stay honest overwrites from the registry.)
+- **`active` flag carried through** (`getCinemasSeedData()`): `isActive` is set from the
+  registry on INSERT only (so a deliberately-inactive venue like `everyman-walthamstow` isn't
+  inserted as active on a fresh DB seed — which would recreate the exact zombie class this fixes)
+  and kept OUT of the update `set`, so a re-seed never flips a manually-toggled venue. [code-review]
+
+## Prod remediation applied (data-only, no code)
+
+- `npm run db:seed:cinemas` → 71 cinemas upserted. Verified: **`garden` gained coordinates
+  (map pin restored)**; the 11 at-risk pinned venues **kept** their coordinates (COALESCE).
+- Deleted 4 orphaned zombie cinema records — `garden-cinema`, `genesis-mile-end` (empty),
+  `nickel` (inactive, 132 stale rows incl. 40 future — already hidden as inactive), `olympic`
+  (inactive, empty) — plus `nickel`'s 132 screenings. 0 zombies remain.
+
+## Verification
+
+- eslint clean; `tsc --noEmit` clean.
+- `getCinemasSeedData()` validated: 71 entries, canonical `garden`/`genesis`/`chiswick-cinema`
+  present, deprecated ids absent, no duplicate ids.
+- Post-seed DB check: `garden` pinned; lexi + Picturehouse/Everyman pins intact; zombies gone.
+
+## Impact
+
+- **The Garden Cinema is back on the map.** No other venue's pin regressed.
+- Future `db:seed:cinemas` runs are registry-driven — they can't recreate the zombies or
+  starve canonical venues of metadata. Removes the `LONDON_CINEMAS`↔registry dual-maintenance.
+
+## Follow-up (not in this change)
+
+- The registry is missing coordinates for 18 cinemas (7 currently pinless: castle-sidcup,
+  arthouse-crouch-end, david-lean-cinema, riverside-studios, everyman-{walthamstow,brentford,
+  the-whiteley}). Backfilling those into `cinema-registry.ts` would give them map pins.

--- a/changelogs/2026-07-14-seed-cli-registry-source.md
+++ b/changelogs/2026-07-14-seed-cli-registry-source.md
@@ -1,6 +1,6 @@
 # seed-cli sources cinemas from the registry (fixes Garden map pin, kills zombie cinemas)
 
-**PR**: TBD
+**PR**: #730
 **Date**: 2026-07-14
 
 ## Problem (found during a coverage audit)

--- a/src/config/cinema-registry.ts
+++ b/src/config/cinema-registry.ts
@@ -1573,6 +1573,9 @@ export const VENUE_LANGUAGE_PRIORS: Record<string, string[]> = {
 export function getCinemasSeedData() {
   return CINEMA_REGISTRY.map((cinema) => ({
     id: cinema.id,
+    // Carried through so seed INSERTs respect deliberately-inactive venues
+    // (e.g. everyman-walthamstow) instead of defaulting is_active=true.
+    active: cinema.active,
     name: cinema.name,
     shortName: cinema.shortName,
     chain: cinema.chain,

--- a/src/db/seed-cli.ts
+++ b/src/db/seed-cli.ts
@@ -16,272 +16,17 @@ import { cinemas, films, screenings, festivals } from "./schema";
 import { v4 as uuidv4, v4 } from "uuid";
 import { addDays, setHours, setMinutes } from "date-fns";
 import type { ScreeningFormat, EventType } from "@/types/screening";
+import { sql } from "drizzle-orm";
+import { getCinemasSeedData } from "@/config/cinema-registry";
 
 // ============================================================================
-// Cinema Seed Data
+// Cinema Seed Data — sourced from the cinema registry (single source of truth)
+// via getCinemasSeedData(). The old hand-maintained LONDON_CINEMAS array was
+// removed 2026-07-14: it had drifted to deprecated ids (garden-cinema,
+// genesis-mile-end) with stale addresses, so `db:seed:cinemas` created empty
+// zombie cinemas and left canonical `garden` without coordinates (no map pin).
 // ============================================================================
 
-const LONDON_CINEMAS = [
-  {
-    id: "bfi-southbank",
-    name: "BFI Southbank",
-    shortName: "BFI",
-    chain: "BFI",
-    address: { street: "Belvedere Road", area: "South Bank", postcode: "SE1 8XT", borough: "Lambeth" },
-    coordinates: { lat: 51.5069, lng: -0.1150 },
-    screens: 4,
-    features: ["35mm", "70mm", "bar", "restaurant", "accessible"],
-    programmingFocus: ["repertory", "arthouse", "documentary", "events"],
-    website: "https://whatson.bfi.org.uk",
-    bookingUrl: "https://whatson.bfi.org.uk/Online/",
-    dataSourceType: "scrape" as const,
-    description: "The UK's leading repertory cinema, home to seasons, retrospectives, and restorations.",
-  },
-  {
-    id: "bfi-imax",
-    name: "BFI IMAX",
-    shortName: "IMAX",
-    chain: "BFI",
-    address: { street: "1 Charlie Chaplin Walk", area: "Waterloo", postcode: "SE1 8XR", borough: "Lambeth" },
-    coordinates: { lat: 51.5033, lng: -0.1134 },
-    screens: 1,
-    features: ["imax", "70mm", "accessible"],
-    programmingFocus: ["mainstream", "events", "repertory"],
-    website: "https://whatson.bfi.org.uk",
-    bookingUrl: "https://whatson.bfi.org.uk/Online/",
-    dataSourceType: "scrape" as const,
-    description: "The UK's largest IMAX screen.",
-  },
-  {
-    id: "prince-charles",
-    name: "Prince Charles Cinema",
-    shortName: "PCC",
-    chain: null,
-    address: { street: "7 Leicester Place", area: "Leicester Square", postcode: "WC2H 7BY", borough: "Westminster" },
-    coordinates: { lat: 51.5114, lng: -0.1302 },
-    screens: 2,
-    features: ["35mm", "bar", "accessible"],
-    programmingFocus: ["repertory", "events"],
-    website: "https://princecharlescinema.com",
-    bookingUrl: "https://princecharlescinema.com/whats-on/",
-    dataSourceType: "scrape" as const,
-    description: "London's legendary repertory cinema. Home to sing-alongs, marathons, and the best double bills.",
-  },
-  {
-    id: "ica",
-    name: "ICA Cinema",
-    shortName: "ICA",
-    chain: null,
-    address: { street: "The Mall", area: "St James's", postcode: "SW1Y 5AH", borough: "Westminster" },
-    coordinates: { lat: 51.5063, lng: -0.1310 },
-    screens: 2,
-    features: ["accessible", "bar"],
-    programmingFocus: ["arthouse", "experimental", "documentary"],
-    website: "https://www.ica.art/films",
-    bookingUrl: "https://www.ica.art/films",
-    dataSourceType: "scrape" as const,
-    description: "Institute of Contemporary Arts cinema. Cutting-edge and avant-garde cinema.",
-  },
-  {
-    id: "barbican",
-    name: "Barbican Cinema",
-    shortName: "Barbican",
-    chain: null,
-    address: { street: "Silk Street", area: "Barbican", postcode: "EC2Y 8DS", borough: "City of London" },
-    coordinates: { lat: 51.5200, lng: -0.0935 },
-    screens: 3,
-    features: ["accessible", "bar", "hearing_loop"],
-    programmingFocus: ["arthouse", "repertory", "documentary", "events"],
-    website: "https://www.barbican.org.uk/whats-on/cinema",
-    bookingUrl: "https://www.barbican.org.uk/whats-on/cinema",
-    dataSourceType: "scrape" as const,
-    description: "Part of Europe's largest arts centre. International cinema and director retrospectives.",
-  },
-  {
-    id: "rio-dalston",
-    name: "Rio Cinema",
-    shortName: "Rio",
-    chain: null,
-    address: { street: "107 Kingsland High Street", area: "Dalston", postcode: "E8 2PB", borough: "Hackney" },
-    coordinates: { lat: 51.5485, lng: -0.0755 },
-    screens: 2,
-    features: ["35mm", "bar", "accessible"],
-    programmingFocus: ["repertory", "arthouse", "community"],
-    website: "https://riocinema.org.uk",
-    bookingUrl: "https://riocinema.org.uk/whats-on/",
-    dataSourceType: "scrape" as const,
-    description: "East London's beloved Art Deco cinema.",
-  },
-  {
-    id: "genesis-mile-end",
-    name: "Genesis Cinema",
-    shortName: "Genesis",
-    chain: null,
-    address: { street: "93-95 Mile End Road", area: "Mile End", postcode: "E1 4UJ", borough: "Tower Hamlets" },
-    coordinates: { lat: 51.5232, lng: -0.0408 },
-    screens: 5,
-    features: ["bar", "accessible"],
-    programmingFocus: ["mainstream", "repertory", "arthouse"],
-    website: "https://genesiscinema.co.uk",
-    bookingUrl: "https://genesiscinema.co.uk/whats-on/",
-    dataSourceType: "scrape" as const,
-    description: "Independent East London cinema with eclectic programming.",
-  },
-  {
-    id: "garden-cinema",
-    name: "The Garden Cinema",
-    shortName: "Garden",
-    chain: null,
-    address: { street: "39-41 Golders Green Road", area: "Golders Green", postcode: "NW11 8EE", borough: "Barnet" },
-    coordinates: { lat: 51.5726, lng: -0.1944 },
-    screens: 1,
-    features: ["bar", "accessible", "35mm"],
-    programmingFocus: ["arthouse", "repertory", "documentary"],
-    website: "https://thegardencinema.co.uk",
-    bookingUrl: "https://thegardencinema.co.uk",
-    dataSourceType: "scrape" as const,
-    description: "Beautiful single-screen independent cinema in North London.",
-  },
-  {
-    id: "close-up-cinema",
-    name: "Close-Up Cinema",
-    shortName: "Close-Up",
-    chain: null,
-    address: { street: "97 Sclater Street", area: "Shoreditch", postcode: "E1 6HR", borough: "Tower Hamlets" },
-    coordinates: { lat: 51.5233, lng: -0.0718 },
-    screens: 1,
-    features: ["bar", "accessible"],
-    programmingFocus: ["repertory", "arthouse", "documentary", "events"],
-    website: "https://www.closeupfilmcentre.com",
-    bookingUrl: "https://www.closeupfilmcentre.com",
-    dataSourceType: "scrape" as const,
-    description: "Intimate single-screen cinema in Shoreditch specializing in repertory.",
-  },
-  {
-    id: "cine-lumiere",
-    name: "Cine Lumiere",
-    shortName: "Lumiere",
-    chain: null,
-    address: { street: "17 Queensberry Place", area: "South Kensington", postcode: "SW7 2DT", borough: "Kensington and Chelsea" },
-    coordinates: { lat: 51.4947, lng: -0.1765 },
-    screens: 1,
-    features: ["accessible", "bar"],
-    programmingFocus: ["arthouse", "repertory", "french", "european"],
-    website: "https://www.institut-francais.org.uk/cine-lumiere/",
-    bookingUrl: "https://cinelumiere.savoysystems.co.uk/CineLumiere.dll/",
-    dataSourceType: "scrape" as const,
-    description: "French and European arthouse cinema at Institut Francais.",
-  },
-  {
-    id: "phoenix-east-finchley",
-    name: "Phoenix Cinema",
-    shortName: "Phoenix",
-    chain: null,
-    address: { street: "52 High Rd", area: "East Finchley", postcode: "N2 9PJ", borough: "Barnet" },
-    coordinates: { lat: 51.5871, lng: -0.1642 },
-    screens: 2,
-    features: ["accessible", "bar", "cafe"],
-    programmingFocus: ["repertory", "arthouse", "mainstream", "events"],
-    website: "https://phoenixcinema.co.uk",
-    bookingUrl: "https://phoenixcinema.co.uk/whats-on/",
-    dataSourceType: "scrape" as const,
-    description: "One of the oldest purpose-built cinemas in the UK (1910).",
-  },
-  {
-    // Chiswick has a scraper (auto-creates its identity row on first scrape),
-    // but it's listed here too so `db:seed:cinemas` writes its full metadata —
-    // ensureCinemaExists does NOT persist coordinates, so without this the map
-    // would have no Chiswick pin.
-    id: "chiswick-cinema",
-    name: "The Chiswick Cinema",
-    shortName: "Chiswick",
-    chain: null,
-    address: { street: "94-96 Chiswick High Road", area: "Chiswick", postcode: "W4 1SH", borough: "Hounslow" },
-    coordinates: { lat: 51.4931, lng: -0.251 },
-    screens: 5,
-    features: ["accessible", "bar", "cafe"],
-    programmingFocus: ["mainstream", "arthouse", "events"],
-    website: "https://www.chiswickcinema.co.uk",
-    bookingUrl: "https://www.chiswickcinema.co.uk/whats-on",
-    dataSourceType: "scrape" as const,
-    description: "Boutique five-screen cinema on Chiswick High Road (opened 2021).",
-  },
-  {
-    id: "coldharbour-blue",
-    name: "Coldharbour Blue",
-    shortName: "Coldharbour",
-    chain: null,
-    address: { street: "259-260 Hardess Street", area: "Loughborough Junction", postcode: "SE24 0HN", borough: "Lambeth" },
-    coordinates: { lat: 51.4630, lng: -0.1010 },
-    screens: 1,
-    features: ["bar", "accessible", "community"],
-    programmingFocus: ["arthouse", "repertory", "documentary", "events"],
-    website: "https://www.coldharbourblue.com",
-    bookingUrl: "https://www.coldharbourblue.com/screenings/",
-    dataSourceType: "scrape" as const,
-    description: "Independent cinema in Brixton. New releases, art-house, classics and documentaries.",
-  },
-  {
-    id: "the-arzner",
-    name: "The Arzner",
-    shortName: "Arzner",
-    chain: null,
-    address: { street: "10 Bermondsey Square", area: "Bermondsey", postcode: "SE1 3UN", borough: "Southwark" },
-    coordinates: { lat: 51.4979, lng: -0.0813 },
-    screens: 1,
-    features: ["bar", "community", "accessible"],
-    programmingFocus: ["lgbtqia", "arthouse", "repertory", "events"],
-    website: "https://thearzner.com",
-    bookingUrl: "https://thearzner.com/TheArzner.dll/Home",
-    dataSourceType: "scrape" as const,
-    description: "London's LGBTQ+ cinema and bar in Bermondsey Square, named after director Dorothy Arzner.",
-  },
-  {
-    id: "horse-hospital",
-    name: "The Horse Hospital",
-    shortName: "Horse Hospital",
-    chain: null,
-    address: { street: "Colonnade", area: "Bloomsbury", postcode: "WC1N 1JD", borough: "Camden" },
-    coordinates: { lat: 51.5231, lng: -0.123 },
-    screens: 1,
-    features: ["historic", "community"],
-    programmingFocus: ["experimental", "repertory", "events"],
-    website: "https://www.thehorsehospital.com",
-    bookingUrl: "https://www.thehorsehospital.com/events",
-    dataSourceType: "scrape" as const,
-    description: "Underground arts venue in a Grade II listed stable; experimental film, counterculture and avant-garde programming.",
-  },
-  {
-    id: "good-shepherd-studios",
-    name: "Good Shepherd Studios",
-    shortName: "Good Shepherd",
-    chain: null,
-    address: { street: "15A Davies Lane", area: "Leytonstone", postcode: "E11 3DR", borough: "Waltham Forest" },
-    coordinates: { lat: 51.5648, lng: 0.0132 },
-    screens: 1,
-    features: ["community", "cafe"],
-    programmingFocus: ["community", "repertory", "documentary", "events"],
-    website: "https://www.goodshepherdstudios.com",
-    bookingUrl: "https://www.goodshepherdstudios.com/events",
-    dataSourceType: "scrape" as const,
-    description: "Community and creative space in Leytonstone hosting pop-up cinema and film club screenings.",
-  },
-  {
-    id: "project-loop",
-    name: "Project Loop",
-    shortName: "Project Loop",
-    chain: null,
-    address: { street: "16 Orsman Road", area: "Haggerston", postcode: "N1 5QJ", borough: "Hackney" },
-    coordinates: { lat: 51.5372, lng: -0.0779 },
-    screens: 1,
-    features: ["community"],
-    programmingFocus: ["experimental", "events"],
-    website: "https://www.instagram.com/projectloop.ldn/",
-    bookingUrl: "https://www.instagram.com/projectloop.ldn/",
-    dataSourceType: "scrape" as const,
-    description: "Canal-side project space in Haggerston hosting occasional film programmes and residencies.",
-  },
-];
 
 // ============================================================================
 // Festival Seed Data
@@ -433,10 +178,13 @@ async function seedCinemas(): Promise<number> {
   console.log("  Seeding cinemas...");
   let count = 0;
 
-  for (const cinema of LONDON_CINEMAS) {
+  for (const { active, ...cinema } of getCinemasSeedData()) {
     await db
       .insert(cinemas)
-      .values(cinema)
+      // isActive is set ONLY on INSERT (respects the registry's `active` flag —
+      // e.g. everyman-walthamstow stays inactive) and kept OUT of the update
+      // `set` below, so re-seeding never flips a manually-toggled venue.
+      .values({ ...cinema, isActive: active })
       .onConflictDoUpdate({
         target: cinemas.id,
         set: {
@@ -444,14 +192,20 @@ async function seedCinemas(): Promise<number> {
           shortName: cinema.shortName,
           chain: cinema.chain,
           address: cinema.address,
-          coordinates: cinema.coordinates,
-          screens: cinema.screens,
-          features: cinema.features,
+          // COALESCE only the NULLABLE columns so a null-in-registry value never
+          // blanks existing DB data — the registry has coords for only ~53/71
+          // cinemas, and 11 live-pinned venues (lexi, several Picturehouse/
+          // Everyman) have no registry coords. Registry wins when present; DB
+          // value preserved when the registry is null.
+          coordinates: sql`coalesce(excluded.coordinates, ${cinemas.coordinates})`,
+          screens: sql`coalesce(excluded.screens, ${cinemas.screens})`,
+          description: sql`coalesce(excluded.description, ${cinemas.description})`,
+          // NOT NULL columns — honest overwrite from the registry (source of truth).
           programmingFocus: cinema.programmingFocus,
+          features: cinema.features,
           website: cinema.website,
           bookingUrl: cinema.bookingUrl,
           dataSourceType: cinema.dataSourceType,
-          description: cinema.description,
           updatedAt: new Date(),
         },
       });
@@ -599,7 +353,7 @@ function listOperations(): void {
   console.log(`
 Available seed operations:
 
-  --cinemas     ${LONDON_CINEMAS.length} London cinemas (production data)
+  --cinemas     ${getCinemasSeedData().length} London cinemas (from registry)
   --festivals   ${LONDON_FESTIVALS.length} London festivals (production data)
   --screenings  ${TEST_FILMS.length} test films + random screenings (development only)
 


### PR DESCRIPTION
## What

Fixes a live bug found during a coverage audit: **The Garden Cinema was missing from the map** (200 screenings, null coordinates), and `db:seed:cinemas` was creating empty **zombie cinemas**.

## Root cause

`seedCinemas()` seeded from a hand-maintained 16-entry `LONDON_CINEMAS` array that had drifted from the cinema registry — it used **deprecated ids** (`garden-cinema`, `genesis-mile-end`) with a **wrong address** (Golders Green vs Garden's actual Covent Garden). So seeding wrote coordinates onto empty zombie ids while canonical `garden` (which the scraper path's `ensureCinemaExists` creates without coordinates) got no pin. The registry already exposed `getCinemasSeedData()` and its comment said seed-cli *should* use it — a stale local array was just left in place.

## Change (`src/db/seed-cli.ts`, `src/config/cinema-registry.ts`)

- `seedCinemas()` iterates `getCinemasSeedData()` (registry, single source of truth, 71 cinemas). The stale 261-line `LONDON_CINEMAS` array is deleted → drift can't recur.
- Nullable columns (`coordinates`/`screens`/`description`) **COALESCE** against the existing row — the registry has null coords for 18/71 cinemas, 11 of them live-pinned (lexi, Picturehouse/Everyman), so a naive overwrite would blank those pins. Registry wins when present; DB preserved when null.
- **`active` carried through** — `isActive` set from the registry on INSERT only (a deliberately-inactive venue like `everyman-walthamstow` isn't inserted as active on a fresh seed → doesn't recreate the zombie class) and kept out of the update `set` (re-seed never flips a manually-toggled venue).

## Prod remediation applied (data-only)

- `db:seed:cinemas` → 71 cinemas. **Verified: `garden` gained coordinates (map pin restored); the 11 at-risk pins were preserved (COALESCE).**
- Deleted 4 orphaned zombie cinema records (`garden-cinema`, `genesis-mile-end`, `nickel`, `olympic`) + 132 stale `nickel` screenings. 0 zombies remain.

## Verification

- eslint + `tsc --noEmit` clean.
- `getCinemasSeedData()` validated (71 entries, canonical ids present, deprecated absent, carries `active`, walthamstow inactive).
- Post-seed DB check: garden pinned, at-risk pins intact, zombies gone.
- code-reviewer agent: COALESCE SQL correct, removal clean, prod claims verified; its two findings (inactive-on-insert, programmingFocus no-op) addressed.

## Follow-up (noted, not in this PR)

18 registry cinemas lack coordinates (7 currently pinless: castle-sidcup, arthouse-crouch-end, david-lean-cinema, riverside-studios, everyman-{walthamstow,brentford,the-whiteley}) — backfilling `cinema-registry.ts` would give them pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
