### PR TITLE
feat(scrape): crash-resume — checkpoint + --resume flag (/scrape improvements, PR 2)

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-07-18: /scrape crash-resume — checkpoint + --resume flag (/scrape improvements, PR 2)
-**PR**: #TBD | **Files**: `src/lib/scrape-checkpoint.ts` (new), `src/lib/scrape-checkpoint.test.ts` (new), `src/scripts/run-scrape-and-enrich.ts`, `src/lib/jobs/scrape-all.ts`
+**PR**: #732 | **Files**: `src/lib/scrape-checkpoint.ts` (new), `src/lib/scrape-checkpoint.test.ts` (new), `src/scripts/run-scrape-and-enrich.ts`, `src/lib/jobs/scrape-all.ts`
 - New checkpoint file (`tmp/scrape-checkpoint.json`) records completed phases AND completed individual scrapers within Phase 1. `npm run scrape:unified -- --resume` skips them — a crash 40 minutes into a run no longer costs a full re-run.
 - Safety: resume is never automatic (explicit flag only); checkpoints expire after 24h and must match the run's CLI args; completions are honored only as a **prefix of the phase dependency chain** (a "completed" cleanup after a failed scrape re-runs — it enriched stale data); read-only detector phases (preflight/health/yield-delta) always re-run so the run summary's health data stays fresh. Checkpoint cleared on clean exit, kept on failure (so `--resume` = retry only what failed).
 - `runScrapeAll` gains `{ skipTaskIds, onEntryComplete }` — skipped scrapers are counted as pre-succeeded ("skipped (resume)") so wave/digest math stays honest.

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,12 @@
+## 2026-07-18: /scrape crash-resume — checkpoint + --resume flag (/scrape improvements, PR 2)
+**PR**: #TBD | **Files**: `src/lib/scrape-checkpoint.ts` (new), `src/lib/scrape-checkpoint.test.ts` (new), `src/scripts/run-scrape-and-enrich.ts`, `src/lib/jobs/scrape-all.ts`
+- New checkpoint file (`tmp/scrape-checkpoint.json`) records completed phases AND completed individual scrapers within Phase 1. `npm run scrape:unified -- --resume` skips them — a crash 40 minutes into a run no longer costs a full re-run.
+- Safety: resume is never automatic (explicit flag only); checkpoints expire after 24h and must match the run's CLI args; completions are honored only as a **prefix of the phase dependency chain** (a "completed" cleanup after a failed scrape re-runs — it enriched stale data); read-only detector phases (preflight/health/yield-delta) always re-run so the run summary's health data stays fresh. Checkpoint cleared on clean exit, kept on failure (so `--resume` = retry only what failed).
+- `runScrapeAll` gains `{ skipTaskIds, onEntryComplete }` — skipped scrapers are counted as pre-succeeded ("skipped (resume)") so wave/digest math stays honest.
+- `/scrape` skill gains a `resume` arg.
+
+---
+
 ## 2026-07-18: /scrape run-summary JSON + warn states + skill rewrite (/scrape improvements, PR 1)
 **PR**: #731 | **Files**: `src/lib/scrape-run-summary.ts` (new), `src/lib/scrape-run-summary.test.ts` (new), `src/scripts/run-scrape-and-enrich.ts`, `src/lib/scrape-quarantine.ts`, `.claude/commands/scrape.md`
 - Orchestrator now persists a machine-readable **run summary** to `tmp/scrape-run-summary.json` on every exit path (ok/failed/**crashed**), with dated history in `tmp/scrape-runs/` (last 20). Includes per-phase results (stable `id`s: preflight/scrape/lcut/cleanup/audit/rematch/health/yield-delta), before/after screening counts, and the full typed detector outputs (silent breakers, flaky, yield drops/deltas, stale, DQS) that were previously formatted-then-discarded.

--- a/changelogs/2026-07-18-scrape-resume.md
+++ b/changelogs/2026-07-18-scrape-resume.md
@@ -1,6 +1,6 @@
 # /scrape crash-resume — checkpoint + --resume flag (/scrape improvements, PR 2)
 
-**PR**: #TBD
+**PR**: #732
 **Date**: 2026-07-18
 
 ## Changes

--- a/changelogs/2026-07-18-scrape-resume.md
+++ b/changelogs/2026-07-18-scrape-resume.md
@@ -1,0 +1,26 @@
+# /scrape crash-resume — checkpoint + --resume flag (/scrape improvements, PR 2)
+
+**PR**: #TBD
+**Date**: 2026-07-18
+
+## Changes
+- New `src/lib/scrape-checkpoint.ts`: atomic-write checkpoint at `tmp/scrape-checkpoint.json` (env override `SCRAPE_CHECKPOINT_FILE`) recording `completedPhases` (stable phase ids from PR 1 / #731) and `completedScrapeEntries` (normalized scraper taskIds that finished OK inside Phase 1).
+  - `readCheckpoint(args)` returns null when the file is absent, malformed, older than 24h, or written by a run with different CLI args — the three guards against the stale-checkpoint failure mode (silently skipping phases on fresh data).
+  - `honoredPhasePrefix(sequence, completed)`: checkpointed completions are honored only as a **prefix of the run's phase dependency chain** (scrape → lcut → cleanup → audit → rematch). Without this, a run where scrape failed but cleanup succeeded would checkpoint cleanup, and the resume would re-scrape fresh data then skip its enrichment (caught by the code-reviewer agent). The carried-over checkpoint is truncated the same way so stale completions can't survive into later resumes.
+  - Unit test `src/lib/scrape-checkpoint.test.ts` (round-trip, idempotent marks, age/args/malformed rejection, resume carry-over, clear semantics).
+- `src/scripts/run-scrape-and-enrich.ts`:
+  - New `--resume` flag. Resume is **never automatic**. With a valid checkpoint, phases in `completedPhases` are skipped and rendered in the summary as `✓ … skipped (resume)`; otherwise it warns and runs fully.
+  - Only expensive/write phases are checkpointable (`scrape`, `lcut`, `cleanup`, `audit`, `rematch`). Read-only detector phases (preflight/health/yield-delta) always re-run — they cost seconds and feed the run summary's health section, which would otherwise persist empty on a resumed run.
+  - Checkpoint cleared on clean exit (exit 0); **kept on failure**, so `--resume` doubles as "retry only the failed phase(s)". Failure output now suggests the resume command.
+- `src/lib/jobs/scrape-all.ts`:
+  - `runScrapeAll(options?: { skipTaskIds, onEntryComplete })`. Per-cinema resume: entries whose normalized taskId is in `skipTaskIds` are not re-run but counted as pre-succeeded in the wave summary (labeled "skipped (resume)") so the Telegram digest math stays honest. `onEntryComplete` fires after each successful entry (errors caught, never propagated) — the orchestrator wires it to the checkpoint writer.
+- `/scrape` skill (local `.claude/commands/scrape.md`, gitignored): new `resume` arg + updated resume documentation.
+
+## Impact
+- A crash or failure partway through the 30-60 min weekly pipeline no longer costs a full re-run: completed phases and completed cinemas are skipped, including inside the expensive scrape phase.
+- Failed runs get a one-command retry path that redoes only unfinished work.
+
+## Verification
+- Live: `--resume` with no checkpoint → warning + full run; crafted checkpoint (`cleanup`+`audit` complete, matching args) → both phases skipped, rendered as "skipped (resume)" in summary, checkpoint cleared on clean exit.
+- `npx tsc --noEmit` clean.
+- Vitest suite (checkpoint module) runs in CI.

--- a/src/lib/jobs/scrape-all.ts
+++ b/src/lib/jobs/scrape-all.ts
@@ -233,6 +233,7 @@ async function runScraperEntry(
   entry: ScraperRegistryEntry,
   waveLabel: string,
   breaker?: RunBreaker,
+  onEntryComplete?: (taskId: string) => void | Promise<void>,
 ): Promise<{ succeeded: boolean; error?: string }> {
   const taskId = entry.taskId.replace(/^scraper-/, "");
   const startedAt = new Date();
@@ -269,6 +270,14 @@ async function runScraperEntry(
     // including wall-clock-cap timeouts — are folded into venueResults), so
     // connection errors must be detected from the per-venue error messages.
     breaker?.record(taskId, breakerOutcomeFor(result));
+    if (result.success) {
+      // Checkpoint hook for --resume; a failed hook must not fail the entry.
+      try {
+        await onEntryComplete?.(taskId);
+      } catch (err) {
+        console.warn(`[scrape-all] onEntryComplete(${taskId}) failed:`, err);
+      }
+    }
     return { succeeded: result.success };
   } catch (err) {
     const ms = Date.now() - startedAt.getTime();
@@ -384,16 +393,31 @@ async function runWave(
   freshness: FreshnessMap,
   countMap: ScreeningCountMap,
   breaker: RunBreaker,
+  options: ScrapeAllOptions = {},
 ): Promise<WaveSummary> {
   if (breaker.isTripped()) {
     const count = SCRAPER_REGISTRY.filter((e) => e.wave === wave).length;
     console.log(`[scrape-all] ${label}: skipped (circuit breaker tripped) — ${count} scrapers`);
     return { label, succeeded: 0, failed: count, total: count };
   }
+  // Resume support: entries that already succeeded in the checkpointed run
+  // are counted as pre-succeeded (so digest math stays honest) and not re-run.
+  const skipSet = new Set(options.skipTaskIds ?? []);
+  const waveEntries = SCRAPER_REGISTRY.filter((e) => e.wave === wave);
+  const resumeSkipped = waveEntries.filter((e) =>
+    skipSet.has(e.taskId.replace(/^scraper-/, "")),
+  );
+  if (resumeSkipped.length > 0) {
+    console.log(
+      `[scrape-all] ${label}: skipped (resume) — ` +
+        resumeSkipped.map((e) => e.taskId.replace(/^scraper-/, "")).join(", "),
+    );
+  }
   // Sort by screening count ASC (fewest first — broken scrapers surface fast),
   // staleness ASC as tiebreaker (preserve rotation when counts are equal).
   // Compute both keys once per entry; sort + log share the results.
-  const ranked = SCRAPER_REGISTRY.filter((e) => e.wave === wave)
+  const ranked = waveEntries
+    .filter((e) => !skipSet.has(e.taskId.replace(/^scraper-/, "")))
     .map((entry) => ({
       entry,
       count: entryScreeningCount(entry, countMap),
@@ -410,10 +434,12 @@ async function runWave(
     console.log(`[scrape-all] ${label} order (fewest screenings, then stalest): ${orderStr}`);
   }
   const entries = ranked.map((r) => r.entry);
-  const tasks = entries.map((entry) => () => runScraperEntry(entry, label, breaker));
+  const tasks = entries.map(
+    (entry) => () => runScraperEntry(entry, label, breaker, options.onEntryComplete),
+  );
   const settled = await runWithConcurrency(tasks, concurrency, breaker.isTripped);
 
-  let succeeded = 0;
+  let succeeded = resumeSkipped.length;
   let failed = 0;
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i];
@@ -432,8 +458,11 @@ async function runWave(
     }
   }
 
-  console.log(`[scrape-all] ${label}: ${succeeded} succeeded, ${failed} failed`);
-  return { label, succeeded, failed, total: entries.length };
+  console.log(
+    `[scrape-all] ${label}: ${succeeded} succeeded, ${failed} failed` +
+      (resumeSkipped.length > 0 ? ` (${resumeSkipped.length} skipped via resume)` : ""),
+  );
+  return { label, succeeded, failed, total: waveEntries.length };
 }
 
 /** Run the enrichment wave: Letterboxd ratings + (best-effort) other tasks. */
@@ -469,6 +498,15 @@ export interface ScrapeAllResult {
   zeroCounts: number;
 }
 
+export interface ScrapeAllOptions {
+  /** Normalized taskIds (no `scraper-` prefix) to skip — used by --resume to
+   * avoid re-running scrapers that already succeeded in a crashed run. */
+  skipTaskIds?: string[];
+  /** Invoked after each scraper entry succeeds (normalized taskId) — used by
+   * the checkpoint writer. Errors are caught and logged, never propagated. */
+  onEntryComplete?: (taskId: string) => void | Promise<void>;
+}
+
 /**
  * Pure-Node entry point for the daily scrape orchestrator.
  *
@@ -476,7 +514,7 @@ export interface ScrapeAllResult {
  * the concurrency cap), then records a Telegram digest covering anomalies,
  * failures, and zero-count baselines for the run window.
  */
-export async function runScrapeAll(): Promise<ScrapeAllResult> {
+export async function runScrapeAll(options: ScrapeAllOptions = {}): Promise<ScrapeAllResult> {
   const startTime = Date.now();
   const startedAt = new Date(startTime);
   const waveSummaries: WaveSummary[] = [];
@@ -506,13 +544,15 @@ export async function runScrapeAll(): Promise<ScrapeAllResult> {
   ]);
 
   // Wave 1: Chain scrapers (3 — fully parallel)
-  waveSummaries.push(await runWave("chain", "Chains", 4, freshness, countMap, breaker));
+  waveSummaries.push(await runWave("chain", "Chains", 4, freshness, countMap, breaker, options));
 
   // Wave 2: Playwright independents (7 — cap at 4 for memory headroom)
-  waveSummaries.push(await runWave("playwright", "Playwright", 4, freshness, countMap, breaker));
+  waveSummaries.push(
+    await runWave("playwright", "Playwright", 4, freshness, countMap, breaker, options),
+  );
 
   // Wave 3: Cheerio / API independents (20 — cap at 4 to mirror prior chunking)
-  waveSummaries.push(await runWave("cheerio", "Cheerio", 4, freshness, countMap, breaker));
+  waveSummaries.push(await runWave("cheerio", "Cheerio", 4, freshness, countMap, breaker, options));
 
   // Wave 4: Post-scrape enrichment (Letterboxd ratings). Skipped when the
   // breaker tripped — enrichment would only hammer the same wedged DB.

--- a/src/lib/scrape-checkpoint.test.ts
+++ b/src/lib/scrape-checkpoint.test.ts
@@ -1,0 +1,137 @@
+/**
+ * scrape-checkpoint — init/mark/read round-trip, validity guards (age, args
+ * mismatch, malformed), idempotent marks, clear.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunSummaryArgs } from "./scrape-run-summary";
+
+const TEST_ROOT = join(tmpdir(), `scrape-checkpoint-test-${process.pid}-${Date.now()}`);
+const CHECKPOINT_FILE = join(TEST_ROOT, "tmp", "scrape-checkpoint.json");
+
+const ARGS: RunSummaryArgs = { skipScrape: false, skipEnrich: false, skipLcut: false };
+
+async function loadModule() {
+  vi.resetModules();
+  vi.stubEnv("SCRAPE_CHECKPOINT_FILE", CHECKPOINT_FILE);
+  return import("./scrape-checkpoint");
+}
+
+describe("scrape-checkpoint", () => {
+  beforeEach(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("round-trips phases and scrape entries through init/mark/read", async () => {
+    const cp = await loadModule();
+    await cp.initCheckpoint("run-1", ARGS);
+    await cp.markPhaseComplete("preflight");
+    await cp.markScrapeEntryComplete("bfi");
+    await cp.markScrapeEntryComplete("pcc");
+
+    const back = await cp.readCheckpoint(ARGS);
+    expect(back?.runId).toBe("run-1");
+    expect(back?.completedPhases).toEqual(["preflight"]);
+    expect(back?.completedScrapeEntries).toEqual(["bfi", "pcc"]);
+  });
+
+  it("marks are idempotent", async () => {
+    const cp = await loadModule();
+    await cp.initCheckpoint("run-1", ARGS);
+    await cp.markPhaseComplete("scrape");
+    await cp.markPhaseComplete("scrape");
+    await cp.markScrapeEntryComplete("bfi");
+    await cp.markScrapeEntryComplete("bfi");
+
+    const back = await cp.readCheckpoint(ARGS);
+    expect(back?.completedPhases).toEqual(["scrape"]);
+    expect(back?.completedScrapeEntries).toEqual(["bfi"]);
+  });
+
+  it("returns null when no checkpoint exists", async () => {
+    const cp = await loadModule();
+    expect(await cp.readCheckpoint(ARGS)).toBeNull();
+  });
+
+  it("rejects a checkpoint older than 24h", async () => {
+    const cp = await loadModule();
+    await cp.initCheckpoint("run-1", ARGS);
+    await cp.markPhaseComplete("preflight");
+    // Backdate the persisted file by 25 hours.
+    const raw = JSON.parse(await fs.readFile(CHECKPOINT_FILE, "utf8"));
+    raw.startedAt = new Date(Date.now() - 25 * 3600_000).toISOString();
+    await fs.writeFile(CHECKPOINT_FILE, JSON.stringify(raw));
+
+    expect(await cp.readCheckpoint(ARGS)).toBeNull();
+  });
+
+  it("rejects a checkpoint written by a run with different args", async () => {
+    const cp = await loadModule();
+    await cp.initCheckpoint("run-1", { ...ARGS, skipEnrich: true });
+    await cp.markPhaseComplete("preflight");
+
+    expect(await cp.readCheckpoint(ARGS)).toBeNull();
+    expect(await cp.readCheckpoint({ ...ARGS, skipEnrich: true })).not.toBeNull();
+  });
+
+  it("rejects a malformed checkpoint file", async () => {
+    const cp = await loadModule();
+    await fs.mkdir(join(TEST_ROOT, "tmp"), { recursive: true });
+    await fs.writeFile(CHECKPOINT_FILE, '{"runId": "x"}');
+    expect(await cp.readCheckpoint(ARGS)).toBeNull();
+  });
+
+  it("carries completed lists over when resuming, under the new runId", async () => {
+    const cp = await loadModule();
+    await cp.initCheckpoint("run-1", ARGS);
+    await cp.markPhaseComplete("preflight");
+    await cp.markScrapeEntryComplete("bfi");
+
+    const prior = await cp.readCheckpoint(ARGS);
+    await cp.initCheckpoint("run-2", ARGS, prior);
+
+    const back = await cp.readCheckpoint(ARGS);
+    expect(back?.runId).toBe("run-2");
+    expect(back?.completedPhases).toEqual(["preflight"]);
+    expect(back?.completedScrapeEntries).toEqual(["bfi"]);
+  });
+
+  it("honoredPhasePrefix only honors completions up to the first gap in the dependency chain", async () => {
+    const { honoredPhasePrefix } = await loadModule();
+    const seq = ["scrape", "lcut", "cleanup", "audit"] as const;
+
+    // Scrape failed but cleanup/audit "completed" (against stale data) —
+    // nothing may be skipped on resume.
+    expect(honoredPhasePrefix([...seq], ["cleanup", "audit"])).toEqual([]);
+    // Contiguous prefix is honored; the gap (cleanup) invalidates audit too.
+    expect(honoredPhasePrefix([...seq], ["scrape", "lcut", "audit"])).toEqual(["scrape", "lcut"]);
+    // Full completion honored in full.
+    expect(honoredPhasePrefix([...seq], ["scrape", "lcut", "cleanup", "audit"])).toEqual([
+      "scrape",
+      "lcut",
+      "cleanup",
+      "audit",
+    ]);
+    // Empty cases.
+    expect(honoredPhasePrefix([...seq], [])).toEqual([]);
+    expect(honoredPhasePrefix([], ["scrape"])).toEqual([]);
+  });
+
+  it("clearCheckpoint removes the file", async () => {
+    const cp = await loadModule();
+    await cp.initCheckpoint("run-1", ARGS);
+    await cp.clearCheckpoint();
+    expect(await cp.readCheckpoint(ARGS)).toBeNull();
+    // Marks after clear are no-ops, not resurrections.
+    await cp.markPhaseComplete("scrape");
+    expect(await cp.readCheckpoint(ARGS)).toBeNull();
+  });
+});

--- a/src/lib/scrape-checkpoint.ts
+++ b/src/lib/scrape-checkpoint.ts
@@ -1,0 +1,140 @@
+/**
+ * Crash-resume checkpoint for /scrape — records which pipeline phases (and
+ * which individual scrapers inside the Scrape phase) completed, so
+ * `npm run scrape:unified -- --resume` can skip finished work instead of
+ * re-running a 30-60 min pipeline from scratch.
+ *
+ * Written atomically to `<cwd>/tmp/scrape-checkpoint.json` (env override
+ * `SCRAPE_CHECKPOINT_FILE`). Local-only, same rules as scrape-progress.ts.
+ *
+ * Safety properties:
+ * - Resume is NEVER automatic — the orchestrator only reads this when the
+ *   operator passes `--resume` (a stale checkpoint silently skipping phases
+ *   on fresh data is the failure mode to avoid).
+ * - A checkpoint older than MAX_AGE_MS (24h) is invalid.
+ * - A checkpoint whose CLI args differ from the current run is invalid —
+ *   `completedPhases` from a `--skip-enrich` run must not skip phases in a
+ *   full run.
+ */
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+import type { PhaseId, RunSummaryArgs } from "@/lib/scrape-run-summary";
+
+export interface ScrapeCheckpoint {
+  runId: string;
+  startedAt: string;
+  args: RunSummaryArgs;
+  completedPhases: PhaseId[];
+  /** Normalized scraper taskIds (no `scraper-` prefix) that finished OK inside the Scrape phase. */
+  completedScrapeEntries: string[];
+}
+
+const DEFAULT_PATH = join(process.cwd(), "tmp", "scrape-checkpoint.json");
+const CHECKPOINT_PATH = process.env.SCRAPE_CHECKPOINT_FILE ?? DEFAULT_PATH;
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** In-memory state for the current run; persisted on every mutation. */
+let current: ScrapeCheckpoint | null = null;
+
+/** Monotonic counter so concurrent writers in one process never share a temp file. */
+let writeSeq = 0;
+
+/** Atomic write, swallow-and-warn — checkpointing must never fail the run. */
+async function persist(): Promise<void> {
+  if (!current) return;
+  const tmp = `${CHECKPOINT_PATH}.${process.pid}.${writeSeq++}.tmp`;
+  try {
+    await fs.mkdir(dirname(CHECKPOINT_PATH), { recursive: true });
+    await fs.writeFile(tmp, JSON.stringify(current, null, 2) + "\n");
+    await fs.rename(tmp, CHECKPOINT_PATH);
+  } catch (err) {
+    await fs.unlink(tmp).catch(() => {});
+    console.warn(
+      `[scrape-checkpoint] write failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function argsMatch(a: RunSummaryArgs, b: RunSummaryArgs): boolean {
+  return (
+    a.skipScrape === b.skipScrape && a.skipEnrich === b.skipEnrich && a.skipLcut === b.skipLcut
+  );
+}
+
+/**
+ * Read a checkpoint valid for a run with the given args, or null if absent,
+ * malformed, older than 24h, or written by a run with different args.
+ */
+export async function readCheckpoint(args: RunSummaryArgs): Promise<ScrapeCheckpoint | null> {
+  try {
+    const raw = await fs.readFile(CHECKPOINT_PATH, "utf8");
+    const cp = JSON.parse(raw) as ScrapeCheckpoint;
+    if (!Array.isArray(cp.completedPhases) || !Array.isArray(cp.completedScrapeEntries)) {
+      return null;
+    }
+    if (Date.now() - Date.parse(cp.startedAt) > MAX_AGE_MS) return null;
+    if (!argsMatch(cp.args, args)) return null;
+    return cp;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start checkpointing for this run. When resuming, pass the prior checkpoint
+ * so its completed lists carry over (under the new runId).
+ */
+export async function initCheckpoint(
+  runId: string,
+  args: RunSummaryArgs,
+  resumeFrom?: ScrapeCheckpoint | null,
+): Promise<void> {
+  current = {
+    runId,
+    startedAt: new Date().toISOString(),
+    args,
+    completedPhases: resumeFrom ? [...resumeFrom.completedPhases] : [],
+    completedScrapeEntries: resumeFrom ? [...resumeFrom.completedScrapeEntries] : [],
+  };
+  await persist();
+}
+
+/** Record a pipeline phase as complete (idempotent). */
+export async function markPhaseComplete(id: PhaseId): Promise<void> {
+  if (!current) return;
+  if (!current.completedPhases.includes(id)) current.completedPhases.push(id);
+  await persist();
+}
+
+/** Record a scraper entry (normalized taskId) as complete (idempotent). */
+export async function markScrapeEntryComplete(taskId: string): Promise<void> {
+  if (!current) return;
+  if (!current.completedScrapeEntries.includes(taskId)) {
+    current.completedScrapeEntries.push(taskId);
+  }
+  await persist();
+}
+
+/** Remove the checkpoint (clean run end — nothing left to resume). */
+export async function clearCheckpoint(): Promise<void> {
+  current = null;
+  await fs.unlink(CHECKPOINT_PATH).catch(() => {});
+}
+
+/**
+ * The pipeline's checkpointable phases form a dependency chain (scrape →
+ * lcut → cleanup → audit → rematch): each consumes the output of the ones
+ * before it. A checkpoint may therefore only be honored as a PREFIX of the
+ * run's phase sequence — if scrape didn't finish, a "completed" cleanup from
+ * the prior run enriched pre-rescrape data and must re-run after the scrape
+ * is redone. Returns the longest honored prefix.
+ */
+export function honoredPhasePrefix(sequence: PhaseId[], completed: PhaseId[]): PhaseId[] {
+  const done = new Set(completed);
+  const prefix: PhaseId[] = [];
+  for (const id of sequence) {
+    if (!done.has(id)) break;
+    prefix.push(id);
+  }
+  return prefix;
+}

--- a/src/scripts/run-scrape-and-enrich.ts
+++ b/src/scripts/run-scrape-and-enrich.ts
@@ -21,6 +21,8 @@
  *   npm run scrape:unified                # full run
  *   npm run scrape:unified -- --skip-scrape   # enrichment only (re-run after a manual scrape)
  *   npm run scrape:unified -- --skip-enrich   # scraping only
+ *   npm run scrape:unified -- --resume        # skip work completed by a crashed/failed run
+ *                                             # (same args, <24h old; per-scraper inside Phase 1)
  */
 
 import { spawn } from "node:child_process";
@@ -29,6 +31,14 @@ import { db, withDbTimeout } from "@/db";
 import { screenings } from "@/db/schema";
 import { runScrapeAll } from "@/lib/jobs/scrape-all";
 import { sendTelegramAlert } from "@/lib/telegram";
+import {
+  initCheckpoint,
+  markPhaseComplete,
+  markScrapeEntryComplete,
+  readCheckpoint,
+  clearCheckpoint,
+  honoredPhasePrefix,
+} from "@/lib/scrape-checkpoint";
 import {
   writeRunSummary,
   computeRunStatus,
@@ -62,6 +72,15 @@ import {
 const SKIP_SCRAPE = process.argv.includes("--skip-scrape");
 const SKIP_ENRICH = process.argv.includes("--skip-enrich");
 const SKIP_LCUT = process.argv.includes("--skip-lcut");
+const RESUME = process.argv.includes("--resume");
+
+/**
+ * Phases eligible for checkpoint/resume — the expensive and/or DB-writing
+ * ones. The read-only detector phases (preflight/health/yield-delta) cost
+ * seconds and feed the run summary's health section, so they always re-run:
+ * skipping them on resume would persist a summary with empty health data.
+ */
+const CHECKPOINTABLE = new Set<PhaseId>(["scrape", "lcut", "cleanup", "audit", "rematch"]);
 
 /** A scraped venue behind L-CUT by more than this many screenings is flagged
  * as a possible scraper regression (matches Phase 1 of the coverage plan). */
@@ -173,6 +192,62 @@ async function main(): Promise<void> {
   };
   persistCrashSummary = () => persistSummary("crashed");
 
+  // Resume: only honored behind the explicit --resume flag. readCheckpoint
+  // validates age (<24h) and arg-match; anything invalid falls back to a
+  // full run with a warning.
+  const resumeFrom = RESUME ? await readCheckpoint(summaryArgs) : null;
+  if (RESUME && !resumeFrom) {
+    console.warn(
+      "[scrape-and-enrich] --resume: no valid checkpoint (absent, >24h old, or different args) — running fully.",
+    );
+  } else if (resumeFrom) {
+    console.log(
+      `[scrape-and-enrich] --resume: checkpoint from ${resumeFrom.startedAt} — ` +
+        `${resumeFrom.completedPhases.length} phase(s), ` +
+        `${resumeFrom.completedScrapeEntries.length} scraper(s) already complete.`,
+    );
+  }
+  // Checkpointed phases are only honored as a PREFIX of this run's phase
+  // sequence: the phases form a dependency chain, so a phase "completed" in a
+  // prior run whose upstream phase did NOT complete (e.g. cleanup done but
+  // scrape failed) ran against stale data and must re-run after the upstream
+  // work is redone. The carried-over checkpoint is truncated the same way so
+  // stale completions can't survive into later resumes either.
+  const phaseSequence: PhaseId[] = [];
+  if (!SKIP_SCRAPE) phaseSequence.push("scrape");
+  if (!SKIP_SCRAPE && !SKIP_LCUT) phaseSequence.push("lcut");
+  if (!SKIP_ENRICH) phaseSequence.push("cleanup", "audit");
+  if (!SKIP_ENRICH && process.env.SCRAPE_REMATCH_SWEEP === "1") phaseSequence.push("rematch");
+  const honored = honoredPhasePrefix(phaseSequence, resumeFrom?.completedPhases ?? []);
+  if (resumeFrom && honored.length < resumeFrom.completedPhases.length) {
+    console.log(
+      `[scrape-and-enrich] --resume: honoring only [${honored.join(", ") || "none"}] from the ` +
+        "checkpoint — later completions depend on unfinished earlier phases and will re-run.",
+    );
+  }
+  await initCheckpoint(
+    runId,
+    summaryArgs,
+    resumeFrom ? { ...resumeFrom, completedPhases: honored } : null,
+  );
+  const donePhases = new Set(honored);
+
+  /** runPhase, minus phases already completed in the checkpointed run. */
+  const runOrSkipPhase = async (
+    id: PhaseId,
+    label: string,
+    fn: () => Promise<{ ok: boolean; warn?: boolean; detail?: string }>,
+  ): Promise<SummaryPhase> => {
+    if (donePhases.has(id)) {
+      console.log(`\n━━━ ${label} ━━━`);
+      console.log(`[${label}] skipped (resume — completed in prior run)`);
+      return { id, label, ok: true, durationMin: 0, detail: "skipped (resume)" };
+    }
+    const result = await runPhase(id, label, fn);
+    if (result.ok && CHECKPOINTABLE.has(id)) await markPhaseComplete(id);
+    return result;
+  };
+
   // Phase 0: Pre-flight quarantine — read-only, ~1s. Tells the user which
   // cinemas have been silently broken BEFORE they sit through a 30-60 min
   // /scrape that just re-runs them. Three signals, fully orthogonal:
@@ -222,8 +297,11 @@ async function main(): Promise<void> {
   // Phase 1: Scrape (unless skipped)
   if (!SKIP_SCRAPE) {
     phases.push(
-      await runPhase("scrape", "Scrape (all cinemas, 4 waves)", async () => {
-        const result = await runScrapeAll();
+      await runOrSkipPhase("scrape", "Scrape (all cinemas, 4 waves)", async () => {
+        const result = await runScrapeAll({
+          skipTaskIds: resumeFrom?.completedScrapeEntries,
+          onEntryComplete: markScrapeEntryComplete,
+        });
         const detail =
           `${result.totalSucceeded} ok / ${result.totalFailed} failed across ${result.waves.length} waves` +
           ` (${result.anomalies} anomalies, ${result.zeroCounts} zero-count)`;
@@ -247,7 +325,7 @@ async function main(): Promise<void> {
   // — parity is only meaningful measured against a fresh scrape.
   if (!SKIP_SCRAPE && !SKIP_LCUT) {
     phases.push(
-      await runPhase("lcut", "L-CUT gap-fill (source-only) + parity monitor", async () => {
+      await runOrSkipPhase("lcut", "L-CUT gap-fill (source-only) + parity monitor", async () => {
         const scrapedIds = getScrapedCinemaIds();
         const { sourceOnly } = classifyLcutTargets(scrapedIds);
         // Insert ONLY for venues we don't scrape ourselves; scraped venues stay
@@ -304,14 +382,14 @@ async function main(): Promise<void> {
   // Phase 2-3: Enrichment (unless skipped)
   if (!SKIP_ENRICH) {
     phases.push(
-      await runPhase("cleanup", "Cleanup upcoming films (4 sub-phases)", async () => {
+      await runOrSkipPhase("cleanup", "Cleanup upcoming films (4 sub-phases)", async () => {
         // The unified scrape command is already a live operational workflow.
         const ok = await runNpmScript("cleanup:upcoming", ["--execute"]);
         return { ok };
       }),
     );
     phases.push(
-      await runPhase("audit", "Audit films (validation pass)", async () => {
+      await runOrSkipPhase("audit", "Audit films (validation pass)", async () => {
         const ok = await runNpmScript("audit:films");
         return { ok };
       }),
@@ -323,7 +401,7 @@ async function main(): Promise<void> {
     // 100 films per run to bound TMDB usage and blast radius.
     if (process.env.SCRAPE_REMATCH_SWEEP === "1") {
       phases.push(
-        await runPhase("rematch", "Rematch sweep (unmatched films, capped)", async () => {
+        await runOrSkipPhase("rematch", "Rematch sweep (unmatched films, capped)", async () => {
           const ok = await runNpmScript("rematch:unmatched", ["--execute", "--limit", "100"]);
           return { ok };
         }),
@@ -405,9 +483,13 @@ async function main(): Promise<void> {
   await persistSummary();
 
   if (failedPhases.length > 0) {
+    // Keep the checkpoint: `npm run scrape:unified -- --resume` (same args,
+    // within 24h) retries the failed phase(s) without redoing completed work.
     console.log(`\nACTION REQUIRED: ${failedPhases.length} phase(s) failed.`);
+    console.log("Retry without redoing completed work: npm run scrape:unified -- --resume");
     process.exit(1);
   } else {
+    await clearCheckpoint();
     console.log("\nAll phases OK.");
     process.exit(0);
   }


### PR DESCRIPTION
## Summary

PR 2 of 3 improving the `/scrape` pipeline (after #731). A crash or failure partway through the 30-60 min weekly run no longer costs a full re-run.

- **New `src/lib/scrape-checkpoint.ts`** — checkpoint at `tmp/scrape-checkpoint.json` recording completed phases (PR 1's stable ids) **and completed individual scrapers inside Phase 1**. `npm run scrape:unified -- --resume` skips them.
- **Safety guards** (stale-checkpoint = the failure mode to avoid):
  - Resume is never automatic — explicit `--resume` only
  - Checkpoints expire after 24h and must match the run's CLI args
  - **Prefix rule**: completions are honored only as a prefix of the phase dependency chain (scrape → lcut → cleanup → audit → rematch). A "completed" cleanup after a failed scrape enriched stale data — on resume it re-runs after the scrape is redone. *Caught by the code-reviewer agent; covered by unit tests.*
  - Read-only detector phases always re-run so the run summary's health section stays fresh
  - Cleared on clean exit; **kept on failure** — `--resume` doubles as retry-only-what-failed (failure output now suggests it)
- **`runScrapeAll(options)`** — `skipTaskIds` (skipped entries counted as pre-succeeded, labeled "skipped (resume)", so wave/digest math stays honest) + `onEntryComplete` checkpoint hook (errors caught, never propagated).
- `/scrape` skill gains a `resume` arg (local gitignored file, noted here since it's untracked).

## Verification
- Live: `--resume` with no checkpoint → warning + full run; crafted checkpoint (cleanup+audit complete, matching args) → both skipped, rendered `✓ … skipped (resume)`, checkpoint cleared on clean exit
- `npx tsx` smoke: round-trip, idempotent marks, args/age guards, carry-over, clear semantics, prefix-chain cases — OK
- `npx tsc --noEmit` clean; vitest (`scrape-checkpoint.test.ts`, 9 tests) runs in CI
- feature-dev:code-reviewer ran on the diff; its critical finding (dependency-chain violation) fixed via the prefix rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)