### PR TITLE
fix(phoenix): use domcontentloaded — site never reaches networkidle

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,3 +1,11 @@
+## 2026-07-20: Phoenix scraper outage fix — networkidle never fires
+**PR**: #TBD | **Files**: `src/scrapers/cinemas/phoenix.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
+- Phoenix failed every run since ~2026-07-18 (`success=false`, all 3 retries): the site keeps analytics connections open so `page.goto(..., networkidle)` never resolves and times out. Switched both navigations to `domcontentloaded` — the site is fully server-rendered ASP.NET/Savoy `.dll`, so all content is in the initial HTML.
+- Showtime extraction upgraded: `.performance` rows now yield clean date/`.perf-time`/booking-deep-link triples (the old selector missed them and the booking-button's inner `.time` span reads "Book Now"). Positional fallback retained.
+- Verified: 56 screenings found (24 added, 32 updated), 72 upcoming in DB, 0 sub-10:00 times, 2 films spot-checked against the live site. Playbook updated (platform notes, redirect, never-networkidle rule, future Savoy-JSON migration path).
+
+---
+
 ## 2026-07-18: /scrape speed + robustness — shared independents pool, any-failure warn, audit gate (/scrape improvements, PR 3)
 **PR**: #733 | **Files**: `src/lib/jobs/scrape-all.ts`, `src/scripts/cleanup-upcoming-films.ts`, `src/scripts/audit-film-data.ts`, `src/scripts/run-scrape-and-enrich.ts`
 - **Waves 2+3 merged into one pool**: Playwright (7) + Cheerio/API (20) independents now share a single concurrency-4 pool instead of running behind a wave barrier — one slow Playwright straggler no longer blocks all 20 Cheerio scrapers. Same concurrency ceiling (memory unchanged); digest still reports one row per wave. Fewest-screenings-first sort now spans the combined set.

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,5 @@
 ## 2026-07-20: Phoenix scraper outage fix — networkidle never fires
-**PR**: #TBD | **Files**: `src/scrapers/cinemas/phoenix.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
+**PR**: #734 | **Files**: `src/scrapers/cinemas/phoenix.ts`, `src/scrapers/SCRAPING_PLAYBOOK.md`
 - Phoenix failed every run since ~2026-07-18 (`success=false`, all 3 retries): the site keeps analytics connections open so `page.goto(..., networkidle)` never resolves and times out. Switched both navigations to `domcontentloaded` — the site is fully server-rendered ASP.NET/Savoy `.dll`, so all content is in the initial HTML.
 - Showtime extraction upgraded: `.performance` rows now yield clean date/`.perf-time`/booking-deep-link triples (the old selector missed them and the booking-button's inner `.time` span reads "Book Now"). Positional fallback retained.
 - Verified: 56 screenings found (24 added, 32 updated), 72 upcoming in DB, 0 sub-10:00 times, 2 films spot-checked against the live site. Playbook updated (platform notes, redirect, never-networkidle rule, future Savoy-JSON migration path).

--- a/changelogs/2026-07-20-phoenix-networkidle-fix.md
+++ b/changelogs/2026-07-20-phoenix-networkidle-fix.md
@@ -1,0 +1,23 @@
+# Phoenix scraper outage fix — networkidle never fires
+
+**PR**: #TBD
+**Date**: 2026-07-20
+
+## Changes
+- `src/scrapers/cinemas/phoenix.ts`:
+  - Both `page.goto` calls switched from `waitUntil: "networkidle"` to `"domcontentloaded"`. Root cause of the 2026-07-18 outage: Phoenix's site holds analytics/tracking connections open indefinitely, so `networkidle` never fires; every navigation hit the 60s timeout, runner-factory burned all 3 retries, and `runScraper` returned `success=false` with 0 screenings. The site is server-rendered ASP.NET/Savoy `.dll` — the full programme is in the initial HTML, so `domcontentloaded` is sufficient.
+  - Showtime extraction: added `.performance` to the structured-group selector (the live site renders one `<li class="performance">` per screening) and prefer `.perf-time` over the booking button's inner `.time` span (which reads "Book Now"). Each row now yields a clean date/time/absolute-booking-URL triple; the positional fallback is retained for layout drift.
+  - Documented the `/whats-on/` → `/PhoenixCinemaLondon.dll/Home` 301 redirect (Playwright follows it automatically; not itself fatal).
+- `src/scrapers/SCRAPING_PLAYBOOK.md`: new Phoenix Cinema section — platform, redirect, the never-networkidle rule tied to this outage, current selectors, and a future-robustness note that `/Home` embeds a Savoy modern-JSON `var Events` blob (Phoenix could migrate to `platforms/savoy.ts` like Rio and drop ~50 per-film navigations).
+
+## Impact
+- Phoenix Cinema (East Finchley) listings flow again after ~2 days of failed scrapes; the warn-flaky signal should clear over the next few runs.
+
+## Verification
+- `npm run scrape:phoenix`: success, 56 screenings found (24 added, 32 updated, 0 failed).
+- DB spot-check: 72 upcoming screenings, 0 before 10:00 London (range 11:00–20:00), booking URLs are proper `.dll/Booking?...` deep-links.
+- Cross-checked "Effi o Blaenau" (Mon 20 Jul 15:15) and "The Odyssey" (Mon 20 Jul 15:30) against the live site — both match.
+- `npx tsc --noEmit` clean.
+
+## Follow-up noted (not in this PR)
+- A few pre-existing "The Odyssey" evening rows carry fallback `WhatsOn?f=` URLs and don't appear on the film page's current listing — possible stale rows/duplicate film record; left untouched per database rules (no deletion without confirmed parsing error).

--- a/changelogs/2026-07-20-phoenix-networkidle-fix.md
+++ b/changelogs/2026-07-20-phoenix-networkidle-fix.md
@@ -1,6 +1,6 @@
 # Phoenix scraper outage fix — networkidle never fires
 
-**PR**: #TBD
+**PR**: #734
 **Date**: 2026-07-20
 
 ## Changes

--- a/src/scrapers/SCRAPING_PLAYBOOK.md
+++ b/src/scrapers/SCRAPING_PLAYBOOK.md
@@ -414,6 +414,27 @@ Use this format when recording cinema-specific quirks:
 - **NOT INDY**: Phoenix Cinema (East Finchley) is an ASP.NET `.dll` system
   (`PhoenixCinemaLondon.dll`), despite an old comment claiming otherwise — see cinemas/phoenix.ts.
 
+### Phoenix Cinema (`cinemas/phoenix.ts`, updated 2026-07-20)
+- **Platform**: ASP.NET/Savoy `.dll` (`PhoenixCinemaLondon.dll`), server-rendered — the full
+  programme and all showtimes are in the initial HTML (no client-side rendering).
+- **URLs**: `programmeUrl` = `/whats-on/` which now **301-redirects** to
+  `/PhoenixCinemaLondon.dll/Home`. Playwright follows the redirect automatically; do not hard-code
+  the `.dll/Home` URL. Film pages are `/PhoenixCinemaLondon.dll/WhatsOn?f={id}`.
+- **CRITICAL — do NOT use `waitUntil: "networkidle"`** (root cause of the 2026-07-18 outage:
+  every `page.goto` timed out at 60s → 3 retries exhausted → `success=false`, ~65 screenings went
+  stale). The site holds analytics/tracking connections open so `networkidle` never fires. Use
+  `waitUntil: "domcontentloaded"` — content is already present.
+- **Programme selectors**: film links from `.film-title` → nearest `a[href*="WhatsOn"]`.
+- **Showtime selectors** (per screening): each `li.performance` (class token `performance`, which
+  does NOT collide with `programme-performances` / `performances`) holds `span.date.column`
+  ("Mon 20 Jul"), `span.perf-time` ("15:15", 24h — no AM/PM), and a booking
+  `a[href^="Booking?"]`. Parser prefers `.perf-time` over the button's inner `.time` span (that
+  one reads "Book Now"). `link.href` resolves to the absolute `.dll/Booking?...` deep-link.
+  A positional date↔time fallback remains for layout drift (booking URL falls back to film page).
+- **FUTURE (robustness)**: the `/Home` page embeds a Savoy modern-JSON `var Events = {…}` blob —
+  Phoenix could migrate to `platforms/savoy.ts` (`extractSavoyEventsJson` + `parseSavoyEvents`,
+  as used by Rio/Lexi/Arzner) and drop the 50+ per-film page navigations entirely.
+
 ### Savoy Systems platform (`src/scrapers/platforms/savoy.ts`, 2026-07-14)
 - **Two DISTINCT front-end templates** — do not conflate them:
   - **Modern JSON** — homepage (root → `/{Dll}.dll/Home`) embeds `var Events = {"Events":[…]};`.

--- a/src/scrapers/cinemas/phoenix.ts
+++ b/src/scrapers/cinemas/phoenix.ts
@@ -40,7 +40,13 @@ export class PhoenixScraper implements CinemaScraper {
     try {
       // Step 1: Get list of films from the programme page
       console.log(`[${this.config.cinemaId}] Loading programme page...`);
-      await page.goto(this.config.programmeUrl, { waitUntil: "networkidle", timeout: 60000 });
+      // NOTE: This is a server-rendered ASP.NET/DLL site (all films + times are in
+      // the initial HTML). Do NOT use waitUntil: "networkidle" — the site keeps
+      // analytics/tracking connections open so networkidle never fires and goto
+      // times out after 60s (this was the cause of the 2026-07-18 outage).
+      // /whats-on/ 301-redirects to /PhoenixCinemaLondon.dll/Home; Playwright
+      // follows the redirect automatically.
+      await page.goto(this.config.programmeUrl, { waitUntil: "domcontentloaded", timeout: 60000 });
       await page.waitForTimeout(3000);
 
       // Extract films from the page
@@ -88,7 +94,7 @@ export class PhoenixScraper implements CinemaScraper {
         try {
           console.log(`[${this.config.cinemaId}] Fetching showtimes for "${film.title}"...`);
 
-          await page.goto(film.pageUrl, { waitUntil: "networkidle", timeout: 30000 });
+          await page.goto(film.pageUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
           await page.waitForTimeout(1500);
 
           // Extract dates and times from the film page
@@ -121,17 +127,25 @@ export class PhoenixScraper implements CinemaScraper {
             // The pattern seems to be dates followed by their times in groups
             // For now, use a simpler approach: pair unique dates with times sequentially
 
-            // Actually look for date-time groups
-            const dateTimeGroups = document.querySelectorAll('[class*="showtime"], [class*="session"], .performance-row, [class*="schedule"]');
+            // Look for date-time groups. The live site renders one
+            // <li class="performance columns is-multiline"> per screening,
+            // each containing a `.date` span ("Mon 20 Jul"), a `.perf-time`
+            // span ("15:15") and a booking <a href="Booking?...">. `.performance`
+            // matches only those <li> rows (not `.programme-performances` /
+            // `.performances`, whose class tokens differ), giving clean triples.
+            const dateTimeGroups = document.querySelectorAll('.performance, [class*="showtime"], [class*="session"], .performance-row, [class*="schedule"]');
 
             if (dateTimeGroups.length > 0) {
               // Parse structured groups
               dateTimeGroups.forEach(group => {
                 const dateEl = group.querySelector('[class*="date"]');
-                const timeEl = group.querySelector('[class*="time"]');
+                // Prefer the real showtime element (.perf-time = "15:15") over the
+                // booking button's inner .time span (which reads "Book Now").
+                const timeEl = group.querySelector('.perf-time') || group.querySelector('[class*="time"]');
                 if (dateEl && timeEl) {
                   const date = dateEl.textContent?.trim() || '';
                   const time = timeEl.textContent?.trim() || '';
+                  // link.href is the resolved absolute URL (includes /PhoenixCinemaLondon.dll/).
                   const link = group.querySelector('a');
                   results.push({
                     date,


### PR DESCRIPTION
## Summary

Phoenix Cinema failed every scrape since ~2026-07-18 (`success=false` through all 3 retries — surfaced by the new /scrape warn-state reporting from #731 and the resume retry from #732).

**Root cause**: the site keeps analytics/tracking connections open indefinitely, so `page.goto(..., { waitUntil: "networkidle" })` never resolves and times out at 60s. The site is server-rendered ASP.NET/Savoy `.dll` — the full programme is in the initial HTML — so both navigations now use `domcontentloaded`.

Also upgraded showtime extraction: the structured selector now matches the live site's `li.performance` rows and prefers `.perf-time` ("15:15") over the booking button's inner `.time` span (which reads "Book Now"), yielding clean date/time/absolute-booking-deep-link triples. Positional fallback retained. Playbook updated with the never-networkidle rule and a future Savoy-JSON migration note.

## Verification
- `npm run scrape:phoenix`: success — 56 screenings found, 24 added / 32 updated / 0 failed
- DB spot-check: 72 upcoming screenings, 0 before 10:00 London (range 11:00–20:00), proper `.dll/Booking?...` deep-links
- Cross-checked *Effi o Blaenau* (Mon 20 Jul 15:15) and *The Odyssey* (Mon 20 Jul 15:30) against the live site — both match
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)