### PR TITLE
docs: ban the Gemini API — all AI analysis is Claude Code's job

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,20 @@ Production actions (merge to main, deploy, push to prod) require explicit keywor
 ## Inline Secrets
 Never run commands with inline secrets or API keys. Always reference env vars from `.env.local`.
 
+## AI Analysis — Claude Code only, no Gemini
+**Never use the Gemini API (`GEMINI_API_KEY`, `@google/genai`, `src/lib/gemini.ts`) for anything.**
+All AI analysis in this project is done by Claude Code directly — reading the data,
+applying judgement, and writing/executing scripts — not by runtime calls to a
+hosted model.
+
+- Do not add, restore, or "fix" a Gemini key. The key in `.env.local` is dead by intent.
+- Runtime code may gather and report data (scrape pages, hit TMDB, compute metrics);
+  the *interpretation* step belongs in a Claude Code session, per
+  `.claude/rules/data-quality.md` ("Claude Code Direct Enrichment").
+- Deterministic API calls (TMDB, Letterboxd, HTTP checks) are not AI analysis and stay.
+- Applies equally to new features: never propose a hosted LLM call as the fix.
+  See also the no-paid-services rule in memory.
+
 ## PR Review Gate
 Before creating any PR that touches 3+ files, run the code-reviewer agent on the diff. Report findings before proceeding.
 


### PR DESCRIPTION
Standing rule, recorded in `CLAUDE.md` so a future session doesn't "helpfully" restore the key.

`GEMINI_API_KEY` is dead by intent. Runtime code may gather and report data (scrape pages, hit TMDB, compute metrics); the **interpretation** step belongs in a Claude Code session — which is already the documented preference in `.claude/rules/data-quality.md` ("Claude Code Direct Enrichment"). Deterministic API calls are unaffected; they aren't AI analysis.

Five modules still import `src/lib/gemini.ts` and need unpicking separately — each needs a decision about what the feature becomes without a hosted model:

| Module | What it uses Gemini for |
|---|---|
| `src/agents/fallback-enrichment/web-search.ts` | film metadata from web search |
| `src/agents/scraper-health/index.ts` | scraper failure analysis |
| `src/agents/link-validator/index.ts` | link validation |
| `src/lib/qa/utils/gemini-analyzer.ts` | QA analysis |
| `src/app/api/admin/anomalies/verify/route.ts` | anomaly verification |

They currently fail soft (invalid key → caught → skip), so nothing is broken by leaving them for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)